### PR TITLE
[codex] Recommend against Claude Code for ACR billing path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -127,8 +127,8 @@ homebrew_casks:
 
       ACR runs parallel code reviews using AI agents and summarizes findings.
       It requires at least one supported LLM CLI: codex, claude, or gemini.
-      Claude users should review Anthropic's claude -p / Agent SDK billing
-      terms before running high reviewer counts or Claude-powered summaries.
+      Claude Code is not recommended with ACR unless you explicitly accept
+      Anthropic's claude -p / Agent SDK billing model.
 
 # Sign and notarize macOS binaries
 notarize:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -127,6 +127,8 @@ homebrew_casks:
 
       ACR runs parallel code reviews using AI agents and summarizes findings.
       It requires at least one supported LLM CLI: codex, claude, or gemini.
+      Claude users should review Anthropic's claude -p / Agent SDK billing
+      terms before running high reviewer counts or Claude-powered summaries.
 
 # Sign and notarize macOS binaries
 notarize:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# AGENTS.md - Development Guide
+
+This file provides guidance for AI assistants working on the ACR codebase.
+
+## Project Overview
+
+ACR (Agentic Code Reviewer) is a Go CLI that runs parallel code reviews using LLM agents (Codex, Codex, or Gemini). It spawns N reviewers, collects their findings, deduplicates/clusters them via an LLM summarizer, and optionally posts results to GitHub PRs.
+
+## Build & Test Commands
+
+Use `make` for all build/test/lint operations. Run `make help` to see available targets.
+
+```bash
+make build       # Build with version info (outputs to bin/)
+make check       # Run all quality checks (fmt, lint, vet, staticcheck, tests)
+make test        # Run all tests
+make lint        # Run golangci-lint v2
+make staticcheck # Run staticcheck
+make fmt         # Format code
+make clean       # Clean build artifacts
+```
+
+Direct go commands (if needed):
+
+```bash
+go test ./...      # Run tests directly
+go install ./cmd/acr  # Install locally
+```
+
+## Architecture
+
+```
+cmd/acr/main.go          # CLI entry point, flag parsing, orchestration
+internal/
+  agent/                 # LLM agent abstraction layer
+    agent.go             # Agent interface (ExecuteReview, ExecuteSummary)
+    codex.go             # Codex CLI agent implementation
+    Codex.go            # Codex CLI agent implementation
+    gemini.go            # Gemini CLI agent implementation
+    factory.go           # Agent and parser factory functions
+    parser.go            # ReviewParser and SummaryParser interfaces
+    *_review_parser.go   # Agent-specific review output parsers
+    *_summary_parser.go  # Agent-specific summary output parsers
+    prompts.go           # Default review prompts per agent
+  config/                # Configuration file support
+    config.go            # Load/parse .acr.yaml, resolve precedence (flags > env > config > defaults)
+  domain/                # Core types: Finding, AggregatedFinding, GroupedFindings
+    finding.go           # Finding types and aggregation logic
+    result.go            # ReviewerResult and ReviewStats
+    exitcode.go          # Exit code constants
+  filter/                # Finding filtering
+    filter.go            # Exclude findings by regex pattern matching
+  fpfilter/              # False positive filtering
+    fpfilter.go          # LLM-based false positive detection and removal
+  feedback/              # PR feedback summarization
+    fetch.go             # Fetch PR description and comments via gh CLI
+    summarizer.go        # LLM-based summarization of prior PR discussion
+  runner/                # Review execution engine
+    runner.go            # Parallel reviewer orchestration
+    report.go            # Report rendering (terminal + markdown)
+  summarizer/            # LLM-based finding summarization
+    summarizer.go        # Orchestrates agent execution and output parsing
+  github/                # GitHub PR operations via gh CLI
+    pr.go                # Post comments, approve PRs, check CI status
+  git/                   # Git operations
+    worktree.go          # Temporary worktree management
+  terminal/              # Terminal UI
+    spinner.go           # Progress spinner
+    logger.go            # Styled logging
+    colors.go            # ANSI color codes
+    format.go            # Text formatting utilities
+```
+
+## Key Design Decisions
+
+1. **Multi-Agent Support**: Supports multiple LLM backends (Codex, Codex, Gemini) via the `Agent` interface. Each agent handles its own CLI invocation and output parsing. Adding new agents requires implementing `Agent`, `ReviewParser`, and `SummaryParser`.
+
+2. **External Dependencies**: Uses LLM CLIs (`codex`, `Codex`, `gemini`) for reviews and `gh` CLI for GitHub. All are exec'd as subprocesses - no SDK dependencies.
+
+3. **Parallel Execution**: Reviewers run concurrently via goroutines. Results collected via channels with context cancellation support.
+
+4. **Finding Aggregation**: Three-phase process:
+   - First: Exact-match deduplication in `domain.AggregateFindings()`
+   - Then: Semantic clustering via LLM in `summarizer.Summarize()`
+   - Finally: LLM-based false positive filtering in `fpfilter.Filter()` (enabled by default, configurable threshold)
+
+5. **Exit Codes**: Semantic exit codes (0=clean, 1=findings, 2=error, 130=interrupted) for CI integration.
+
+6. **Terminal Detection**: Colors auto-disabled when stdout is not a TTY.
+
+## Code Patterns
+
+- **Error handling**: Return errors up the call stack. Log at the top level in main.go.
+- **Context propagation**: All long-running operations accept `context.Context` for cancellation.
+- **Configuration**: Three-tier precedence (flags > env vars > .acr.yaml > defaults). See `internal/config/config.go` for resolution logic.
+- **Testing**: Table-driven tests preferred. See `internal/domain/finding_test.go` for examples.
+
+## Adding New Features
+
+When adding features:
+
+1. **Domain types go in `internal/domain/`** - Keep them simple, no external dependencies.
+2. **New CLI flags** - Add to `cmd/acr/main.go`, follow existing pattern with env var defaults.
+3. **Tests required** - Add `_test.go` files alongside implementation.
+4. **Lint clean** - Run `make lint` before committing.
+
+## Common Tasks
+
+### Adding a new CLI flag
+
+```go
+// In cmd/acr/main.go, add to var block:
+var myFlag string
+
+// In run(), add flag definition:
+rootCmd.Flags().StringVarP(&myFlag, "my-flag", "m", getEnvStr("ACR_MY_FLAG", "default"), "Description")
+```
+
+### Adding a new finding field
+
+1. Update `domain.Finding` struct
+2. Update `domain.AggregatedFinding` if needed
+3. Update aggregation logic in `domain.AggregateFindings()`
+4. Update summarizer prompt if the field should be considered in clustering
+5. Add tests
+
+## Release Process
+
+Releases are automated via GoReleaser when tags are pushed:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+This triggers `.github/workflows/release.yml` which builds binaries for Linux/macOS (amd64/arm64), creates GitHub releases, and updates the Homebrew tap.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,14 @@ All PRs must include evidence of a successful ACR run against the
 contributed code using the repository's `.acr.yaml` configuration
 (which uses all three agent types with 6 reviewers):
 
