### PR TITLE
chore(deps): upgrade to Go 1.25 and unpin staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ find-deadcode:
 # Run staticcheck
 staticcheck:
 	@echo "Running staticcheck..."
-	@go run honnef.co/go/tools/cmd/staticcheck@v0.6.0 ./...
+	@go run honnef.co/go/tools/cmd/staticcheck@latest ./...
 	@echo "Staticcheck passed!"
 
 # Run all quality checks (format, lint, vet, staticcheck, tests)

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/richhaase/agentic-code-reviewer
 
-go 1.24.6
+go 1.25.0
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -29,7 +30,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/sys v0.39.0 // indirect


### PR DESCRIPTION
## Summary

- Bumps minimum Go version from 1.24.6 to 1.25.0
- Switches staticcheck from pinned `v0.6.0` back to `@latest` (v0.7.0+ requires Go >= 1.25)

Closes #160

## Test plan

- [x] `make check` passes locally (fmt, lint, vet, staticcheck, all tests)
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)