### PR TITLE
feat: fetch remote base branch before diff

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -12,7 +12,7 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
 
-func executeReview(ctx context.Context, workDir string, excludePatterns []string, customPrompt string, reviewerAgentNames []string, logger *terminal.Logger) domain.ExitCode {
+func executeReview(ctx context.Context, workDir string, excludePatterns []string, customPrompt string, reviewerAgentNames []string, fetchRemote bool, logger *terminal.Logger) domain.ExitCode {
 	if concurrency < reviewers {
 		logger.Logf(terminal.StyleInfo, "Starting review %s(%d reviewers, %d concurrent, base=%s)%s",
 			terminal.Color(terminal.Dim), reviewers, concurrency, baseRef, terminal.Color(terminal.Reset))
@@ -62,6 +62,7 @@ func executeReview(ctx context.Context, workDir string, excludePatterns []string
 		BaseRef:      baseRef,
 		Timeout:      timeout,
 		Retries:      retries,
+		FetchRemote:  fetchRemote,
 		Verbose:      verbose,
 		WorkDir:      workDir,
 		CustomPrompt: customPrompt,

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -53,7 +53,7 @@ func (c *ClaudeAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (
 	}
 
 	// Get git diff and append to prompt
-	diff, err := GetGitDiff(ctx, config.BaseRef, config.WorkDir)
+	diff, err := GetGitDiff(ctx, config.BaseRef, config.WorkDir, config.FetchRemote)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get diff for review: %w", err)
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -47,7 +47,7 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (i
 
 	if config.CustomPrompt != "" {
 		// Custom prompt mode: pipe prompt + diff to 'codex exec -'
-		diff, err := GetGitDiff(ctx, config.BaseRef, config.WorkDir)
+		diff, err := GetGitDiff(ctx, config.BaseRef, config.WorkDir, config.FetchRemote)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get diff for review: %w", err)
 		}

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -22,4 +22,8 @@ type ReviewConfig struct {
 
 	// ReviewerID is a unique identifier for this reviewer instance (e.g., "reviewer-1").
 	ReviewerID string
+
+	// FetchRemote enables fetching the latest base ref from origin before diffing.
+	// When true, compares against origin/<baseRef>. Falls back to local ref if fetch fails.
+	FetchRemote bool
 }

--- a/internal/agent/diff_test.go
+++ b/internal/agent/diff_test.go
@@ -1,0 +1,230 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetGitDiff_EmptyBaseRef(t *testing.T) {
+	ctx := context.Background()
+	_, err := GetGitDiff(ctx, "", "", false)
+	if err == nil {
+		t.Error("GetGitDiff() should return error for empty baseRef")
+	}
+	if !strings.Contains(err.Error(), "base ref cannot be empty") {
+		t.Errorf("GetGitDiff() error = %v, want error containing 'base ref cannot be empty'", err)
+	}
+}
+
+func TestGetGitDiff_InvalidBaseRef(t *testing.T) {
+	ctx := context.Background()
+	_, err := GetGitDiff(ctx, "-invalidref", "", false)
+	if err == nil {
+		t.Error("GetGitDiff() should return error for baseRef starting with -")
+	}
+	if !strings.Contains(err.Error(), "must not start with -") {
+		t.Errorf("GetGitDiff() error = %v, want error containing 'must not start with -'", err)
+	}
+}
+
+func TestGetGitDiff_FetchDisabled(t *testing.T) {
+	// Create a temporary git repo for testing
+	tmpDir, err := os.MkdirTemp("", "git-diff-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Initialize git repo
+	if err := runGit(tmpDir, "init"); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+	if err := runGit(tmpDir, "config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("Failed to set git email: %v", err)
+	}
+	if err := runGit(tmpDir, "config", "user.name", "Test"); err != nil {
+		t.Fatalf("Failed to set git name: %v", err)
+	}
+
+	// Create initial commit
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("initial"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+	if err := runGit(tmpDir, "add", "."); err != nil {
+		t.Fatalf("Failed to git add: %v", err)
+	}
+	if err := runGit(tmpDir, "commit", "-m", "initial"); err != nil {
+		t.Fatalf("Failed to git commit: %v", err)
+	}
+
+	// Modify file
+	if err := os.WriteFile(testFile, []byte("modified"), 0644); err != nil {
+		t.Fatalf("Failed to modify test file: %v", err)
+	}
+
+	// Get diff without fetch (fetchRemote=false)
+	ctx := context.Background()
+	diff, err := GetGitDiff(ctx, "HEAD", tmpDir, false)
+	if err != nil {
+		t.Fatalf("GetGitDiff() error = %v", err)
+	}
+
+	// Verify diff contains the change
+	if !strings.Contains(diff, "-initial") || !strings.Contains(diff, "+modified") {
+		t.Errorf("GetGitDiff() diff doesn't contain expected changes: %s", diff)
+	}
+}
+
+func TestGetGitDiff_FetchEnabled_FallbackOnFailure(t *testing.T) {
+	// Create a temporary git repo for testing (no remote configured)
+	tmpDir, err := os.MkdirTemp("", "git-diff-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Initialize git repo
+	if err := runGit(tmpDir, "init"); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+	if err := runGit(tmpDir, "config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("Failed to set git email: %v", err)
+	}
+	if err := runGit(tmpDir, "config", "user.name", "Test"); err != nil {
+		t.Fatalf("Failed to set git name: %v", err)
+	}
+
+	// Create initial commit
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("initial"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+	if err := runGit(tmpDir, "add", "."); err != nil {
+		t.Fatalf("Failed to git add: %v", err)
+	}
+	if err := runGit(tmpDir, "commit", "-m", "initial"); err != nil {
+		t.Fatalf("Failed to git commit: %v", err)
+	}
+
+	// Modify file
+	if err := os.WriteFile(testFile, []byte("modified"), 0644); err != nil {
+		t.Fatalf("Failed to modify test file: %v", err)
+	}
+
+	// Get diff with fetch enabled (should fall back to local since no remote)
+	ctx := context.Background()
+	diff, err := GetGitDiff(ctx, "HEAD", tmpDir, true)
+	if err != nil {
+		t.Fatalf("GetGitDiff() error = %v", err)
+	}
+
+	// Verify diff contains the change (fallback to local worked)
+	if !strings.Contains(diff, "-initial") || !strings.Contains(diff, "+modified") {
+		t.Errorf("GetGitDiff() diff doesn't contain expected changes: %s", diff)
+	}
+}
+
+func TestGetGitDiff_FetchEnabled_AlreadyHasOriginPrefix(t *testing.T) {
+	// Create a temporary git repo for testing
+	tmpDir, err := os.MkdirTemp("", "git-diff-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Initialize git repo
+	if err := runGit(tmpDir, "init"); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+	if err := runGit(tmpDir, "config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("Failed to set git email: %v", err)
+	}
+	if err := runGit(tmpDir, "config", "user.name", "Test"); err != nil {
+		t.Fatalf("Failed to set git name: %v", err)
+	}
+
+	// Create initial commit
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("initial"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+	if err := runGit(tmpDir, "add", "."); err != nil {
+		t.Fatalf("Failed to git add: %v", err)
+	}
+	if err := runGit(tmpDir, "commit", "-m", "initial"); err != nil {
+		t.Fatalf("Failed to git commit: %v", err)
+	}
+
+	// Add a fake origin remote
+	if err := runGit(tmpDir, "remote", "add", "origin", tmpDir); err != nil {
+		t.Fatalf("Failed to add remote: %v", err)
+	}
+
+	// Fetch to create origin refs
+	if err := runGit(tmpDir, "fetch", "origin"); err != nil {
+		t.Fatalf("Failed to fetch: %v", err)
+	}
+
+	// Get current branch name (could be main or master depending on git config)
+	cmd := exec.Command("git", "branch", "--show-current")
+	cmd.Dir = tmpDir
+	branchOutput, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Failed to get current branch: %v", err)
+	}
+	branchName := strings.TrimSpace(string(branchOutput))
+
+	// Modify file
+	if err := os.WriteFile(testFile, []byte("modified"), 0644); err != nil {
+		t.Fatalf("Failed to modify test file: %v", err)
+	}
+
+	// Get diff with baseRef already containing "origin/" prefix
+	// Should NOT prepend another "origin/" (i.e., should not become "origin/origin/<branch>")
+	ctx := context.Background()
+	diff, err := GetGitDiff(ctx, "origin/"+branchName, tmpDir, true)
+	if err != nil {
+		t.Fatalf("GetGitDiff() error = %v", err)
+	}
+
+	// Verify diff contains the change
+	if !strings.Contains(diff, "-initial") || !strings.Contains(diff, "+modified") {
+		t.Errorf("GetGitDiff() diff doesn't contain expected changes: %s", diff)
+	}
+}
+
+func TestBuildPromptWithDiff_EmptyDiff(t *testing.T) {
+	prompt := "Review this code"
+	result := BuildPromptWithDiff(prompt, "")
+	expected := "Review this code\n\n(No changes detected)"
+	if result != expected {
+		t.Errorf("BuildPromptWithDiff() = %q, want %q", result, expected)
+	}
+}
+
+func TestBuildPromptWithDiff_WithDiff(t *testing.T) {
+	prompt := "Review this code"
+	diff := "- old\n+ new"
+	result := BuildPromptWithDiff(prompt, diff)
+	if !strings.Contains(result, prompt) {
+		t.Errorf("BuildPromptWithDiff() result doesn't contain prompt")
+	}
+	if !strings.Contains(result, "```diff") {
+		t.Errorf("BuildPromptWithDiff() result doesn't contain diff block")
+	}
+	if !strings.Contains(result, diff) {
+		t.Errorf("BuildPromptWithDiff() result doesn't contain diff")
+	}
+}
+
+// runGit runs a git command in the specified directory
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	return cmd.Run()
+}

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -49,7 +49,7 @@ func (g *GeminiAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (
 	}
 
 	// Get git diff and append to prompt
-	diff, err := GetGitDiff(ctx, config.BaseRef, config.WorkDir)
+	diff, err := GetGitDiff(ctx, config.BaseRef, config.WorkDir, config.FetchRemote)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get diff for review: %w", err)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -22,6 +22,7 @@ type Config struct {
 	BaseRef      string
 	Timeout      time.Duration
 	Retries      int
+	FetchRemote  bool
 	Verbose      bool
 	WorkDir      string
 	CustomPrompt string
@@ -188,6 +189,7 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		Verbose:      r.config.Verbose,
 		CustomPrompt: r.config.CustomPrompt,
 		ReviewerID:   strconv.Itoa(reviewerID),
+		FetchRemote:  r.config.FetchRemote,
 	}
 
 	// Execute the review


### PR DESCRIPTION
## Summary

- Add `--fetch` flag (default: true) to fetch latest base ref from origin before computing diff
- Add `--no-fetch` flag to disable remote fetch and use local state
- Support via env var `ACR_FETCH` and config file `fetch:` field
- Graceful fallback to local ref if fetch fails (offline mode, ref doesn't exist)

## Changes

- `internal/agent/diff.go`: Add `fetchRemote` parameter to `GetGitDiff()`, fetch from origin when enabled
- `cmd/acr/main.go`: Add `--fetch` and `--no-fetch` CLI flags
- `internal/config/config.go`: Add fetch to config resolution (flags > env > config > defaults)
- `internal/agent/config.go`: Add `FetchRemote` field to `ReviewConfig`
- `internal/runner/runner.go`: Add `FetchRemote` to runner config, pass to review config
- All agent implementations updated to pass `FetchRemote` to `GetGitDiff()`
- `internal/agent/diff_test.go`: Unit tests for new functionality

## Test plan

- [x] `make check` passes (fmt, lint, vet, staticcheck, tests)
- [x] Unit tests for `GetGitDiff` with fetch enabled/disabled
- [x] Test fallback when fetch fails (no remote configured)
- [x] Test edge case where baseRef already has `origin/` prefix
- [x] Manual test: `acr --base main --local` (default fetch behavior)
- [x] Manual test: `acr --base main --local --no-fetch` (skip fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)