+Note: the repository configuration uses Claude Code for part of the review.
+ACR invokes Claude in non-interactive `claude --print` mode, which Anthropic
+treats like `claude -p`/Agent SDK usage. Starting June 15, 2026, that usage
+uses a separate Agent SDK credit for subscription-authenticated Claude plans,
+or pay-as-you-go API billing when authenticated with `ANTHROPIC_API_KEY`.
+Adjust `--reviewer-agent`, `--summarizer-agent`, `--reviewers`, or
+`--concurrency` if needed.
+
     acr --pr <your-pr-number>
 
 If you don't have access to all three agents (codex, claude, gemini),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,11 @@ contributed code using the repository's `.acr.yaml` configuration
 Note: the repository configuration uses Claude Code for part of the review, but
 we recommend against using Claude with ACR unless you intentionally accept
 Anthropic's non-interactive `claude -p`/Agent SDK billing model. ACR invokes
-Claude in `claude --print` mode for Claude review and summary phases. Starting
-June 15, 2026, subscription-authenticated usage draws from a separate Agent SDK
-credit, while `ANTHROPIC_API_KEY` authentication uses pay-as-you-go API billing.
-Prefer overriding `--reviewer-agent`, `--summarizer-agent`, `--reviewers`, or
+Claude in non-interactive mode (`claude -p`; ACR uses the equivalent `--print`
+flag internally) for Claude review and summary phases. Starting June 15, 2026,
+subscription-authenticated usage draws from a separate Agent SDK credit, while
+`ANTHROPIC_API_KEY` authentication uses pay-as-you-go API billing. Prefer
+overriding `--reviewer-agent`, `--summarizer-agent`, `--reviewers`, or
 `--concurrency` if you want to avoid Claude usage.
 
     acr --pr <your-pr-number>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,14 @@ All PRs must include evidence of a successful ACR run against the
 contributed code using the repository's `.acr.yaml` configuration
 (which uses all three agent types with 6 reviewers):
 
