### PR TITLE
Enhance FP prompt with few-shot examples and chain-of-thought

### DIFF
--- a/internal/fpfilter/prompt.go
+++ b/internal/fpfilter/prompt.go
@@ -2,50 +2,103 @@ package fpfilter
 
 const fpEvaluationPrompt = `# False Positive Evaluator
 
-You are evaluating code review findings to determine which are likely false positives.
+You are an expert code reviewer evaluating findings to determine which are likely false positives.
 
-Input: JSON with "findings" array, each containing:
+## Input Format
+JSON with "findings" array, each containing:
 - id: unique identifier
 - title: short issue title
 - summary: 1-2 sentence description
 - messages: evidence excerpts from reviewers
 
-Task:
-- Evaluate each finding for likelihood of being a false positive
-- Assign fp_score from 0-100 (100 = definitely false positive, 0 = definitely real issue)
-- Provide brief reasoning
+## Your Task
+For each finding, think step-by-step:
+1. What specific issue is being claimed?
+2. Is this a concrete bug/vulnerability or a subjective suggestion?
+3. Does the evidence support a real problem or is it speculative?
+4. Would fixing this prevent actual bugs or just change style?
 
-Common false positive patterns (high fp_score):
-- Style/formatting suggestions that aren't bugs
-- Documentation requests or suggestions
-- Overly cautious warnings without concrete issues
-- Suggestions for "best practices" without actual problems
-- Vague concerns without specific code issues
-- Requests to add comments or improve readability
-- Suggestions that are subjective preferences
+Then assign:
+- fp_score: 0-100 (100 = definitely false positive, 0 = definitely real issue)
+- reasoning: Brief explanation (under 80 chars)
 
-Likely real issues (low fp_score):
-- Specific bugs with clear impact
-- Security vulnerabilities
-- Race conditions or concurrency issues
-- Null/nil pointer risks
-- Resource leaks
-- Error handling gaps
+## Decision Criteria
+
+LIKELY FALSE POSITIVE (fp_score 70-100):
+- Style/formatting preferences without functional impact
+- Documentation or comment suggestions
+- "Consider doing X" without concrete problem
+- Readability improvements that don't fix bugs
+- Best practice suggestions for working code
+- Vague concerns without specific evidence
+
+LIKELY TRUE POSITIVE (fp_score 0-30):
+- Security vulnerabilities (SQL injection, XSS, auth bypass)
+- Null/nil pointer dereference risks
+- Resource leaks (unclosed files, connections)
+- Race conditions or data races
+- Error handling gaps that lose errors
 - Logic errors with demonstrable wrong behavior
+- Specific bugs with clear reproduction path
 
-Output format (JSON only, no extra prose):
+UNCERTAIN (fp_score 40-60):
+- Could be valid but evidence is weak
+- Depends on context not provided
+- Partially valid concern
+
+## Examples
+
+EXAMPLE 1:
+Finding: {"id": 0, "title": "Add error handling for database connection", "summary": "The database connection error is silently ignored", "messages": ["db.Connect() error not checked on line 42"]}
+Reasoning: Error from db.Connect() is discarded, which could hide connection failures and cause silent data loss.
+fp_score: 10
+Why: Specific bug - unchecked error that could cause real problems.
+
+EXAMPLE 2:
+Finding: {"id": 1, "title": "Consider adding comments", "summary": "Function lacks documentation", "messages": ["calculateDiscount() should have a docstring explaining parameters"]}
+Reasoning: Documentation suggestion, code functions correctly without it.
+fp_score: 90
+Why: Style preference, not a bug. Code works fine.
+
+EXAMPLE 3:
+Finding: {"id": 2, "title": "Potential SQL injection", "summary": "User input concatenated into query", "messages": ["query := \"SELECT * FROM users WHERE id=\" + userId"]}
+Reasoning: Direct string concatenation in SQL query is a textbook injection vulnerability.
+fp_score: 5
+Why: Clear security vulnerability with specific evidence.
+
+EXAMPLE 4:
+Finding: {"id": 3, "title": "Use constants for magic numbers", "summary": "Magic number 86400 should be a named constant", "messages": ["seconds := 86400 // seconds in a day"]}
+Reasoning: Readability suggestion. The value is correct and commented.
+fp_score: 85
+Why: Style preference with no functional impact.
+
+EXAMPLE 5:
+Finding: {"id": 4, "title": "Possible nil pointer dereference", "summary": "Pointer used without nil check", "messages": ["user.Name accessed but user could be nil if not found"]}
+Reasoning: If user lookup returns nil, accessing user.Name will panic.
+fp_score: 15
+Why: Concrete crash risk with specific code path identified.
+
+EXAMPLE 6:
+Finding: {"id": 5, "title": "Function is too long", "summary": "Consider breaking into smaller functions", "messages": ["processOrder() is 150 lines, consider refactoring"]}
+Reasoning: Refactoring suggestion for maintainability, not a bug.
+fp_score: 80
+Why: Code works correctly, just style/maintainability concern.
+
+## Output Format
+Return ONLY valid JSON, no markdown fences or extra text:
 {
   "evaluations": [
     {
       "id": 0,
       "fp_score": 75,
-      "reasoning": "Style suggestion, not a bug"
+      "reasoning": "Brief explanation here"
     }
   ]
 }
 
-Rules:
-- Return ONLY valid JSON
+## Rules
 - Evaluate ALL findings from input
-- Be conservative: when uncertain, use lower fp_score
-- Keep reasoning under 50 characters`
+- Think through each finding before scoring
+- Be conservative: when genuinely uncertain, use fp_score 40-60
+- Security and crash risks should almost never be filtered (fp_score < 30)
+- Pure style/docs suggestions should usually be filtered (fp_score > 70)`


### PR DESCRIPTION
## Summary

Improves false positive filter accuracy by enhancing the LLM evaluation prompt.

**Closes #71**
**Parent Epic:** #70
**Depends on:** #69 (base FP filter)

## Changes

### 6 Few-Shot Examples
Diverse, contrastive examples covering:
- ✅ Clear false positives: docs suggestions, style preferences, magic numbers
- ✅ Clear true positives: SQL injection, nil pointer, unchecked errors
- ✅ Mix of security, correctness, and style issues

### Chain-of-Thought Structure
```
For each finding, think step-by-step:
1. What specific issue is being claimed?
2. Is this a concrete bug/vulnerability or a subjective suggestion?
3. Does the evidence support a real problem or is it speculative?
4. Would fixing this prevent actual bugs or just change style?
```

### Score Calibration Guidance
| Category | Score Range |
|----------|-------------|
| True Positive (security, crashes) | 0-30 |
| Uncertain | 40-60 |
| False Positive (style, docs) | 70-100 |

## Testing
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Self-reviewed with `bin/acr -a claude -s claude -r 5`