### PR TITLE
Fix Claude prompt too long error by truncating large diffs

### DIFF
--- a/internal/agent/cohort.go
+++ b/internal/agent/cohort.go
@@ -121,3 +121,29 @@ func AgentForReviewer(agents []Agent, reviewerID int) Agent {
 	}
 	return agents[(reviewerID-1)%len(agents)]
 }
+
+// NeedsDiffInPrompt returns true if the agent requires the diff to be passed
+// in the prompt (as opposed to handling it internally like Codex's built-in review).
+// When customPrompt is set, all agents need diff in prompt.
+// When customPrompt is empty, only Claude and Gemini need diff in prompt.
+func NeedsDiffInPrompt(agent Agent, customPrompt string) bool {
+	if customPrompt != "" {
+		// All agents need diff in prompt when using custom prompts
+		return true
+	}
+	// Without custom prompt, Codex uses built-in review --base which handles diff internally
+	// Claude and Gemini always need diff in prompt
+	return agent.Name() != "codex"
+}
+
+// AllAgentsNeedDiffInPrompt returns true if all agents in the cohort need
+// the diff passed in the prompt. This determines whether diff distribution
+// across reviewers is possible.
+func AllAgentsNeedDiffInPrompt(agents []Agent, customPrompt string) bool {
+	for _, agent := range agents {
+		if !NeedsDiffInPrompt(agent, customPrompt) {
+			return false
+		}
+	}
+	return len(agents) > 0
+}

--- a/internal/agent/cohort_test.go
+++ b/internal/agent/cohort_test.go
@@ -242,6 +242,104 @@ func TestFormatDistribution(t *testing.T) {
 	}
 }
 