-Note: the repository configuration uses Claude Code for part of the review.
-ACR invokes Claude in non-interactive `claude --print` mode, which Anthropic
-treats like `claude -p`/Agent SDK usage. Starting June 15, 2026, that usage
-uses a separate Agent SDK credit for subscription-authenticated Claude plans,
-or pay-as-you-go API billing when authenticated with `ANTHROPIC_API_KEY`.
-Adjust `--reviewer-agent`, `--summarizer-agent`, `--reviewers`, or
-`--concurrency` if needed.
+Note: the repository configuration uses Claude Code for part of the review, but
+we recommend against using Claude with ACR unless you intentionally accept
+Anthropic's non-interactive `claude -p`/Agent SDK billing model. ACR invokes
+Claude in `claude --print` mode for Claude review and summary phases. Starting
+June 15, 2026, subscription-authenticated usage draws from a separate Agent SDK
+credit, while `ANTHROPIC_API_KEY` authentication uses pay-as-you-go API billing.
+Prefer overriding `--reviewer-agent`, `--summarizer-agent`, `--reviewers`, or
+`--concurrency` if you want to avoid Claude usage.
 
     acr --pr <your-pr-number>
 

--- a/README.md
+++ b/README.md
@@ -32,17 +32,21 @@ You need **at least one** of the following LLM CLIs installed and authenticated:
 | Claude Code | [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code) |
 | Gemini CLI | [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) |
 
-> **Claude Code billing note:** When `claude` is selected, ACR invokes Claude Code
-> in non-interactive `claude --print` mode, equivalent to `claude -p`, for each
+> **Claude Code billing warning:** We recommend against using Claude Code as an
+> ACR agent unless you explicitly accept Anthropic's non-interactive
+> `claude -p`/Agent SDK billing model. When `claude` is selected, ACR invokes
+> Claude Code in `claude --print` mode, equivalent to `claude -p`, for each
 > Claude reviewer and for Claude-powered summarization, false-positive filtering,
-> and PR feedback. Anthropic says that starting June 15, 2026,
+> and PR feedback, so one ACR run can start several non-interactive Claude
+> sessions. Anthropic says that starting June 15, 2026,
 > subscription-authenticated `claude -p` and Agent SDK usage will draw from a
 > separate monthly Agent SDK credit instead of normal interactive Claude Code
 > subscription limits. After that credit is exhausted, usage moves to extra usage
 > at standard API rates only if extra usage is enabled; otherwise requests stop
 > until the credit refreshes. API-key authentication with `ANTHROPIC_API_KEY`
 > continues to use pay-as-you-go API billing and does not receive the Agent SDK
