### PR TITLE
feat: Agent-based review mode for Claude

### DIFF
--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -20,6 +20,44 @@ Skip:
 
 Output format: file:line: description`
 
+// DefaultClaudeExplorePrompt is the exploration-based review prompt for Claude.
+// This prompt instructs Claude to use tools to explore and review code rather
+// than receiving the diff directly. This enables smarter reviews that can
+// follow imports, check tests, and understand context.
+const DefaultClaudeExplorePrompt = `You are a code reviewer. Your task is to review the changes in this branch compared to %s.
+
+IMPORTANT: You have access to tools (Bash, Read, Grep). Use them to explore the code.
+
+## Your workflow:
+1. First, run: git diff --name-only %s
+   This shows you which files changed.
+
+2. For each changed file, use the Read tool to examine the full file content.
+   Understanding the full context helps you find issues the diff alone would miss.
+
+3. If you see imports or function calls, trace them to understand the code flow.
+   Use Grep to find definitions and usages.
+
+4. Check if there are related test files. Review those too.
+
+## What to look for:
+- Logic errors, wrong behavior, crashes
+- Security issues (injection, auth bypass, exposure)
+- Silent failures, swallowed errors
+- Wrong type conversions
+- Missing operations (data not passed, steps skipped)
+
+## What to skip:
+- Style/formatting
+- Performance unless severe
+- Suggestions (only report actual bugs)
+
+## Output format:
+After your exploration, output your findings as:
+file:line: description
+
+One finding per line. Only report actual issues - if there are no bugs, output nothing.`
+
 // DefaultGeminiPrompt is the default review prompt for Gemini-based agents.
 // Decoupled from Claude prompt to allow independent tuning.
 const DefaultGeminiPrompt = `You are a code reviewer. Review the provided code changes (git diff) and identify actionable issues.


### PR DESCRIPTION
## Summary
Implements agent-based review for Claude where Claude explores the code using its tools (Bash, Read, Grep) rather than receiving the diff in the prompt.

## Approach
- Uses `claude --print --allowedTools "Bash,Read,Grep"` for non-interactive tool access
- Claude runs `git diff --name-only` to discover changed files
- Claude reads and reviews files autonomously
- More like how a human reviews code

## Changes
- Updated `internal/agent/claude.go` to use exploration mode
- New exploration prompt that guides Claude to discover and review changes
- This is now the DEFAULT behavior for `-a claude`

## Benefits
- No prompt size limits - Claude reads files on demand
- Smarter - can follow imports, check tests, understand context
- Can prioritize high-risk areas (auth, payments, etc.)

## Test plan
- [ ] Manual testing with various branch sizes
- [ ] Compare findings quality vs diff-in-prompt approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)