+func TestNeedsDiffInPrompt(t *testing.T) {
+	tests := []struct {
+		name         string
+		agent        Agent
+		customPrompt string
+		expected     bool
+	}{
+		{
+			name:         "claude without custom prompt needs diff",
+			agent:        &mockAgent{name: "claude"},
+			customPrompt: "",
+			expected:     true,
+		},
+		{
+			name:         "gemini without custom prompt needs diff",
+			agent:        &mockAgent{name: "gemini"},
+			customPrompt: "",
+			expected:     true,
+		},
+		{
+			name:         "codex without custom prompt does NOT need diff",
+			agent:        &mockAgent{name: "codex"},
+			customPrompt: "",
+			expected:     false,
+		},
+		{
+			name:         "codex with custom prompt needs diff",
+			agent:        &mockAgent{name: "codex"},
+			customPrompt: "custom review prompt",
+			expected:     true,
+		},
+		{
+			name:         "claude with custom prompt needs diff",
+			agent:        &mockAgent{name: "claude"},
+			customPrompt: "custom review prompt",
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NeedsDiffInPrompt(tt.agent, tt.customPrompt)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAllAgentsNeedDiffInPrompt(t *testing.T) {
+	tests := []struct {
+		name         string
+		agents       []Agent
+		customPrompt string
+		expected     bool
+	}{
+		{
+			name:         "all claude agents without custom prompt",
+			agents:       []Agent{&mockAgent{name: "claude"}, &mockAgent{name: "claude"}},
+			customPrompt: "",
+			expected:     true,
+		},
+		{
+			name:         "mixed claude and gemini without custom prompt",
+			agents:       []Agent{&mockAgent{name: "claude"}, &mockAgent{name: "gemini"}},
+			customPrompt: "",
+			expected:     true,
+		},
+		{
+			name:         "codex without custom prompt prevents distribution",
+			agents:       []Agent{&mockAgent{name: "claude"}, &mockAgent{name: "codex"}},
+			customPrompt: "",
+			expected:     false,
+		},
+		{
+			name:         "all agents with custom prompt enables distribution",
+			agents:       []Agent{&mockAgent{name: "codex"}, &mockAgent{name: "claude"}},
+			customPrompt: "custom prompt",
+			expected:     true,
+		},
+		{
+			name:         "empty agents returns false",
+			agents:       []Agent{},
+			customPrompt: "",
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AllAgentsNeedDiffInPrompt(tt.agents, tt.customPrompt)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
 // mockAgent implements Agent interface for testing
 type mockAgent struct {
 	name string

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -22,4 +22,9 @@ type ReviewConfig struct {
 
 	// ReviewerID is a unique identifier for this reviewer instance (e.g., "reviewer-1").
 	ReviewerID string
+
+	// DiffOverride, if non-empty, is used instead of fetching the diff from git.
+	// This allows the runner to distribute different portions of a large diff
+	// to different reviewers for parallel processing.
+	DiffOverride string
 }

--- a/internal/agent/diff_test.go
+++ b/internal/agent/diff_test.go
@@ -120,3 +120,204 @@ func TestBuildPromptWithDiff_SmallDiff(t *testing.T) {
 		t.Error("expected full diff in result")
 	}
 }
+
+func TestParseDiffIntoFiles_EmptyDiff(t *testing.T) {
+	files := ParseDiffIntoFiles("")
+	if len(files) != 0 {
+		t.Errorf("expected empty slice for empty diff, got %d files", len(files))
+	}
+}
+
+func TestParseDiffIntoFiles_SingleFile(t *testing.T) {
+	diff := `diff --git a/file.go b/file.go
+index 1234567..abcdefg 100644
+--- a/file.go
++++ b/file.go
+@@ -1,3 +1,4 @@
+ package main
++import "fmt"
+ func main() {}`
+
+	files := ParseDiffIntoFiles(diff)
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	if files[0].Filename != "file.go" {
+		t.Errorf("expected filename 'file.go', got %q", files[0].Filename)
+	}
+
+	if !strings.Contains(files[0].Content, "diff --git") {
+		t.Error("expected content to include diff header")
+	}
+
+	if files[0].Size != len(files[0].Content) {
+		t.Errorf("expected size %d to match content length %d", files[0].Size, len(files[0].Content))
+	}
+}
+
+func TestParseDiffIntoFiles_MultipleFiles(t *testing.T) {
+	diff := `diff --git a/file1.go b/file1.go
++first file content
+diff --git a/file2.go b/file2.go
++second file content
+diff --git a/path/to/file3.go b/path/to/file3.go
++third file content`
+
+	files := ParseDiffIntoFiles(diff)
+
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files, got %d", len(files))
+	}
+
+	expectedFilenames := []string{"file1.go", "file2.go", "path/to/file3.go"}
+	for i, expected := range expectedFilenames {
+		if files[i].Filename != expected {
+			t.Errorf("file %d: expected filename %q, got %q", i, expected, files[i].Filename)
+		}
+	}
+
+	// Verify each file contains only its content
+	if !strings.Contains(files[0].Content, "first file") || strings.Contains(files[0].Content, "second file") {
+		t.Error("file 1 should only contain first file content")
+	}
+	if !strings.Contains(files[1].Content, "second file") || strings.Contains(files[1].Content, "third file") {
+		t.Error("file 2 should only contain second file content")
+	}
+	if !strings.Contains(files[2].Content, "third file") {
+		t.Error("file 3 should contain third file content")
+	}
+}
+
+func TestParseDiffIntoFiles_RenamedFile(t *testing.T) {
+	// When a file is renamed, the a/ and b/ paths differ
+	diff := `diff --git a/old_name.go b/new_name.go
+similarity index 95%
+rename from old_name.go
+rename to new_name.go
++some content`
+
+	files := ParseDiffIntoFiles(diff)
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	// Should use the b/ path (destination/new name)
+	if files[0].Filename != "new_name.go" {
+		t.Errorf("expected filename 'new_name.go' (destination), got %q", files[0].Filename)
+	}
+}
+
+func TestDistributeFiles_ZeroReviewers(t *testing.T) {
+	files := []FileDiff{{Filename: "test.go", Content: "content", Size: 7}}
+
+	result := DistributeFiles(files, 0)
+	if result != nil {
+		t.Error("expected nil for zero reviewers")
+	}
+
+	result = DistributeFiles(files, -1)
+	if result != nil {
+		t.Error("expected nil for negative reviewers")
+	}
+}
+
+func TestDistributeFiles_EmptyFiles(t *testing.T) {
+	result := DistributeFiles([]FileDiff{}, 3)
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(result))
+	}
+
+	for i, chunk := range result {
+		if chunk != "" {
+			t.Errorf("chunk %d should be empty, got %q", i, chunk)
+		}
+	}
+}
+
+func TestDistributeFiles_RoundRobin(t *testing.T) {
+	files := []FileDiff{
+		{Filename: "file1.go", Content: "content1", Size: 8},
+		{Filename: "file2.go", Content: "content2", Size: 8},
+		{Filename: "file3.go", Content: "content3", Size: 8},
+		{Filename: "file4.go", Content: "content4", Size: 8},
+		{Filename: "file5.go", Content: "content5", Size: 8},
+	}
+
+	// Distribute 5 files across 3 reviewers
+	result := DistributeFiles(files, 3)
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(result))
+	}
+
+	// Reviewer 0 gets files 0, 3 (indices 0, 3)
+	if !strings.Contains(result[0], "content1") || !strings.Contains(result[0], "content4") {
+		t.Errorf("reviewer 0 should have files 1 and 4, got %q", result[0])
+	}
+
+	// Reviewer 1 gets files 1, 4 (indices 1, 4)
+	if !strings.Contains(result[1], "content2") || !strings.Contains(result[1], "content5") {
+		t.Errorf("reviewer 1 should have files 2 and 5, got %q", result[1])
+	}
+
+	// Reviewer 2 gets file 2 (index 2)
+	if !strings.Contains(result[2], "content3") {
+		t.Errorf("reviewer 2 should have file 3, got %q", result[2])
+	}
+}
+
+func TestDistributeFiles_MoreReviewersThanFiles(t *testing.T) {
+	files := []FileDiff{
+		{Filename: "file1.go", Content: "content1", Size: 8},
+		{Filename: "file2.go", Content: "content2", Size: 8},
+	}
+
+	// 2 files distributed to 5 reviewers
+	result := DistributeFiles(files, 5)
+
+	if len(result) != 5 {
+		t.Fatalf("expected 5 chunks, got %d", len(result))
+	}
+
+	// Reviewers 0, 1 get files; reviewers 2, 3, 4 get nothing
+	if !strings.Contains(result[0], "content1") {
+		t.Error("reviewer 0 should have file 1")
+	}
+	if !strings.Contains(result[1], "content2") {
+		t.Error("reviewer 1 should have file 2")
+	}
+	for i := 2; i < 5; i++ {
+		if result[i] != "" {
+			t.Errorf("reviewer %d should have empty chunk, got %q", i, result[i])
+		}
+	}
+}
+
+func TestDistributeFiles_LargeFileTruncated(t *testing.T) {
+	// Create a file larger than MaxDiffSize
+	largeContent := strings.Repeat("x", MaxDiffSize+1000)
+	files := []FileDiff{
+		{Filename: "large.go", Content: largeContent, Size: len(largeContent)},
+	}
+
+	result := DistributeFiles(files, 1)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(result))
+	}
+
+	// The chunk should be truncated and include the truncation notice
+	if !strings.Contains(result[0], TruncationNotice) {
+		t.Error("large file should be truncated")
+	}
+
+	// Result should be smaller than original
+	if len(result[0]) >= len(largeContent) {
+		t.Errorf("truncated content (%d bytes) should be smaller than original (%d bytes)",
+			len(result[0]), len(largeContent))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds automatic diff truncation (400KB default) to prevent Claude's "prompt too long" errors
- Truncates at file boundaries when possible to preserve complete file diffs
- Includes a notice when truncation occurs so reviewers know context was limited
- Adds comprehensive tests for the truncation logic

## Root Cause
When running `acr -r 8 -a claude -B <branch>`, the Claude agent passes the full git diff in the prompt. Unlike Codex (which uses a built-in `review --base` command that handles diffs internally), Claude receives the entire diff as part of the prompt text. Large diffs exceed Claude's context limits (~200K tokens).

## Test plan
- [x] Unit tests for TruncateDiff function
- [x] Unit tests for BuildPromptWithDiff with large diffs
- [x] Full test suite passes
- [ ] Manual testing with large branch diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)