-> credit. See Anthropic's [Agent SDK plan billing](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+> credit. Prefer `codex` or `gemini` for ACR runs if you want to avoid this
+> Claude billing path. See Anthropic's [Agent SDK plan billing](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
 > and [`claude -p` documentation](https://code.claude.com/docs/en/headless).
 
 Optional:
@@ -211,7 +215,7 @@ acr --reviewer-agent claude --reviewer-model opus-4 \
 ```
 
 Different agents may find different issues. When multiple agents are specified (comma-separated), reviewers are assigned to agents in round-robin order. The appropriate CLI must be installed and authenticated for all selected agents.
-If you use `claude`, review the Claude Code billing note above before running high reviewer counts or selecting Claude for multiple phases.
+Avoid selecting `claude` for ACR unless you intentionally want ACR's non-interactive `claude -p` usage under Anthropic's current billing model.
 
 ### Review Guidance
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ You need **at least one** of the following LLM CLIs installed and authenticated:
 > **Claude Code billing warning:** We recommend against using Claude Code as an
 > ACR agent unless you explicitly accept Anthropic's non-interactive
 > `claude -p`/Agent SDK billing model. When `claude` is selected, ACR invokes
-> Claude Code in `claude --print` mode, equivalent to `claude -p`, for each
-> Claude reviewer and for Claude-powered summarization, false-positive filtering,
-> and PR feedback, so one ACR run can start several non-interactive Claude
-> sessions. Anthropic says that starting June 15, 2026,
+> Claude Code in non-interactive mode (`claude -p`; ACR uses the equivalent
+> `--print` flag internally) for each Claude reviewer and for Claude-powered
+> summarization, false-positive filtering, and PR feedback, so one ACR run can
+> start several non-interactive Claude sessions. Anthropic says that starting
+> June 15, 2026,
 > subscription-authenticated `claude -p` and Agent SDK usage will draw from a
 > separate monthly Agent SDK credit instead of normal interactive Claude Code
 > subscription limits. After that credit is exhausted, usage moves to extra usage

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ You need **at least one** of the following LLM CLIs installed and authenticated:
 | Claude Code | [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code) |
 | Gemini CLI | [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) |
 
+> **Claude Code billing note:** When `claude` is selected, ACR invokes Claude Code
+> in non-interactive `claude --print` mode, equivalent to `claude -p`, for each
+> Claude reviewer and for Claude-powered summarization, false-positive filtering,
+> and PR feedback. Anthropic says that starting June 15, 2026,
+> subscription-authenticated `claude -p` and Agent SDK usage will draw from a
+> separate monthly Agent SDK credit instead of normal interactive Claude Code
+> subscription limits. After that credit is exhausted, usage moves to extra usage
+> at standard API rates only if extra usage is enabled; otherwise requests stop
+> until the credit refreshes. API-key authentication with `ANTHROPIC_API_KEY`
+> continues to use pay-as-you-go API billing and does not receive the Agent SDK
+> credit. See Anthropic's [Agent SDK plan billing](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+> and [`claude -p` documentation](https://code.claude.com/docs/en/headless).
+
 Optional:
 
 | Tool | Installation | Purpose |
@@ -198,6 +211,7 @@ acr --reviewer-agent claude --reviewer-model opus-4 \
 ```
 
 Different agents may find different issues. When multiple agents are specified (comma-separated), reviewers are assigned to agents in round-robin order. The appropriate CLI must be installed and authenticated for all selected agents.
+If you use `claude`, review the Claude Code billing note above before running high reviewer counts or selecting Claude for multiple phases.
 
 ### Review Guidance
 


### PR DESCRIPTION
## Summary

- Recommend against using Claude Code as an ACR agent unless users explicitly accept Anthropic's non-interactive `claude -p` / Agent SDK billing model.
- Explain that ACR invokes Claude Code in non-interactive mode via `claude -p`; internally ACR uses the equivalent `--print` flag for Claude reviewers and Claude-powered summarization, false-positive filtering, and PR feedback.
- Document Anthropic's June 15, 2026 Agent SDK credit change for subscription-authenticated `claude -p` usage, plus API-key pay-as-you-go behavior.
- Add contributor and Homebrew caveat guidance for Claude users.
- Include the current `AGENTS.md` workspace guide as requested.

## Validation

- `go test ./cmd/acr ./internal/config`

## Notes

The billing warning is based on Anthropic's official Agent SDK plan billing article and Claude Code `claude -p` documentation.