### PR TITLE
feat: fetch remote base branch before diff

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -60,9 +60,9 @@ func executeReview(ctx context.Context, workDir string, excludePatterns []string
 	if fetchRemote {
 		result := agent.FetchRemoteRef(ctx, baseRef, workDir)
 		resolvedBaseRef = result.ResolvedRef
-		if result.FetchAttempted && !result.FetchSucceeded {
+		if result.FetchAttempted && !result.RefResolved {
 			logger.Logf(terminal.StyleWarning, "Failed to fetch %s from origin, comparing against local %s (may be stale)", baseRef, resolvedBaseRef)
-		} else if verbose && result.FetchAttempted && result.FetchSucceeded {
+		} else if verbose && result.FetchAttempted && result.RefResolved {
 			logger.Logf(terminal.StyleDim, "Comparing against %s (fetched from origin)", resolvedBaseRef)
 		}
 	}
@@ -74,7 +74,6 @@ func executeReview(ctx context.Context, workDir string, excludePatterns []string
 		BaseRef:      resolvedBaseRef,
 		Timeout:      timeout,
 		Retries:      retries,
-		FetchRemote:  fetchRemote,
 		Verbose:      verbose,
 		WorkDir:      workDir,
 		CustomPrompt: customPrompt,

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -23,10 +23,6 @@ type ReviewConfig struct {
 	// ReviewerID is a unique identifier for this reviewer instance (e.g., "reviewer-1").
 	ReviewerID string
 
-	// FetchRemote enables fetching the latest base ref from origin before diffing.
-	// When true, compares against origin/<baseRef>. Falls back to local ref if fetch fails.
-	FetchRemote bool
-
 	// UseRefFile writes the diff to a temp file and instructs the agent to read it,
 	// instead of embedding the diff in the prompt. This avoids "prompt too long" errors.
 	// When false (default), ref-file mode is still used automatically if diff exceeds RefFileSizeThreshold.

--- a/internal/agent/diff.go
+++ b/internal/agent/diff.go
@@ -11,9 +11,9 @@ import (
 type FetchResult struct {
 	// ResolvedRef is the ref to use for diffing (either "origin/<baseRef>" or "<baseRef>")
 	ResolvedRef string
-	// FetchSucceeded indicates whether the remote fetch was successful
-	FetchSucceeded bool
-	// FetchAttempted indicates whether a fetch was attempted (false if baseRef already has origin/ prefix)
+	// RefResolved indicates whether the ref was successfully resolved (true if fetch succeeded or was skipped)
+	RefResolved bool
+	// FetchAttempted indicates whether a fetch was attempted (false if baseRef already has origin/ prefix or is a non-branch ref)
 	FetchAttempted bool
 }
 
@@ -30,7 +30,7 @@ func FetchRemoteRef(ctx context.Context, baseRef, workDir string) FetchResult {
 	if strings.HasPrefix(baseRef, "origin/") {
 		return FetchResult{
 			ResolvedRef:    baseRef,
-			FetchSucceeded: true,
+			RefResolved:    true,
 			FetchAttempted: false,
 		}
 	}
@@ -49,7 +49,7 @@ func FetchRemoteRef(ctx context.Context, baseRef, workDir string) FetchResult {
 		strings.HasPrefix(baseRef, "refs/") {
 		return FetchResult{
 			ResolvedRef:    baseRef,
-			FetchSucceeded: true,
+			RefResolved:    true,
 			FetchAttempted: false,
 		}
 	}
@@ -67,14 +67,14 @@ func FetchRemoteRef(ctx context.Context, baseRef, workDir string) FetchResult {
 		if isTag(ctx, baseRef, workDir) {
 			return FetchResult{
 				ResolvedRef:    baseRef,
-				FetchSucceeded: true,
+				RefResolved:    true,
 				FetchAttempted: true,
 			}
 		}
 		// It's a branch, use the remote ref
 		return FetchResult{
 			ResolvedRef:    "origin/" + baseRef,
-			FetchSucceeded: true,
+			RefResolved:    true,
 			FetchAttempted: true,
 		}
 	}
@@ -82,7 +82,7 @@ func FetchRemoteRef(ctx context.Context, baseRef, workDir string) FetchResult {
 	// Fetch failed, fall back to local ref
 	return FetchResult{
 		ResolvedRef:    baseRef,
-		FetchSucceeded: false,
+		RefResolved:    false,
 		FetchAttempted: true,
 	}
 }

--- a/internal/agent/diff_test.go
+++ b/internal/agent/diff_test.go
@@ -87,8 +87,8 @@ func TestFetchRemoteRef_AlreadyHasOriginPrefix(t *testing.T) {
 	if result.ResolvedRef != "origin/main" {
 		t.Errorf("FetchRemoteRef() ResolvedRef = %q, want %q", result.ResolvedRef, "origin/main")
 	}
-	if !result.FetchSucceeded {
-		t.Error("FetchRemoteRef() FetchSucceeded = false, want true")
+	if !result.RefResolved {
+		t.Error("FetchRemoteRef() RefResolved = false, want true")
 	}
 	if result.FetchAttempted {
 		t.Error("FetchRemoteRef() FetchAttempted = true, want false (no fetch needed)")
@@ -118,8 +118,8 @@ func TestFetchRemoteRef_SkipsNonBranchRefs(t *testing.T) {
 			if result.ResolvedRef != tt.baseRef {
 				t.Errorf("FetchRemoteRef(%q) ResolvedRef = %q, want %q", tt.baseRef, result.ResolvedRef, tt.baseRef)
 			}
-			if !result.FetchSucceeded {
-				t.Errorf("FetchRemoteRef(%q) FetchSucceeded = false, want true", tt.baseRef)
+			if !result.RefResolved {
+				t.Errorf("FetchRemoteRef(%q) RefResolved = false, want true", tt.baseRef)
 			}
 			if result.FetchAttempted {
 				t.Errorf("FetchRemoteRef(%q) FetchAttempted = true, want false (skip fetch for non-branch refs)", tt.baseRef)
@@ -133,14 +133,14 @@ func TestIsLikelyCommitSHA(t *testing.T) {
 		ref      string
 		expected bool
 	}{
-		{"abc1234", true},                                      // 7 char short SHA
-		{"abc1234567890abcdef1234567890abcdef1234", true},      // 40 char full SHA
-		{"ABC1234", true},                                      // uppercase hex
-		{"main", false},                                        // branch name
-		{"HEAD~3", false},                                      // contains ~
-		{"abc123", false},                                      // too short (6 chars)
-		{"abc123456789012345678901234567890123456789", false},   // too long (41 chars)
-		{"xyz1234", false},                                     // contains non-hex
+		{"abc1234", true}, // 7 char short SHA
+		{"abc1234567890abcdef1234567890abcdef1234", true}, // 40 char full SHA
+		{"ABC1234", true}, // uppercase hex
+		{"main", false},   // branch name
+		{"HEAD~3", false}, // contains ~
+		{"abc123", false}, // too short (6 chars)
+		{"abc123456789012345678901234567890123456789", false}, // too long (41 chars)
+		{"xyz1234", false}, // contains non-hex
 	}
 
 	for _, tt := range tests {
@@ -200,8 +200,8 @@ func TestFetchRemoteRef_NoRemote(t *testing.T) {
 	if result.ResolvedRef != branchName {
 		t.Errorf("FetchRemoteRef() ResolvedRef = %q, want %q (local fallback)", result.ResolvedRef, branchName)
 	}
-	if result.FetchSucceeded {
-		t.Error("FetchRemoteRef() FetchSucceeded = true, want false (no remote)")
+	if result.RefResolved {
+		t.Error("FetchRemoteRef() RefResolved = true, want false (no remote)")
 	}
 	if !result.FetchAttempted {
 		t.Error("FetchRemoteRef() FetchAttempted = false, want true")
@@ -261,8 +261,8 @@ func TestFetchRemoteRef_WithRemote(t *testing.T) {
 	if result.ResolvedRef != expectedRef {
 		t.Errorf("FetchRemoteRef() ResolvedRef = %q, want %q", result.ResolvedRef, expectedRef)
 	}
-	if !result.FetchSucceeded {
-		t.Error("FetchRemoteRef() FetchSucceeded = false, want true")
+	if !result.RefResolved {
+		t.Error("FetchRemoteRef() RefResolved = false, want true")
 	}
 	if !result.FetchAttempted {
 		t.Error("FetchRemoteRef() FetchAttempted = false, want true")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -22,7 +22,6 @@ type Config struct {
 	BaseRef      string
 	Timeout      time.Duration
 	Retries      int
-	FetchRemote  bool
 	Verbose      bool
 	WorkDir      string
 	CustomPrompt string
@@ -190,7 +189,6 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		Verbose:      r.config.Verbose,
 		CustomPrompt: r.config.CustomPrompt,
 		ReviewerID:   strconv.Itoa(reviewerID),
-		FetchRemote:  r.config.FetchRemote,
 		UseRefFile:   r.config.UseRefFile,
 	}
 


### PR DESCRIPTION
## Summary

- Add `--fetch` flag (default: true) to fetch latest base ref from origin before computing diff
- Add `--no-fetch` flag to disable remote fetch and use local state
- Support via env var `ACR_FETCH` and config file `fetch:` field
- Graceful fallback to local ref if fetch fails (offline mode, ref doesn't exist)

## Changes

- `internal/agent/diff.go`: Add `fetchRemote` parameter to `GetGitDiff()`, fetch from origin when enabled
- `cmd/acr/main.go`: Add `--fetch` and `--no-fetch` CLI flags
- `internal/config/config.go`: Add fetch to config resolution (flags > env > config > defaults)
- `internal/agent/config.go`: Add `FetchRemote` field to `ReviewConfig`
- `internal/runner/runner.go`: Add `FetchRemote` to runner config, pass to review config
- All agent implementations updated to pass `FetchRemote` to `GetGitDiff()`
- `internal/agent/diff_test.go`: Unit tests for new functionality

## Test plan

- [x] `make check` passes (fmt, lint, vet, staticcheck, tests)
- [x] Unit tests for `GetGitDiff` with fetch enabled/disabled
- [x] Test fallback when fetch fails (no remote configured)
- [x] Test edge case where baseRef already has `origin/` prefix
- [ ] Manual test: `acr --base main --local` (default fetch behavior)
- [ ] Manual test: `acr --base main --local --no-fetch` (skip fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)