### PR TITLE
feat: add PR watch mode for iterative re-reviews

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -45,3 +45,10 @@ summarizer_agent: claude
 # pr_feedback:
 #   enabled: true
 #   agent: ""
+
+# Watch mode pacing and bounds (post mode is flag-only)
+# watch:
+#   poll_interval: 1m
+#   settle_time: 10m
+#   max_reviews: 10
+#   max_duration: 24h

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ bin/acr-test
 
 # Local agent caches
 cache/
+/acr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,10 @@ internal/
   summarizer/            # LLM-based finding summarization
     summarizer.go        # Orchestrates agent execution and output parsing
   github/                # GitHub PR operations via gh CLI
-    pr.go                # Post comments, approve PRs, check CI status
+    pr.go                # Post comments, approve PRs, check CI status, poll PR state
+  watch/                 # acr watch loop
+    watch.go             # Poll/trigger/bounds state machine with injected effects
+    clock.go             # Clock abstraction (real + test fakes)
   git/                   # Git operations
     worktree.go          # Temporary worktree management
   terminal/              # Terminal UI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,16 @@ internal/
 
 6. **Terminal Detection**: Colors auto-disabled when stdout is not a TTY.
 
+## Code Comments — Absolute Rule
+
+Code comments of any kind are never acceptable in this codebase — no doc
+comments, no inline comments, no section markers, no exceptions. Adding a
+comment is the number one bug and a major flaw in review. Comments age poorly
+and do not age uniformly with the code, so nothing that can be read in the
+code may ever be documented separately. Maintain only user-facing
+documentation (README, CLI help text, config samples) that makes someone's
+life easier, and only as much of it as is absolutely necessary.
+
 ## Code Patterns
 
 - **Error handling**: Return errors up the call stack. Log at the top level in main.go.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,10 @@ internal/
   summarizer/            # LLM-based finding summarization
     summarizer.go        # Orchestrates agent execution and output parsing
   github/                # GitHub PR operations via gh CLI
-    pr.go                # Post comments, approve PRs, check CI status
+    pr.go                # Post comments, approve PRs, check CI status, poll PR state
+  watch/                 # acr watch loop
+    watch.go             # Poll/trigger/bounds state machine with injected effects
+    clock.go             # Clock abstraction (real + test fakes)
   git/                   # Git operations
     worktree.go          # Temporary worktree management
   terminal/              # Terminal UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,16 @@ internal/
 
 6. **Terminal Detection**: Colors auto-disabled when stdout is not a TTY.
 
+## Code Comments — Absolute Rule
+
+Code comments of any kind are never acceptable in this codebase — no doc
+comments, no inline comments, no section markers, no exceptions. Adding a
+comment is the number one bug and a major flaw in review. Comments age poorly
+and do not age uniformly with the code, so nothing that can be read in the
+code may ever be documented separately. Maintain only user-facing
+documentation (README, CLI help text, config samples) that makes someone's
+life easier, and only as much of it as is absolutely necessary.
+
 ## Code Patterns
 
 - **Error handling**: Return errors up the call stack. Log at the top level in main.go.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,74 @@ ACR will:
 
 This requires an open PR from the fork to the current repository. The `gh` CLI must be authenticated.
 
+### Watch Mode
+
+`acr watch` reviews one PR, posts the result, then keeps watching the PR and
+re-reviews until a terminal LGTM is posted or a safety bound is reached:
+
+```bash
+# Watch the current branch's PR interactively (default)
+acr watch
+
+# Watch a PR unattended, posting every result as a comment review
+acr watch --pr 123 --post-mode comment
+
+# Watch unattended and approve once the review is clean and CI is green
+acr watch --pr 123 --post-mode approve
+
+# Tune the pacing and bounds
+acr watch --pr 123 --post-mode comment \
+    --poll-interval 2m --settle-time 15m --max-reviews 5 --max-duration 8h
+```
+
+A new review cycle starts when:
+
+- **A re-review is requested** from the authenticated `gh` user on the watched
+  PR — this triggers on the next poll, without waiting for the commit quiet
+  period. Requests aimed at other reviewers are ignored.
+- **New commits are pushed** — a changed head starts the `--settle-time` quiet
+  period (default 10m); each additional commit restarts it. The review runs
+  once the head stops moving.
+
+Every cycle fetches the PR head into a fresh temporary worktree, so local
+branch state never goes stale mid-watch.
+
+Post modes control what gets posted:
+
+| Mode | Behavior |
+| --- | --- |
+| `interactive` | Default. Prompts for every submission decision; requires a TTY. Declining to post an LGTM ends the watch cleanly. |
+| `comment` | Unattended. Every result is posted as a comment review only — it can never request changes or approve. An LGTM is posted as an explicit LGTM comment, then the watch exits. |
+| `approve` | Unattended. Findings follow the automated `--yes` rules; an LGTM approves the PR. If CI is not green, the LGTM is posted as a comment and the watch keeps polling CI, approving once it goes green for the same head. New commits invalidate the pending approval. |
+
+`--yes`, `--local`, and `--worktree-branch` are invalid with `acr watch`:
+unattended posting must be an explicit `--post-mode` decision, and the watch
+always posts to the PR it is following.
+
+The watch stops when the terminal LGTM is posted, the PR is closed or merged,
+`--max-reviews` (default 10) or `--max-duration` (default 24h) is reached, or
+the process is interrupted. Reaching a safety bound without an LGTM exits
+non-zero.
+
+Watch pacing can also be set in `.acr.yaml` (flags win over config):
+
+```yaml
+watch:
+  poll_interval: 1m
+  settle_time: 10m
+  max_reviews: 10
+  max_duration: 24h
+```
+
+The post mode is deliberately flag-only.
+
+> **Cost note:** every review cycle spawns the full reviewer fleet plus the
+> summarizer, false-positive filter, and PR feedback phases — roughly eight
+> agent invocations per cycle at the defaults, so the default bounds allow on
+> the order of 80 invocations per watched PR. If Claude Code is one of your
+> agents, see the Claude billing note under Prerequisites before running
+> unattended watches.
+
 ### Agent Selection
 
 ACR supports multiple AI backends for code review:

--- a/README.md
+++ b/README.md
@@ -222,7 +222,11 @@ A new review cycle starts when:
   once the head stops moving.
 
 Every cycle fetches the PR head into a fresh temporary worktree, so local
-branch state never goes stale mid-watch.
+branch state never goes stale mid-watch. Configuration (`.acr.yaml`) is read
+from the checkout the watch is launched from — never from the PR head — so
+run unattended watches from a trusted base-branch checkout. If the PR head
+moves while a review is running, the result is discarded instead of posted,
+and the new head is re-reviewed after the settle period.
 
 Post modes control what gets posted:
 

--- a/cmd/acr/help.go
+++ b/cmd/acr/help.go
@@ -38,6 +38,10 @@ var flagGroups = []flagGroup{
 		flags: []string{"guidance", "guidance-file", "ref-file"},
 	},
 	{
+		title: "Watch",
+		flags: []string{"post-mode", "poll-interval", "settle-time", "max-reviews", "max-duration"},
+	},
+	{
 		title: "Advanced",
 		flags: []string{"fetch", "no-fetch", "no-config"},
 	},

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -48,6 +48,13 @@ var (
 	fpFilterTimeout     time.Duration
 	noPRFeedback        bool
 	prFeedbackAgent     string
+
+	// watch-only flags
+	watchPostMode     string
+	watchPollInterval time.Duration
+	watchSettleTime   time.Duration
+	watchMaxReviews   int
+	watchMaxDuration  time.Duration
 )
 
 func main() {
@@ -73,66 +80,20 @@ Exit codes:
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 
-	// Configuration flags (defaults are resolved via config.Resolve with precedence: flag > env > config > default)
-	rootCmd.Flags().IntVarP(&reviewers, "reviewers", "r", 0,
-		"Number of parallel reviewers (default: 5, env: ACR_REVIEWERS)")
-	rootCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0,
-		"Max concurrent reviewers (default: same as --reviewers, env: ACR_CONCURRENCY)")
-	rootCmd.Flags().StringVarP(&baseRef, "base", "b", "",
-		"Base ref for review command (default: main, env: ACR_BASE_REF)")
-	rootCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0,
-		"Timeout per reviewer (default: 10m, env: ACR_TIMEOUT)")
-	rootCmd.Flags().IntVarP(&retries, "retries", "R", 0,
-		"Retry failed reviewers N times (default: 1, env: ACR_RETRIES)")
-	rootCmd.Flags().BoolVar(&fetch, "fetch", true,
-		"Fetch latest base ref from origin before diff (default: true, env: ACR_FETCH)")
-	rootCmd.Flags().BoolVar(&noFetch, "no-fetch", false,
-		"Disable fetching base ref from origin (use local state)")
-	rootCmd.Flags().StringVar(&guidance, "guidance", "",
-		"Steering context appended to the review prompt (env: ACR_GUIDANCE)")
-	rootCmd.Flags().StringVar(&guidanceFile, "guidance-file", "",
-		"Path to file containing review guidance (env: ACR_GUIDANCE_FILE)")
-	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
-		"Print agent messages as they arrive")
+	registerSharedReviewFlags(rootCmd)
+
+	// One-shot review flags that are invalid with `acr watch`: watch requires an
+	// explicit --post-mode instead of --yes, always posts (no --local), and
+	// re-fetches the moving PR head each cycle (no --worktree-branch).
+	rootCmd.Flags().BoolVarP(&autoYes, "yes", "y", false,
+		"Automatically submit review without prompting")
 	rootCmd.Flags().BoolVarP(&local, "local", "l", false,
 		"Skip posting findings to a PR")
 	rootCmd.Flags().StringVarP(&worktreeBranch, "worktree-branch", "B", "",
 		"Review a branch in a temporary worktree")
-	rootCmd.Flags().StringVar(&prNumber, "pr", "",
-		"Review a PR by number (fetches into temp worktree)")
-
-	rootCmd.Flags().BoolVarP(&autoYes, "yes", "y", false,
-		"Automatically submit review without prompting")
-
-	// Filtering options
-	rootCmd.Flags().StringArrayVar(&excludePatterns, "exclude-pattern", nil,
-		"Exclude findings matching regex pattern (repeatable)")
-	rootCmd.Flags().BoolVar(&noConfig, "no-config", false,
-		"Skip loading .acr.yaml config file")
-	rootCmd.Flags().StringVarP(&agentName, "reviewer-agent", "a", "codex",
-		"Agent(s) for reviews (comma-separated): agy, codex, claude, gemini (env: ACR_REVIEWER_AGENT)")
-	rootCmd.Flags().StringVarP(&summarizerAgentName, "summarizer-agent", "s", "codex",
-		"Agent to use for summarization: agy, codex, claude, gemini (env: ACR_SUMMARIZER_AGENT)")
-	rootCmd.Flags().StringVar(&reviewerModel, "reviewer-model", "",
-		"LLM model for review agents (env: ACR_REVIEWER_MODEL)")
-	rootCmd.Flags().StringVar(&summarizerModel, "summarizer-model", "",
-		"LLM model for summarizer/FP filter agents (env: ACR_SUMMARIZER_MODEL)")
-	rootCmd.Flags().BoolVar(&refFile, "ref-file", false,
-		"Write diff to a temp file instead of embedding in prompt (auto-enabled for large diffs)")
-	rootCmd.Flags().BoolVar(&noFPFilter, "no-fp-filter", false,
-		"Disable false positive filtering (env: ACR_FP_FILTER=false to disable)")
-	rootCmd.Flags().IntVar(&fpThreshold, "fp-threshold", 75,
-		"False positive confidence threshold 1-100 (default: 75, env: ACR_FP_THRESHOLD)")
-	rootCmd.Flags().DurationVar(&summarizerTimeout, "summarizer-timeout", 0,
-		"Timeout for summarizer phase (default: 5m, env: ACR_SUMMARIZER_TIMEOUT)")
-	rootCmd.Flags().DurationVar(&fpFilterTimeout, "fp-filter-timeout", 0,
-		"Timeout for false positive filter phase (default: 5m, env: ACR_FP_FILTER_TIMEOUT)")
-	rootCmd.Flags().BoolVar(&noPRFeedback, "no-pr-feedback", false,
-		"Disable reading PR comments for feedback context (env: ACR_PR_FEEDBACK=false)")
-	rootCmd.Flags().StringVar(&prFeedbackAgent, "pr-feedback-agent", "",
-		"Agent for PR feedback summarization (default: same as --summarizer-agent, env: ACR_PR_FEEDBACK_AGENT)")
 
 	rootCmd.AddCommand(newConfigCmd())
+	rootCmd.AddCommand(newWatchCmd())
 
 	setGroupedUsage(rootCmd)
 
@@ -146,6 +107,64 @@ Exit codes:
 	}
 
 	return 0
+}
+
+// registerSharedReviewFlags registers the review flags shared by the root
+// review command and the watch subcommand. Flags valid only for one-shot
+// reviews (--yes, --local, --worktree-branch) are registered separately on
+// the root command so `acr watch` rejects them with a usage error.
+func registerSharedReviewFlags(cmd *cobra.Command) {
+	// Configuration flags (defaults are resolved via config.Resolve with precedence: flag > env > config > default)
+	cmd.Flags().IntVarP(&reviewers, "reviewers", "r", 0,
+		"Number of parallel reviewers (default: 5, env: ACR_REVIEWERS)")
+	cmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0,
+		"Max concurrent reviewers (default: same as --reviewers, env: ACR_CONCURRENCY)")
+	cmd.Flags().StringVarP(&baseRef, "base", "b", "",
+		"Base ref for review command (default: main, env: ACR_BASE_REF)")
+	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 0,
+		"Timeout per reviewer (default: 10m, env: ACR_TIMEOUT)")
+	cmd.Flags().IntVarP(&retries, "retries", "R", 0,
+		"Retry failed reviewers N times (default: 1, env: ACR_RETRIES)")
+	cmd.Flags().BoolVar(&fetch, "fetch", true,
+		"Fetch latest base ref from origin before diff (default: true, env: ACR_FETCH)")
+	cmd.Flags().BoolVar(&noFetch, "no-fetch", false,
+		"Disable fetching base ref from origin (use local state)")
+	cmd.Flags().StringVar(&guidance, "guidance", "",
+		"Steering context appended to the review prompt (env: ACR_GUIDANCE)")
+	cmd.Flags().StringVar(&guidanceFile, "guidance-file", "",
+		"Path to file containing review guidance (env: ACR_GUIDANCE_FILE)")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
+		"Print agent messages as they arrive")
+	cmd.Flags().StringVar(&prNumber, "pr", "",
+		"Review a PR by number (fetches into temp worktree)")
+
+	// Filtering options
+	cmd.Flags().StringArrayVar(&excludePatterns, "exclude-pattern", nil,
+		"Exclude findings matching regex pattern (repeatable)")
+	cmd.Flags().BoolVar(&noConfig, "no-config", false,
+		"Skip loading .acr.yaml config file")
+	cmd.Flags().StringVarP(&agentName, "reviewer-agent", "a", "codex",
+		"Agent(s) for reviews (comma-separated): agy, codex, claude, gemini (env: ACR_REVIEWER_AGENT)")
+	cmd.Flags().StringVarP(&summarizerAgentName, "summarizer-agent", "s", "codex",
+		"Agent to use for summarization: agy, codex, claude, gemini (env: ACR_SUMMARIZER_AGENT)")
+	cmd.Flags().StringVar(&reviewerModel, "reviewer-model", "",
+		"LLM model for review agents (env: ACR_REVIEWER_MODEL)")
+	cmd.Flags().StringVar(&summarizerModel, "summarizer-model", "",
+		"LLM model for summarizer/FP filter agents (env: ACR_SUMMARIZER_MODEL)")
+	cmd.Flags().BoolVar(&refFile, "ref-file", false,
+		"Write diff to a temp file instead of embedding in prompt (auto-enabled for large diffs)")
+	cmd.Flags().BoolVar(&noFPFilter, "no-fp-filter", false,
+		"Disable false positive filtering (env: ACR_FP_FILTER=false to disable)")
+	cmd.Flags().IntVar(&fpThreshold, "fp-threshold", 75,
+		"False positive confidence threshold 1-100 (default: 75, env: ACR_FP_THRESHOLD)")
+	cmd.Flags().DurationVar(&summarizerTimeout, "summarizer-timeout", 0,
+		"Timeout for summarizer phase (default: 5m, env: ACR_SUMMARIZER_TIMEOUT)")
+	cmd.Flags().DurationVar(&fpFilterTimeout, "fp-filter-timeout", 0,
+		"Timeout for false positive filter phase (default: 5m, env: ACR_FP_FILTER_TIMEOUT)")
+	cmd.Flags().BoolVar(&noPRFeedback, "no-pr-feedback", false,
+		"Disable reading PR comments for feedback context (env: ACR_PR_FEEDBACK=false)")
+	cmd.Flags().StringVar(&prFeedbackAgent, "pr-feedback-agent", "",
+		"Agent for PR feedback summarization (default: same as --summarizer-agent, env: ACR_PR_FEEDBACK_AGENT)")
 }
 
 // worktreeResult holds the outputs from worktree setup.
@@ -360,6 +379,12 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		FPThresholdSet:       cmd.Flags().Changed("fp-threshold"),
 		NoPRFeedbackSet:      cmd.Flags().Changed("no-pr-feedback"),
 		PRFeedbackAgentSet:   cmd.Flags().Changed("pr-feedback-agent"),
+		// Watch flags exist only on the watch subcommand; Changed() on an
+		// unregistered flag is false, so this is safe for the root command.
+		WatchPollIntervalSet: cmd.Flags().Changed("poll-interval"),
+		WatchSettleTimeSet:   cmd.Flags().Changed("settle-time"),
+		WatchMaxReviewsSet:   cmd.Flags().Changed("max-reviews"),
+		WatchMaxDurationSet:  cmd.Flags().Changed("max-duration"),
 	}
 
 	// Load env var state
@@ -398,6 +423,10 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		FPThreshold:       fpThreshold,
 		PRFeedbackEnabled: !noPRFeedback,
 		PRFeedbackAgent:   prFeedbackAgent,
+		WatchPollInterval: watchPollInterval,
+		WatchSettleTime:   watchSettleTime,
+		WatchMaxReviews:   watchMaxReviews,
+		WatchMaxDuration:  watchMaxDuration,
 	}
 
 	// Resolve final configuration (precedence: flags > env vars > config file > defaults)

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -49,7 +49,6 @@ var (
 	noPRFeedback        bool
 	prFeedbackAgent     string
 
-	// watch-only flags
 	watchPostMode     string
 	watchPollInterval time.Duration
 	watchSettleTime   time.Duration
@@ -82,9 +81,6 @@ Exit codes:
 
 	registerSharedReviewFlags(rootCmd)
 
-	// One-shot review flags that are invalid with `acr watch`: watch requires an
-	// explicit --post-mode instead of --yes, always posts (no --local), and
-	// re-fetches the moving PR head each cycle (no --worktree-branch).
 	rootCmd.Flags().BoolVarP(&autoYes, "yes", "y", false,
 		"Automatically submit review without prompting")
 	rootCmd.Flags().BoolVarP(&local, "local", "l", false,
@@ -98,7 +94,6 @@ Exit codes:
 	setGroupedUsage(rootCmd)
 
 	if err := rootCmd.Execute(); err != nil {
-		// Check if this is an exit code wrapper (not a real error)
 		if exitErr, ok := err.(exitCodeError); ok {
 			return exitErr.code.Int()
 		}
@@ -109,12 +104,7 @@ Exit codes:
 	return 0
 }
 
-// registerSharedReviewFlags registers the review flags shared by the root
-// review command and the watch subcommand. Flags valid only for one-shot
-// reviews (--yes, --local, --worktree-branch) are registered separately on
-// the root command so `acr watch` rejects them with a usage error.
 func registerSharedReviewFlags(cmd *cobra.Command) {
-	// Configuration flags (defaults are resolved via config.Resolve with precedence: flag > env > config > default)
 	cmd.Flags().IntVarP(&reviewers, "reviewers", "r", 0,
 		"Number of parallel reviewers (default: 5, env: ACR_REVIEWERS)")
 	cmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0,
@@ -138,7 +128,6 @@ func registerSharedReviewFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&prNumber, "pr", "",
 		"Review a PR by number (fetches into temp worktree)")
 
-	// Filtering options
 	cmd.Flags().StringArrayVar(&excludePatterns, "exclude-pattern", nil,
 		"Exclude findings matching regex pattern (repeatable)")
 	cmd.Flags().BoolVar(&noConfig, "no-config", false,
@@ -379,8 +368,6 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		FPThresholdSet:       cmd.Flags().Changed("fp-threshold"),
 		NoPRFeedbackSet:      cmd.Flags().Changed("no-pr-feedback"),
 		PRFeedbackAgentSet:   cmd.Flags().Changed("pr-feedback-agent"),
-		// Watch flags exist only on the watch subcommand; Changed() on an
-		// unregistered flag is false, so this is safe for the root command.
 		WatchPollIntervalSet: cmd.Flags().Changed("poll-interval"),
 		WatchSettleTimeSet:   cmd.Flags().Changed("settle-time"),
 		WatchMaxReviewsSet:   cmd.Flags().Changed("max-reviews"),

--- a/cmd/acr/outcome.go
+++ b/cmd/acr/outcome.go
@@ -1,0 +1,42 @@
+package main
+
+// OutcomeKind classifies what a review cycle produced and what was posted.
+// Watch mode uses it to decide whether a cycle was terminal; one-shot review
+// runs leave ReviewOpts.Outcome nil and never record.
+type OutcomeKind int
+
+const (
+	// OutcomeNone means nothing was recorded (cycle errored before a result).
+	OutcomeNone OutcomeKind = iota
+	// OutcomeNoChanges means the diff was empty; nothing was reviewed.
+	OutcomeNoChanges
+	// OutcomeFindings means the review produced findings (posted or handled
+	// interactively, including a user skip).
+	OutcomeFindings
+	// OutcomeLGTMApproved means an LGTM was posted as an approval.
+	OutcomeLGTMApproved
+	// OutcomeLGTMComment means an LGTM was posted as a comment review.
+	OutcomeLGTMComment
+	// OutcomeLGTMDeclined means the user chose not to post an LGTM result.
+	OutcomeLGTMDeclined
+	// OutcomeLGTMSkipped means an LGTM result could not be posted (e.g. no PR).
+	OutcomeLGTMSkipped
+)
+
+// CycleOutcome records what a single review cycle did, for the watch loop.
+type CycleOutcome struct {
+	Kind OutcomeKind
+	// LGTMBody is the rendered LGTM review body, kept so watch mode can post
+	// the approval later once CI goes green.
+	LGTMBody string
+	// CIDowngraded is set when an intended approval was posted as a comment
+	// because CI was not green.
+	CIDowngraded bool
+}
+
+// record stores kind into the outcome sink, if one is attached.
+func (o ReviewOpts) record(kind OutcomeKind) {
+	if o.Outcome != nil {
+		o.Outcome.Kind = kind
+	}
+}

--- a/cmd/acr/outcome.go
+++ b/cmd/acr/outcome.go
@@ -1,43 +1,24 @@
 package main
 
-// OutcomeKind classifies what a review cycle produced and what was posted.
-// Watch mode uses it to decide whether a cycle was terminal; one-shot review
-// runs leave ReviewOpts.Outcome nil and never record.
 type OutcomeKind int
 
 const (
-	// OutcomeNone means nothing was recorded (cycle errored before a result).
 	OutcomeNone OutcomeKind = iota
-	// OutcomeNoChanges means the diff was empty; nothing was reviewed.
 	OutcomeNoChanges
-	// OutcomeFindings means the review produced findings (posted or handled
-	// interactively, including a user skip).
 	OutcomeFindings
-	// OutcomeLGTMApproved means an LGTM was posted as an approval.
 	OutcomeLGTMApproved
-	// OutcomeLGTMComment means an LGTM was posted as a comment review.
 	OutcomeLGTMComment
-	// OutcomeLGTMDeclined means the user chose not to post an LGTM result.
 	OutcomeLGTMDeclined
-	// OutcomeLGTMSkipped means an LGTM result could not be posted (e.g. no PR).
 	OutcomeLGTMSkipped
-	// OutcomeStaleHead means nothing was posted because the PR head moved
-	// while the review ran; the result no longer describes the PR.
 	OutcomeStaleHead
 )
 
-// CycleOutcome records what a single review cycle did, for the watch loop.
 type CycleOutcome struct {
-	Kind OutcomeKind
-	// LGTMBody is the rendered LGTM review body, kept so watch mode can post
-	// the approval later once CI goes green.
-	LGTMBody string
-	// CIDowngraded is set when an intended approval was posted as a comment
-	// because CI was not green.
+	Kind         OutcomeKind
+	LGTMBody     string
 	CIDowngraded bool
 }
 
-// record stores kind into the outcome sink, if one is attached.
 func (o ReviewOpts) record(kind OutcomeKind) {
 	if o.Outcome != nil {
 		o.Outcome.Kind = kind

--- a/cmd/acr/outcome.go
+++ b/cmd/acr/outcome.go
@@ -21,6 +21,9 @@ const (
 	OutcomeLGTMDeclined
 	// OutcomeLGTMSkipped means an LGTM result could not be posted (e.g. no PR).
 	OutcomeLGTMSkipped
+	// OutcomeStaleHead means nothing was posted because the PR head moved
+	// while the review ran; the result no longer describes the PR.
+	OutcomeStaleHead
 )
 
 // CycleOutcome records what a single review cycle did, for the watch loop.

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -271,6 +271,11 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 		}
 	}
 
+	if headMovedSinceReview(ctx, opts, pr.number, logger) {
+		opts.record(OutcomeStaleHead)
+		return nil
+	}
+
 	if err := github.SubmitPRReview(ctx, pr.number, body, requestChanges); err != nil {
 		logger.Logf(terminal.StyleError, "Failed: %v", err)
 		return err
@@ -353,6 +358,11 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		}
 	}
 
+	if headMovedSinceReview(ctx, opts, pr.number, logger) {
+		opts.record(OutcomeStaleHead)
+		return nil
+	}
+
 	if err := executeLGTMAction(ctx, action, pr.number, body, logger); err != nil {
 		return err
 	}
@@ -398,6 +408,25 @@ func promptLGTMAction(pr prContext) lgtmAction {
 	}
 }
 
+// headMovedSinceReview reports whether the PR head no longer matches the
+// commit the review ran against (watch mode only; no-op when ExpectedHeadSHA
+// is unset). A failed state fetch resolves to false so a transient gh error
+// cannot block a submission.
+func headMovedSinceReview(ctx context.Context, opts ReviewOpts, prNumber string, logger *terminal.Logger) bool {
+	if opts.ExpectedHeadSHA == "" {
+		return false
+	}
+	st, err := github.GetPRWatchState(ctx, prNumber)
+	if err != nil || st.HeadSHA == "" {
+		return false
+	}
+	if strings.EqualFold(st.HeadSHA, opts.ExpectedHeadSHA) {
+		return false
+	}
+	logger.Logf(terminal.StyleWarning, "PR head moved since the review; skipping post (the new head will be re-reviewed).")
+	return true
+}
+
 // logCIChecks logs a list of CI checks with truncation.
 func logCIChecks(logger *terminal.Logger, checks []string) {
 	for i, check := range checks {
@@ -415,6 +444,15 @@ func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmActi
 	ciStatus := github.CheckCIStatus(ctx, prNum)
 
 	if ciStatus.Error != "" {
+		// Watch mode: a transient CI-status failure must not abort the watch
+		// at its most expensive moment (a clean review in hand). Post the
+		// comment downgrade and let the watch loop's CI wait retry the
+		// approval. One-shot --yes behavior is unchanged.
+		if opts.Outcome != nil && opts.AutoYes {
+			logger.Logf(terminal.StyleWarning, "Failed to check CI status (%s); posting as comment and deferring approval.", ciStatus.Error)
+			opts.Outcome.CIDowngraded = true
+			return actionComment, nil
+		}
 		logger.Logf(terminal.StyleError, "Failed to check CI status: %s", ciStatus.Error)
 		return actionSkip, fmt.Errorf("CI check failed: %s", ciStatus.Error)
 	}

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -274,7 +274,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 		return nil
 	}
 
-	if err := retrySubmission(func() error {
+	if err := retrySubmission(ctx, func() error {
 		return github.SubmitPRReview(ctx, pr.number, body, requestChanges)
 	}, opts.Outcome != nil, logger); err != nil {
 		logger.Logf(terminal.StyleError, "Failed: %v", err)
@@ -361,7 +361,7 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		return nil
 	}
 
-	if err := retrySubmission(func() error {
+	if err := retrySubmission(ctx, func() error {
 		return executeLGTMAction(ctx, action, pr.number, body, logger)
 	}, opts.Outcome != nil, logger); err != nil {
 		return err
@@ -412,14 +412,23 @@ var submissionRetryDelay = 5 * time.Second
 
 const submissionAttempts = 3
 
-func retrySubmission(submit func() error, watchMode bool, logger *terminal.Logger) error {
+func retrySubmission(ctx context.Context, submit func() error, watchMode bool, logger *terminal.Logger) error {
 	err := submit()
 	if err == nil || !watchMode {
 		return err
 	}
 	for attempt := 2; attempt <= submissionAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return err
+		}
 		logger.Logf(terminal.StyleWarning, "Submission failed (%v); retrying (%d/%d)", err, attempt, submissionAttempts)
-		time.Sleep(submissionRetryDelay)
+		timer := time.NewTimer(submissionRetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return err
+		case <-timer.C:
+		}
 		if err = submit(); err == nil {
 			return nil
 		}
@@ -459,13 +468,27 @@ func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmActi
 	ciStatus := github.CheckCIStatus(ctx, prNum)
 
 	if ciStatus.Error != "" {
-		if opts.Outcome != nil && opts.AutoYes {
+		if opts.Outcome == nil {
+			logger.Logf(terminal.StyleError, "Failed to check CI status: %s", ciStatus.Error)
+			return actionSkip, fmt.Errorf("CI check failed: %s", ciStatus.Error)
+		}
+		if opts.AutoYes {
 			logger.Logf(terminal.StyleWarning, "Failed to check CI status (%s); posting as comment and deferring approval.", ciStatus.Error)
 			opts.Outcome.CIDowngraded = true
 			return actionComment, nil
 		}
-		logger.Logf(terminal.StyleError, "Failed to check CI status: %s", ciStatus.Error)
-		return actionSkip, fmt.Errorf("CI check failed: %s", ciStatus.Error)
+		logger.Logf(terminal.StyleWarning, "Failed to check CI status (%s).", ciStatus.Error)
+		if !terminal.IsStdinTTY() {
+			return actionSkip, nil
+		}
+		fmt.Print(formatPrompt("Post as comment instead?", "[C]omment (default) / [S]kip:"))
+		switch readUserInput() {
+		case "", "c", "y", "yes":
+			return actionComment, nil
+		default:
+			logger.Log("Skipped posting LGTM.", terminal.StyleDim)
+			return actionSkip, nil
+		}
 	}
 
 	if ciStatus.AllPassed {

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/github"
@@ -276,7 +277,9 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 		return nil
 	}
 
-	if err := github.SubmitPRReview(ctx, pr.number, body, requestChanges); err != nil {
+	if err := retrySubmission(func() error {
+		return github.SubmitPRReview(ctx, pr.number, body, requestChanges)
+	}, opts.Outcome != nil, logger); err != nil {
 		logger.Logf(terminal.StyleError, "Failed: %v", err)
 		return err
 	}
@@ -363,7 +366,9 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		return nil
 	}
 
-	if err := executeLGTMAction(ctx, action, pr.number, body, logger); err != nil {
+	if err := retrySubmission(func() error {
+		return executeLGTMAction(ctx, action, pr.number, body, logger)
+	}, opts.Outcome != nil, logger); err != nil {
 		return err
 	}
 	if action == actionApprove {
@@ -406,6 +411,31 @@ func promptLGTMAction(pr prContext) lgtmAction {
 	default:
 		return actionApprove
 	}
+}
+
+// submissionRetryDelay is a variable so tests can zero it.
+var submissionRetryDelay = 5 * time.Second
+
+const submissionAttempts = 3
+
+// retrySubmission runs submit, retrying transient failures in watch mode.
+// One-shot runs (watchMode=false) return the first error unchanged. A retry
+// can double-post if gh errored after the review actually landed; a
+// duplicate comment or approval is benign next to discarding a finished
+// watch cycle.
+func retrySubmission(submit func() error, watchMode bool, logger *terminal.Logger) error {
+	err := submit()
+	if err == nil || !watchMode {
+		return err
+	}
+	for attempt := 2; attempt <= submissionAttempts; attempt++ {
+		logger.Logf(terminal.StyleWarning, "Submission failed (%v); retrying (%d/%d)", err, attempt, submissionAttempts)
+		time.Sleep(submissionRetryDelay)
+		if err = submit(); err == nil {
+			return nil
+		}
+	}
+	return err
 }
 
 // headMovedSinceReview reports whether the PR head no longer matches the

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -159,6 +159,10 @@ func handleLGTM(ctx context.Context, opts ReviewOpts, allFindings []domain.Findi
 }
 
 func handleFindings(ctx context.Context, opts ReviewOpts, grouped domain.GroupedFindings, aggregated []domain.AggregatedFinding, stats domain.ReviewStats, logger *terminal.Logger) domain.ExitCode {
+	// May be overwritten by the LGTM records below when the user dismisses
+	// every finding.
+	opts.record(OutcomeFindings)
+
 	selectedFindings := grouped.Findings
 
 	// Interactive selection when in TTY and not auto-submitting (skip in local mode)
@@ -215,8 +219,8 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 		return nil
 	}
 
-	// Determine review type (self-review can only comment)
-	requestChanges := !pr.isSelfReview
+	// Determine review type (self-review and forced-comment policy can only comment)
+	requestChanges := !pr.isSelfReview && !opts.ForcePostComment
 
 	if !opts.AutoYes {
 		// Check if stdin is a TTY before prompting to avoid hanging in CI
@@ -295,28 +299,37 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		return nil
 	}
 
+	if opts.Outcome != nil {
+		// Keep the rendered body so watch mode can post the approval later
+		// once CI goes green.
+		opts.Outcome.LGTMBody = body
+	}
+
 	available, err := checkPRAvailable(pr, opts, logger)
 	if err != nil {
 		return err
 	}
 	if !available {
+		opts.record(OutcomeLGTMSkipped)
 		return nil
 	}
 
 	action := actionApprove
-	if pr.isSelfReview {
+	if pr.isSelfReview || opts.ForcePostComment {
 		action = actionComment
 	}
 
 	if !opts.AutoYes {
 		if !terminal.IsStdinTTY() {
 			logger.Log("Non-interactive mode without --yes flag; skipping LGTM.", terminal.StyleDim)
+			opts.record(OutcomeLGTMSkipped)
 			return nil
 		}
 
 		action = promptLGTMAction(pr)
 		if action == actionSkip {
 			logger.Log("Skipped posting LGTM.", terminal.StyleDim)
+			opts.record(OutcomeLGTMDeclined)
 			return nil
 		}
 	}
@@ -329,6 +342,7 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 			return err
 		}
 		if action == actionSkip {
+			opts.record(OutcomeLGTMDeclined)
 			return nil
 		}
 	}
@@ -339,7 +353,15 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		}
 	}
 
-	return executeLGTMAction(ctx, action, pr.number, body, logger)
+	if err := executeLGTMAction(ctx, action, pr.number, body, logger); err != nil {
+		return err
+	}
+	if action == actionApprove {
+		opts.record(OutcomeLGTMApproved)
+	} else {
+		opts.record(OutcomeLGTMComment)
+	}
+	return nil
 }
 
 // promptLGTMAction prompts the user for LGTM action choice.
@@ -412,6 +434,9 @@ func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmActi
 
 	if opts.AutoYes {
 		logger.Log("CI not green; posting as comment instead of approval.", terminal.StyleDim)
+		if opts.Outcome != nil {
+			opts.Outcome.CIDowngraded = true
+		}
 		return actionComment, nil
 	}
 

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -160,8 +160,6 @@ func handleLGTM(ctx context.Context, opts ReviewOpts, allFindings []domain.Findi
 }
 
 func handleFindings(ctx context.Context, opts ReviewOpts, grouped domain.GroupedFindings, aggregated []domain.AggregatedFinding, stats domain.ReviewStats, logger *terminal.Logger) domain.ExitCode {
-	// May be overwritten by the LGTM records below when the user dismisses
-	// every finding.
 	opts.record(OutcomeFindings)
 
 	selectedFindings := grouped.Findings
@@ -220,7 +218,6 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 		return nil
 	}
 
-	// Determine review type (self-review and forced-comment policy can only comment)
 	requestChanges := !pr.isSelfReview && !opts.ForcePostComment
 
 	if !opts.AutoYes {
@@ -308,8 +305,6 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 	}
 
 	if opts.Outcome != nil {
-		// Keep the rendered body so watch mode can post the approval later
-		// once CI goes green.
 		opts.Outcome.LGTMBody = body
 	}
 
@@ -413,16 +408,10 @@ func promptLGTMAction(pr prContext) lgtmAction {
 	}
 }
 
-// submissionRetryDelay is a variable so tests can zero it.
 var submissionRetryDelay = 5 * time.Second
 
 const submissionAttempts = 3
 
-// retrySubmission runs submit, retrying transient failures in watch mode.
-// One-shot runs (watchMode=false) return the first error unchanged. A retry
-// can double-post if gh errored after the review actually landed; a
-// duplicate comment or approval is benign next to discarding a finished
-// watch cycle.
 func retrySubmission(submit func() error, watchMode bool, logger *terminal.Logger) error {
 	err := submit()
 	if err == nil || !watchMode {
@@ -438,10 +427,6 @@ func retrySubmission(submit func() error, watchMode bool, logger *terminal.Logge
 	return err
 }
 
-// headMovedSinceReview reports whether the PR head no longer matches the
-// commit the review ran against (watch mode only; no-op when ExpectedHeadSHA
-// is unset). A failed state fetch resolves to false so a transient gh error
-// cannot block a submission.
 func headMovedSinceReview(ctx context.Context, opts ReviewOpts, prNumber string, logger *terminal.Logger) bool {
 	if opts.ExpectedHeadSHA == "" {
 		return false
@@ -474,10 +459,6 @@ func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmActi
 	ciStatus := github.CheckCIStatus(ctx, prNum)
 
 	if ciStatus.Error != "" {
-		// Watch mode: a transient CI-status failure must not abort the watch
-		// at its most expensive moment (a clean review in hand). Post the
-		// comment downgrade and let the watch loop's CI wait retry the
-		// approval. One-shot --yes behavior is unchanged.
 		if opts.Outcome != nil && opts.AutoYes {
 			logger.Logf(terminal.StyleWarning, "Failed to check CI status (%s); posting as comment and deferring approval.", ciStatus.Error)
 			opts.Outcome.CIDowngraded = true

--- a/cmd/acr/pr_submit_test.go
+++ b/cmd/acr/pr_submit_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
+
+var errTransient = errors.New("transient gh failure")
 
 func TestPrContext_Defaults(t *testing.T) {
 	pc := prContext{}
@@ -63,5 +67,39 @@ func TestLgtmAction_Constants(t *testing.T) {
 	}
 	if actionComment == actionSkip {
 		t.Error("actionComment should not equal actionSkip")
+	}
+}
+
+func TestRetrySubmission(t *testing.T) {
+	oldDelay := submissionRetryDelay
+	submissionRetryDelay = 0
+	defer func() { submissionRetryDelay = oldDelay }()
+	logger := terminal.NewLogger()
+
+	// Watch mode: transient failures are retried until success.
+	calls := 0
+	err := retrySubmission(func() error {
+		calls++
+		if calls < 3 {
+			return errTransient
+		}
+		return nil
+	}, true, logger)
+	if err != nil || calls != 3 {
+		t.Errorf("watch mode: err = %v, calls = %d; want success on attempt 3", err, calls)
+	}
+
+	// Watch mode: persistent failure surfaces after the attempt budget.
+	calls = 0
+	err = retrySubmission(func() error { calls++; return errTransient }, true, logger)
+	if err == nil || calls != submissionAttempts {
+		t.Errorf("watch mode persistent: err = %v, calls = %d; want error after %d attempts", err, calls, submissionAttempts)
+	}
+
+	// One-shot mode: the first error returns unchanged, no retries.
+	calls = 0
+	err = retrySubmission(func() error { calls++; return errTransient }, false, logger)
+	if err == nil || calls != 1 {
+		t.Errorf("one-shot: err = %v, calls = %d; want single attempt", err, calls)
 	}
 }

--- a/cmd/acr/pr_submit_test.go
+++ b/cmd/acr/pr_submit_test.go
@@ -76,7 +76,6 @@ func TestRetrySubmission(t *testing.T) {
 	defer func() { submissionRetryDelay = oldDelay }()
 	logger := terminal.NewLogger()
 
-	// Watch mode: transient failures are retried until success.
 	calls := 0
 	err := retrySubmission(func() error {
 		calls++
@@ -89,14 +88,12 @@ func TestRetrySubmission(t *testing.T) {
 		t.Errorf("watch mode: err = %v, calls = %d; want success on attempt 3", err, calls)
 	}
 
-	// Watch mode: persistent failure surfaces after the attempt budget.
 	calls = 0
 	err = retrySubmission(func() error { calls++; return errTransient }, true, logger)
 	if err == nil || calls != submissionAttempts {
 		t.Errorf("watch mode persistent: err = %v, calls = %d; want error after %d attempts", err, calls, submissionAttempts)
 	}
 
-	// One-shot mode: the first error returns unchanged, no retries.
 	calls = 0
 	err = retrySubmission(func() error { calls++; return errTransient }, false, logger)
 	if err == nil || calls != 1 {

--- a/cmd/acr/pr_submit_test.go
+++ b/cmd/acr/pr_submit_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -77,7 +78,7 @@ func TestRetrySubmission(t *testing.T) {
 	logger := terminal.NewLogger()
 
 	calls := 0
-	err := retrySubmission(func() error {
+	err := retrySubmission(context.Background(), func() error {
 		calls++
 		if calls < 3 {
 			return errTransient
@@ -89,14 +90,30 @@ func TestRetrySubmission(t *testing.T) {
 	}
 
 	calls = 0
-	err = retrySubmission(func() error { calls++; return errTransient }, true, logger)
+	err = retrySubmission(context.Background(), func() error { calls++; return errTransient }, true, logger)
 	if err == nil || calls != submissionAttempts {
 		t.Errorf("watch mode persistent: err = %v, calls = %d; want error after %d attempts", err, calls, submissionAttempts)
 	}
 
 	calls = 0
-	err = retrySubmission(func() error { calls++; return errTransient }, false, logger)
+	err = retrySubmission(context.Background(), func() error { calls++; return errTransient }, false, logger)
 	if err == nil || calls != 1 {
 		t.Errorf("one-shot: err = %v, calls = %d; want single attempt", err, calls)
+	}
+}
+
+func TestRetrySubmissionStopsOnCanceledContext(t *testing.T) {
+	oldDelay := submissionRetryDelay
+	submissionRetryDelay = 0
+	defer func() { submissionRetryDelay = oldDelay }()
+	logger := terminal.NewLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	err := retrySubmission(ctx, func() error { calls++; return errTransient }, true, logger)
+	if err == nil || calls != 1 {
+		t.Errorf("err = %v, calls = %d; want the first error with no retries after cancellation", err, calls)
 	}
 }

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -102,6 +102,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	// Short-circuit: no changes means nothing to review
 	if diff == "" {
 		logger.Logf(terminal.StyleSuccess, "No changes detected between HEAD and %s. Nothing to review.", resolvedBaseRef)
+		opts.record(OutcomeNoChanges)
 		return domain.ExitNoFindings
 	}
 

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -25,6 +25,9 @@ type ReviewOpts struct {
 	// Watch-mode policy: post every result as a comment review only, never
 	// request changes or approve (and never run the pre-approval CI check).
 	ForcePostComment bool
+	// ExpectedHeadSHA, when set, makes submission verify the PR head still
+	// matches the commit that was reviewed and skip posting if it moved.
+	ExpectedHeadSHA string
 	// Outcome, when non-nil, receives a record of what the cycle posted.
 	Outcome *CycleOutcome
 }

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -21,4 +21,10 @@ type ReviewOpts struct {
 	UseRefFile      bool
 	ExcludePatterns []string
 	WorkDir         string // Worktree path (empty = current directory)
+
+	// Watch-mode policy: post every result as a comment review only, never
+	// request changes or approve (and never run the pre-approval CI check).
+	ForcePostComment bool
+	// Outcome, when non-nil, receives a record of what the cycle posted.
+	Outcome *CycleOutcome
 }

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -22,12 +22,7 @@ type ReviewOpts struct {
 	ExcludePatterns []string
 	WorkDir         string // Worktree path (empty = current directory)
 
-	// Watch-mode policy: post every result as a comment review only, never
-	// request changes or approve (and never run the pre-approval CI check).
 	ForcePostComment bool
-	// ExpectedHeadSHA, when set, makes submission verify the PR head still
-	// matches the commit that was reviewed and skip posting if it moved.
-	ExpectedHeadSHA string
-	// Outcome, when non-nil, receives a record of what the cycle posted.
-	Outcome *CycleOutcome
+	ExpectedHeadSHA  string
+	Outcome          *CycleOutcome
 }

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -103,8 +104,15 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	watchPR := prNumber
 	if watchPR == "" {
 		detected, err := github.GetCurrentPRNumber(ctx, "")
-		if err != nil || detected == "" {
+		switch {
+		case errors.Is(err, github.ErrAuthFailed):
+			logger.Log("GitHub authentication failed. Run 'gh auth login' to authenticate.", terminal.StyleError)
+			return exitCode(domain.ExitError)
+		case errors.Is(err, github.ErrNoPRFound), err == nil && detected == "":
 			logger.Log("No open PR found for the current branch; use --pr to select one.", terminal.StyleError)
+			return exitCode(domain.ExitError)
+		case err != nil:
+			logger.Logf(terminal.StyleError, "Failed to detect PR for current branch: %v", err)
 			return exitCode(domain.ExitError)
 		}
 		watchPR = detected

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -231,6 +231,7 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		ExcludePatterns:  cfgResult.excludePatterns,
 		WorkDir:          wt.workDir,
 		ForcePostComment: mode == watch.PostModeComment,
+		ExpectedHeadSHA:  reviewedHead,
 		Outcome:          outcome,
 	}
 
@@ -264,6 +265,8 @@ func mapCycleOutcome(o *CycleOutcome) watch.CycleResult {
 		return watch.CycleLGTMDeclined
 	case OutcomeLGTMSkipped:
 		return watch.CycleLGTMSkipped
+	case OutcomeStaleHead:
+		return watch.CycleStaleHead
 	default:
 		return watch.CycleError
 	}

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -200,7 +200,10 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 
 	reviewedHead := ""
 	if wt.workDir != "" {
-		if sha, err := git.GetHeadSHA(wt.workDir); err == nil {
+		sha, err := git.GetHeadSHA(wt.workDir)
+		if err != nil {
+			logger.Logf(terminal.StyleWarning, "Could not resolve the worktree head (%v); the stale-head posting guard is disabled for this cycle.", err)
+		} else {
 			reviewedHead = sha
 		}
 	}

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -45,7 +45,6 @@ Exit codes:
 
 	registerSharedReviewFlags(cmd)
 
-	// Watch pacing defaults are resolved via config.Resolve (flag > config > default).
 	cmd.Flags().StringVar(&watchPostMode, "post-mode", "interactive",
 		"How results are posted: interactive, comment, or approve")
 	cmd.Flags().DurationVar(&watchPollInterval, "poll-interval", 0,
@@ -83,7 +82,6 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		return exitCode(domain.ExitError)
 	}
 
-	// Prune stale ACR worktrees from previous runs (only review-* dirs older than 2h)
 	if err := git.PruneStaleWorktrees(); err != nil && verbose {
 		logger.Logf(terminal.StyleDim, "Worktree prune: %v", err)
 	}
@@ -100,7 +98,6 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		cancel()
 	}()
 
-	// Resolve the watched PR: explicit --pr, or the current branch's PR.
 	watchPR := prNumber
 	if watchPR == "" {
 		detected, err := github.GetCurrentPRNumber(ctx, "")
@@ -123,11 +120,8 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		return exitCode(domain.ExitError)
 	}
 
-	// Every cycle reviews the PR in a fresh worktree fetched from its current
-	// head, so local branch state never goes stale mid-watch.
 	prNumber = watchPR
 
-	// Resolve watch pacing once at startup from the repo-root config + flags.
 	cfgResult, err := loadAndResolveConfig(cmd, worktreeResult{}, logger)
 	if err != nil {
 		return err
@@ -140,7 +134,6 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		MaxDuration:  cfgResult.resolved.WatchMaxDuration,
 	}
 
-	// Re-review requests only trigger for the authenticated gh user.
 	currentUser := github.GetCurrentUser(ctx)
 	if currentUser == "" {
 		logger.Log("Could not determine the authenticated gh user; re-review request triggers are disabled.", terminal.StyleWarning)
@@ -191,14 +184,11 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		return exitCode(domain.ExitInterrupted)
 	case watch.ReasonError:
 		return exitCode(domain.ExitError)
-	default: // ReasonClosed, ReasonMaxReviews, ReasonMaxDuration
+	default:
 		return exitCode(domain.ExitFindings)
 	}
 }
 
-// runWatchCycle runs one full review cycle: fresh worktree at the PR's
-// current head, config resolution from that worktree, review, and posting
-// per the watch post mode.
 func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode watch.PostMode, logger *terminal.Logger) (watch.Cycle, error) {
 	wt, err := setupWorktree(ctx, cmd, logger)
 	if err != nil {
@@ -208,8 +198,6 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		defer wt.cleanup()
 	}
 
-	// Record the head the cycle actually reviews; commits can land between
-	// the watch loop's poll and the worktree fetch.
 	reviewedHead := ""
 	if wt.workDir != "" {
 		if sha, err := git.GetHeadSHA(wt.workDir); err == nil {
@@ -217,10 +205,6 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		}
 	}
 
-	// Load config from the base repo, never from the PR-head worktree: the
-	// worktree's .acr.yaml is PR-author-controlled, and in unattended modes
-	// honoring its filters/guidance/thresholds would let a hostile PR excuse
-	// its own findings (an approval bypass under --post-mode approve).
 	cfgSource := wt
 	cfgSource.workDir = ""
 	cfgResult, err := loadAndResolveConfig(cmd, cfgSource, logger)
@@ -254,8 +238,6 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 	return watch.Cycle{Result: mapCycleOutcome(outcome), LGTMBody: outcome.LGTMBody, HeadSHA: reviewedHead}, nil
 }
 
-// mapCycleOutcome translates the submission layer's record into the watch
-// loop's cycle result.
 func mapCycleOutcome(o *CycleOutcome) watch.CycleResult {
 	switch o.Kind {
 	case OutcomeNoChanges:

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -36,6 +36,7 @@ Exit codes:
   1 - Safety bound reached or PR closed without an LGTM
   2 - Error
   130 - Interrupted`,
+		Args:          cobra.NoArgs,
 		RunE:          runWatch,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -199,7 +200,22 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		defer wt.cleanup()
 	}
 
-	cfgResult, err := loadAndResolveConfig(cmd, wt, logger)
+	// Record the head the cycle actually reviews; commits can land between
+	// the watch loop's poll and the worktree fetch.
+	reviewedHead := ""
+	if wt.workDir != "" {
+		if sha, err := git.GetHeadSHA(wt.workDir); err == nil {
+			reviewedHead = sha
+		}
+	}
+
+	// Load config from the base repo, never from the PR-head worktree: the
+	// worktree's .acr.yaml is PR-author-controlled, and in unattended modes
+	// honoring its filters/guidance/thresholds would let a hostile PR excuse
+	// its own findings (an approval bypass under --post-mode approve).
+	cfgSource := wt
+	cfgSource.workDir = ""
+	cfgResult, err := loadAndResolveConfig(cmd, cfgSource, logger)
 	if err != nil {
 		return watch.Cycle{Result: watch.CycleError}, err
 	}
@@ -226,7 +242,7 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		return watch.Cycle{Result: watch.CycleError}, fmt.Errorf("review cycle failed")
 	}
 
-	return watch.Cycle{Result: mapCycleOutcome(outcome), LGTMBody: outcome.LGTMBody}, nil
+	return watch.Cycle{Result: mapCycleOutcome(outcome), LGTMBody: outcome.LGTMBody, HeadSHA: reviewedHead}, nil
 }
 
 // mapCycleOutcome translates the submission layer's record into the watch

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/git"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+	"github.com/richhaase/agentic-code-reviewer/internal/watch"
+)
+
+func newWatchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Watch a PR and re-review until an LGTM is posted",
+		Long: `Run a review against one PR, post the result according to --post-mode, then
+keep watching the PR and re-review when a re-review is requested or new
+commits settle, until a terminal LGTM is posted or a safety bound is reached.
+
+The watched PR is selected with --pr or detected from the current branch.
+
+Post modes:
+  interactive  Prompt for every submission decision (default; requires a TTY)
+  comment      Unattended; every result is posted as a comment review only
+  approve      Unattended; LGTM approves the PR once CI is green
+
+Exit codes:
+  0 - LGTM posted (or declined interactively), or PR merged
+  1 - Safety bound reached or PR closed without an LGTM
+  2 - Error
+  130 - Interrupted`,
+		RunE:          runWatch,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	registerSharedReviewFlags(cmd)
+
+	// Watch pacing defaults are resolved via config.Resolve (flag > config > default).
+	cmd.Flags().StringVar(&watchPostMode, "post-mode", "interactive",
+		"How results are posted: interactive, comment, or approve")
+	cmd.Flags().DurationVar(&watchPollInterval, "poll-interval", 0,
+		"How often to refresh the watched PR's state (default: 1m)")
+	cmd.Flags().DurationVar(&watchSettleTime, "settle-time", 0,
+		"Quiet period after the latest pushed commit before re-reviewing (default: 10m)")
+	cmd.Flags().IntVar(&watchMaxReviews, "max-reviews", 0,
+		"Maximum total review runs, including the initial run (default: 10)")
+	cmd.Flags().DurationVar(&watchMaxDuration, "max-duration", 0,
+		"Maximum wall-clock watch lifetime (default: 24h)")
+
+	setGroupedUsage(cmd)
+
+	return cmd
+}
+
+func runWatch(cmd *cobra.Command, _ []string) error {
+	if !terminal.IsStdoutTTY() {
+		terminal.DisableColors()
+	}
+	logger := terminal.NewLogger()
+
+	mode, err := watch.ParsePostMode(watchPostMode)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "%v", err)
+		return exitCode(domain.ExitError)
+	}
+	if mode == watch.PostModeInteractive && !terminal.IsStdinTTY() {
+		logger.Log("Interactive watch requires a TTY on stdin. Use --post-mode comment or approve for unattended runs.", terminal.StyleError)
+		return exitCode(domain.ExitError)
+	}
+
+	if err := github.CheckGHAvailable(); err != nil {
+		logger.Logf(terminal.StyleError, "acr watch requires the gh CLI: %v", err)
+		return exitCode(domain.ExitError)
+	}
+
+	// Prune stale ACR worktrees from previous runs (only review-* dirs older than 2h)
+	if err := git.PruneStaleWorktrees(); err != nil && verbose {
+		logger.Logf(terminal.StyleDim, "Worktree prune: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		fmt.Fprintln(os.Stderr)
+		logger.Log("Interrupted, shutting down...", terminal.StyleWarning)
+		cancel()
+	}()
+
+	// Resolve the watched PR: explicit --pr, or the current branch's PR.
+	watchPR := prNumber
+	if watchPR == "" {
+		detected, err := github.GetCurrentPRNumber(ctx, "")
+		if err != nil || detected == "" {
+			logger.Log("No open PR found for the current branch; use --pr to select one.", terminal.StyleError)
+			return exitCode(domain.ExitError)
+		}
+		watchPR = detected
+		logger.Logf(terminal.StyleDim, "Detected PR #%s for current branch", watchPR)
+	}
+	if err := github.ValidatePR(ctx, watchPR); err != nil {
+		logger.Logf(terminal.StyleError, "Failed to access PR #%s: %v", watchPR, err)
+		return exitCode(domain.ExitError)
+	}
+
+	// Every cycle reviews the PR in a fresh worktree fetched from its current
+	// head, so local branch state never goes stale mid-watch.
+	prNumber = watchPR
+
+	// Resolve watch pacing once at startup from the repo-root config + flags.
+	cfgResult, err := loadAndResolveConfig(cmd, worktreeResult{}, logger)
+	if err != nil {
+		return err
+	}
+	wcfg := watch.Config{
+		Mode:         mode,
+		PollInterval: cfgResult.resolved.WatchPollInterval,
+		SettleTime:   cfgResult.resolved.WatchSettleTime,
+		MaxReviews:   cfgResult.resolved.WatchMaxReviews,
+		MaxDuration:  cfgResult.resolved.WatchMaxDuration,
+	}
+
+	// Re-review requests only trigger for the authenticated gh user.
+	currentUser := github.GetCurrentUser(ctx)
+	if currentUser == "" {
+		logger.Log("Could not determine the authenticated gh user; re-review request triggers are disabled.", terminal.StyleWarning)
+	}
+
+	logger.Logf(terminal.StyleInfo, "Watching PR %s (mode=%s, poll=%s, settle=%s, max-reviews=%d, max-duration=%s)",
+		formatPRRef(watchPR), mode, wcfg.PollInterval, wcfg.SettleTime, wcfg.MaxReviews, wcfg.MaxDuration)
+
+	deps := watch.Deps{
+		Clock: watch.RealClock{},
+		Logf: func(format string, args ...any) {
+			logger.Logf(terminal.StyleInfo, format, args...)
+		},
+		State: func(ctx context.Context) (watch.PRState, error) {
+			st, err := github.GetPRWatchState(ctx, watchPR)
+			if err != nil {
+				return watch.PRState{}, err
+			}
+			return watch.PRState{
+				HeadSHA:         st.HeadSHA,
+				Closed:          st.Closed(),
+				Merged:          st.Merged(),
+				ReviewRequested: st.ReviewRequestedFrom(currentUser),
+			}, nil
+		},
+		CIGreen: func(ctx context.Context) (bool, error) {
+			status := github.CheckCIStatus(ctx, watchPR)
+			if status.Error != "" {
+				return false, fmt.Errorf("%s", status.Error)
+			}
+			return status.AllPassed, nil
+		},
+		Approve: func(ctx context.Context, body string) error {
+			return github.ApprovePR(ctx, watchPR, body)
+		},
+		RunCycle: func(ctx context.Context, _ int, _ string) (watch.Cycle, error) {
+			return runWatchCycle(ctx, cmd, watchPR, mode, logger)
+		},
+	}
+
+	reason := watch.Run(ctx, wcfg, deps)
+	logger.Logf(terminal.StyleInfo, "Watch finished: %s", reason)
+
+	switch reason {
+	case watch.ReasonLGTM, watch.ReasonDeclined, watch.ReasonMerged:
+		return nil
+	case watch.ReasonInterrupted:
+		return exitCode(domain.ExitInterrupted)
+	case watch.ReasonError:
+		return exitCode(domain.ExitError)
+	default: // ReasonClosed, ReasonMaxReviews, ReasonMaxDuration
+		return exitCode(domain.ExitFindings)
+	}
+}
+
+// runWatchCycle runs one full review cycle: fresh worktree at the PR's
+// current head, config resolution from that worktree, review, and posting
+// per the watch post mode.
+func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode watch.PostMode, logger *terminal.Logger) (watch.Cycle, error) {
+	wt, err := setupWorktree(ctx, cmd, logger)
+	if err != nil {
+		return watch.Cycle{Result: watch.CycleError}, err
+	}
+	if wt.cleanup != nil {
+		defer wt.cleanup()
+	}
+
+	cfgResult, err := loadAndResolveConfig(cmd, wt, logger)
+	if err != nil {
+		return watch.Cycle{Result: watch.CycleError}, err
+	}
+
+	outcome := &CycleOutcome{}
+	opts := ReviewOpts{
+		ResolvedConfig:   cfgResult.resolved,
+		Verbose:          verbose,
+		AutoYes:          mode != watch.PostModeInteractive,
+		PRNumber:         watchPR,
+		DetectedPR:       watchPR,
+		UseRefFile:       refFile,
+		ExcludePatterns:  cfgResult.excludePatterns,
+		WorkDir:          wt.workDir,
+		ForcePostComment: mode == watch.PostModeComment,
+		Outcome:          outcome,
+	}
+
+	code := executeReview(ctx, opts, logger)
+	if code == domain.ExitInterrupted {
+		return watch.Cycle{Result: watch.CycleError}, ctx.Err()
+	}
+	if code == domain.ExitError {
+		return watch.Cycle{Result: watch.CycleError}, fmt.Errorf("review cycle failed")
+	}
+
+	return watch.Cycle{Result: mapCycleOutcome(outcome), LGTMBody: outcome.LGTMBody}, nil
+}
+
+// mapCycleOutcome translates the submission layer's record into the watch
+// loop's cycle result.
+func mapCycleOutcome(o *CycleOutcome) watch.CycleResult {
+	switch o.Kind {
+	case OutcomeNoChanges:
+		return watch.CycleNoChanges
+	case OutcomeFindings:
+		return watch.CycleFindings
+	case OutcomeLGTMApproved:
+		return watch.CycleLGTMApproved
+	case OutcomeLGTMComment:
+		if o.CIDowngraded {
+			return watch.CycleLGTMCommentCIPending
+		}
+		return watch.CycleLGTMComment
+	case OutcomeLGTMDeclined:
+		return watch.CycleLGTMDeclined
+	case OutcomeLGTMSkipped:
+		return watch.CycleLGTMSkipped
+	default:
+		return watch.CycleError
+	}
+}

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/watch"
+)
+
+func TestWatchRejectsOneShotOnlyFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"--yes"},
+		{"-y"},
+		{"--local"},
+		{"-l"},
+		{"--worktree-branch", "feature"},
+		{"-B", "feature"},
+	} {
+		cmd := newWatchCmd()
+		if err := cmd.ParseFlags(args); err == nil {
+			t.Errorf("watch must reject %v with a usage error", args)
+		}
+	}
+}
+
+func TestWatchAcceptsSharedAndWatchFlags(t *testing.T) {
+	cmd := newWatchCmd()
+	err := cmd.ParseFlags([]string{
+		"--pr", "42",
+		"--reviewers", "3",
+		"--reviewer-agent", "codex",
+		"--post-mode", "comment",
+		"--poll-interval", "30s",
+		"--settle-time", "5m",
+		"--max-reviews", "4",
+		"--max-duration", "2h",
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+}
+
+func TestMapCycleOutcome(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome CycleOutcome
+		want    watch.CycleResult
+	}{
+		{"no changes", CycleOutcome{Kind: OutcomeNoChanges}, watch.CycleNoChanges},
+		{"findings", CycleOutcome{Kind: OutcomeFindings}, watch.CycleFindings},
+		{"approved", CycleOutcome{Kind: OutcomeLGTMApproved}, watch.CycleLGTMApproved},
+		{"comment", CycleOutcome{Kind: OutcomeLGTMComment}, watch.CycleLGTMComment},
+		{"comment via CI downgrade", CycleOutcome{Kind: OutcomeLGTMComment, CIDowngraded: true}, watch.CycleLGTMCommentCIPending},
+		{"declined", CycleOutcome{Kind: OutcomeLGTMDeclined}, watch.CycleLGTMDeclined},
+		{"skipped", CycleOutcome{Kind: OutcomeLGTMSkipped}, watch.CycleLGTMSkipped},
+		{"unrecorded is an error", CycleOutcome{}, watch.CycleError},
+	}
+	for _, tt := range tests {
+		if got := mapCycleOutcome(&tt.outcome); got != tt.want {
+			t.Errorf("%s: mapCycleOutcome = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -52,6 +52,7 @@ func TestMapCycleOutcome(t *testing.T) {
 		{"comment via CI downgrade", CycleOutcome{Kind: OutcomeLGTMComment, CIDowngraded: true}, watch.CycleLGTMCommentCIPending},
 		{"declined", CycleOutcome{Kind: OutcomeLGTMDeclined}, watch.CycleLGTMDeclined},
 		{"skipped", CycleOutcome{Kind: OutcomeLGTMSkipped}, watch.CycleLGTMSkipped},
+		{"stale head", CycleOutcome{Kind: OutcomeStaleHead}, watch.CycleStaleHead},
 		{"unrecorded is an error", CycleOutcome{}, watch.CycleError},
 	}
 	for _, tt := range tests {

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -60,3 +60,10 @@ func TestMapCycleOutcome(t *testing.T) {
 		}
 	}
 }
+
+func TestWatchRejectsPositionalArgs(t *testing.T) {
+	cmd := newWatchCmd()
+	if err := cmd.ValidateArgs([]string{"123"}); err == nil {
+		t.Error("watch must reject positional args; a bare PR number would be silently ignored")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,17 @@ type Config struct {
 	Filters           FilterConfig     `yaml:"filters"`
 	FPFilter          FPFilterConfig   `yaml:"fp_filter"`
 	PRFeedback        PRFeedbackConfig `yaml:"pr_feedback"`
+	Watch             WatchConfig      `yaml:"watch"`
+}
+
+// WatchConfig holds watch-mode pacing and bounds. The post mode is
+// intentionally flag-only: automated posting must be an explicit per-run
+// decision, not something a config file switches on.
+type WatchConfig struct {
+	PollInterval *Duration `yaml:"poll_interval"`
+	SettleTime   *Duration `yaml:"settle_time"`
+	MaxReviews   *int      `yaml:"max_reviews"`
+	MaxDuration  *Duration `yaml:"max_duration"`
 }
 
 type FPFilterConfig struct {
@@ -171,11 +182,13 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "guidance_file", "filters", "fp_filter", "pr_feedback"}
+var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "guidance_file", "filters", "fp_filter", "pr_feedback", "watch"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
 var knownPRFeedbackKeys = []string{"enabled", "agent"}
+
+var knownWatchKeys = []string{"poll_interval", "settle_time", "max_reviews", "max_duration"}
 
 // knownFilterKeys are the valid keys under the "filters" section.
 var knownFilterKeys = []string{"exclude_patterns"}
@@ -231,6 +244,18 @@ func checkUnknownKeys(data []byte) []string {
 			if !slices.Contains(knownPRFeedbackKeys, key) {
 				warning := fmt.Sprintf("unknown key %q in pr_feedback section of %s", key, ConfigFileName)
 				if suggestion := findSimilar(key, knownPRFeedbackKeys); suggestion != "" {
+					warning += fmt.Sprintf(" (did you mean %q?)", suggestion)
+				}
+				warnings = append(warnings, warning)
+			}
+		}
+	}
+
+	if watch, ok := raw["watch"].(map[string]any); ok {
+		for key := range watch {
+			if !slices.Contains(knownWatchKeys, key) {
+				warning := fmt.Sprintf("unknown key %q in watch section of %s", key, ConfigFileName)
+				if suggestion := findSimilar(key, knownWatchKeys); suggestion != "" {
 					warning += fmt.Sprintf(" (did you mean %q?)", suggestion)
 				}
 				warnings = append(warnings, warning)
@@ -379,6 +404,18 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.PRFeedbackAgent != "" && !slices.Contains(agent.SupportedAgents, r.PRFeedbackAgent) {
 		errs = append(errs, fmt.Sprintf("pr_feedback.agent must be one of %v, got %q", agent.SupportedAgents, r.PRFeedbackAgent))
 	}
+	if r.WatchPollInterval <= 0 {
+		errs = append(errs, fmt.Sprintf("watch.poll_interval must be > 0, got %s", r.WatchPollInterval))
+	}
+	if r.WatchSettleTime < 0 {
+		errs = append(errs, fmt.Sprintf("watch.settle_time must be >= 0, got %s", r.WatchSettleTime))
+	}
+	if r.WatchMaxReviews < 1 {
+		errs = append(errs, fmt.Sprintf("watch.max_reviews must be >= 1, got %d", r.WatchMaxReviews))
+	}
+	if r.WatchMaxDuration <= 0 {
+		errs = append(errs, fmt.Sprintf("watch.max_duration must be > 0, got %s", r.WatchMaxDuration))
+	}
 	return errs
 }
 
@@ -407,6 +444,10 @@ var Defaults = ResolvedConfig{
 	FPThreshold:       75,
 	PRFeedbackEnabled: true,
 	PRFeedbackAgent:   "", // empty means use summarizer agent
+	WatchPollInterval: time.Minute,
+	WatchSettleTime:   10 * time.Minute,
+	WatchMaxReviews:   10,
+	WatchMaxDuration:  24 * time.Hour,
 }
 
 type ResolvedConfig struct {
@@ -428,6 +469,10 @@ type ResolvedConfig struct {
 	FPThreshold       int
 	PRFeedbackEnabled bool
 	PRFeedbackAgent   string
+	WatchPollInterval time.Duration
+	WatchSettleTime   time.Duration
+	WatchMaxReviews   int
+	WatchMaxDuration  time.Duration
 }
 
 type FlagState struct {
@@ -449,6 +494,11 @@ type FlagState struct {
 	FPThresholdSet       bool
 	NoPRFeedbackSet      bool
 	PRFeedbackAgentSet   bool
+
+	WatchPollIntervalSet bool
+	WatchSettleTimeSet   bool
+	WatchMaxReviewsSet   bool
+	WatchMaxDurationSet  bool
 }
 
 type EnvState struct {
@@ -699,6 +749,18 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.PRFeedback.Agent != nil {
 			result.PRFeedbackAgent = *cfg.PRFeedback.Agent
 		}
+		if cfg.Watch.PollInterval != nil {
+			result.WatchPollInterval = cfg.Watch.PollInterval.AsDuration()
+		}
+		if cfg.Watch.SettleTime != nil {
+			result.WatchSettleTime = cfg.Watch.SettleTime.AsDuration()
+		}
+		if cfg.Watch.MaxReviews != nil {
+			result.WatchMaxReviews = *cfg.Watch.MaxReviews
+		}
+		if cfg.Watch.MaxDuration != nil {
+			result.WatchMaxDuration = cfg.Watch.MaxDuration.AsDuration()
+		}
 	}
 
 	// Apply env var values (if set)
@@ -798,6 +860,18 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	}
 	if flagState.PRFeedbackAgentSet {
 		result.PRFeedbackAgent = flagValues.PRFeedbackAgent
+	}
+	if flagState.WatchPollIntervalSet {
+		result.WatchPollInterval = flagValues.WatchPollInterval
+	}
+	if flagState.WatchSettleTimeSet {
+		result.WatchSettleTime = flagValues.WatchSettleTime
+	}
+	if flagState.WatchMaxReviewsSet {
+		result.WatchMaxReviews = flagValues.WatchMaxReviews
+	}
+	if flagState.WatchMaxDurationSet {
+		result.WatchMaxDuration = flagValues.WatchMaxDuration
 	}
 
 	return result

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,9 +74,6 @@ type Config struct {
 	Watch             WatchConfig      `yaml:"watch"`
 }
 
-// WatchConfig holds watch-mode pacing and bounds. The post mode is
-// intentionally flag-only: automated posting must be an explicit per-run
-// decision, not something a config file switches on.
 type WatchConfig struct {
 	PollInterval *Duration `yaml:"poll_interval"`
 	SettleTime   *Duration `yaml:"settle_time"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1612,7 +1612,6 @@ func TestResolve_WatchConfigAndFlagPrecedence(t *testing.T) {
 		},
 	}
 
-	// Config file values apply over defaults.
 	resolved := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
 	if resolved.WatchPollInterval != 30*time.Second {
 		t.Errorf("WatchPollInterval = %s, want 30s from config", resolved.WatchPollInterval)
@@ -1621,7 +1620,6 @@ func TestResolve_WatchConfigAndFlagPrecedence(t *testing.T) {
 		t.Errorf("WatchMaxReviews = %d, want 3 from config", resolved.WatchMaxReviews)
 	}
 
-	// Flags win over the config file.
 	resolved = Resolve(cfg, EnvState{},
 		FlagState{WatchPollIntervalSet: true, WatchMaxReviewsSet: true},
 		ResolvedConfig{WatchPollInterval: 2 * time.Minute, WatchMaxReviews: 5})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1584,3 +1584,108 @@ func TestResolvedConfig_Validate_EmptyReviewerAgents(t *testing.T) {
 		t.Errorf("expected 'reviewer_agents must not be empty' in error, got: %v", err)
 	}
 }
+
+func TestResolve_WatchDefaults(t *testing.T) {
+	resolved := Resolve(nil, EnvState{}, FlagState{}, ResolvedConfig{})
+
+	if resolved.WatchPollInterval != time.Minute {
+		t.Errorf("WatchPollInterval = %s, want 1m", resolved.WatchPollInterval)
+	}
+	if resolved.WatchSettleTime != 10*time.Minute {
+		t.Errorf("WatchSettleTime = %s, want 10m", resolved.WatchSettleTime)
+	}
+	if resolved.WatchMaxReviews != 10 {
+		t.Errorf("WatchMaxReviews = %d, want 10", resolved.WatchMaxReviews)
+	}
+	if resolved.WatchMaxDuration != 24*time.Hour {
+		t.Errorf("WatchMaxDuration = %s, want 24h", resolved.WatchMaxDuration)
+	}
+}
+
+func TestResolve_WatchConfigAndFlagPrecedence(t *testing.T) {
+	pollInterval := Duration(30 * time.Second)
+	maxReviews := 3
+	cfg := &Config{
+		Watch: WatchConfig{
+			PollInterval: &pollInterval,
+			MaxReviews:   &maxReviews,
+		},
+	}
+
+	// Config file values apply over defaults.
+	resolved := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.WatchPollInterval != 30*time.Second {
+		t.Errorf("WatchPollInterval = %s, want 30s from config", resolved.WatchPollInterval)
+	}
+	if resolved.WatchMaxReviews != 3 {
+		t.Errorf("WatchMaxReviews = %d, want 3 from config", resolved.WatchMaxReviews)
+	}
+
+	// Flags win over the config file.
+	resolved = Resolve(cfg, EnvState{},
+		FlagState{WatchPollIntervalSet: true, WatchMaxReviewsSet: true},
+		ResolvedConfig{WatchPollInterval: 2 * time.Minute, WatchMaxReviews: 5})
+	if resolved.WatchPollInterval != 2*time.Minute {
+		t.Errorf("WatchPollInterval = %s, want 2m from flag", resolved.WatchPollInterval)
+	}
+	if resolved.WatchMaxReviews != 5 {
+		t.Errorf("WatchMaxReviews = %d, want 5 from flag", resolved.WatchMaxReviews)
+	}
+}
+
+func TestValidate_WatchBounds(t *testing.T) {
+	resolved := Defaults
+	resolved.WatchPollInterval = 0
+	resolved.WatchMaxReviews = 0
+	resolved.WatchSettleTime = -time.Second
+	resolved.WatchMaxDuration = 0
+
+	errs := resolved.ValidateAll()
+	for _, want := range []string{"watch.poll_interval", "watch.settle_time", "watch.max_reviews", "watch.max_duration"} {
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected validation error mentioning %s, got %v", want, errs)
+		}
+	}
+}
+
+func TestLoadFromPathWithWarnings_WatchSection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ConfigFileName)
+	content := `watch:
+  poll_interval: 45s
+  settle_time: 5m
+  max_reviews: 4
+  max_duration: 2h
+  unknown_key: true
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Config.Watch.PollInterval == nil || result.Config.Watch.PollInterval.AsDuration() != 45*time.Second {
+		t.Errorf("poll_interval not parsed: %+v", result.Config.Watch)
+	}
+	if result.Config.Watch.MaxReviews == nil || *result.Config.Watch.MaxReviews != 4 {
+		t.Errorf("max_reviews not parsed: %+v", result.Config.Watch)
+	}
+	foundWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "unknown_key") && strings.Contains(w, "watch section") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected unknown-key warning for watch section, got %v", result.Warnings)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -41,6 +41,17 @@ func GetRoot() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// GetHeadSHA returns the commit SHA of HEAD in the given directory.
+func GetHeadSHA(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD in %s: %w", dir, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // GetCommonDir returns the git common directory (shared across worktrees).
 func GetCommonDir() (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--git-common-dir")

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -41,7 +41,6 @@ func GetRoot() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// GetHeadSHA returns the commit SHA of HEAD in the given directory.
 func GetHeadSHA(dir string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "HEAD")
 	cmd.Dir = dir

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -303,7 +303,8 @@ func ParseCIChecks(data []byte) CIStatus {
 type PRWatchState struct {
 	HeadSHA        string
 	State          string   // "OPEN", "CLOSED", or "MERGED"
-	ReviewRequests []string // user logins and team slugs with pending review requests
+	ReviewRequests []string // user logins with pending review requests
+	TeamRequests   []string // team slugs with pending review requests
 }
 
 // Closed reports whether the PR is closed without being merged.
@@ -312,7 +313,9 @@ func (s PRWatchState) Closed() bool { return strings.EqualFold(s.State, "CLOSED"
 // Merged reports whether the PR has been merged.
 func (s PRWatchState) Merged() bool { return strings.EqualFold(s.State, "MERGED") }
 
-// ReviewRequestedFrom reports whether login has a pending review request on the PR.
+// ReviewRequestedFrom reports whether the user login has a pending review
+// request on the PR. Team requests never match: a team slug that collides
+// with a login must not trigger, and team-routed requests are out of scope.
 func (s PRWatchState) ReviewRequestedFrom(login string) bool {
 	if login == "" {
 		return false
@@ -359,7 +362,7 @@ func ParsePRWatchState(data []byte) (PRWatchState, error) {
 		case r.Login != "":
 			state.ReviewRequests = append(state.ReviewRequests, r.Login)
 		case r.Slug != "":
-			state.ReviewRequests = append(state.ReviewRequests, r.Slug)
+			state.TeamRequests = append(state.TeamRequests, r.Slug)
 		}
 	}
 	return state, nil

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -297,25 +297,17 @@ func ParseCIChecks(data []byte) CIStatus {
 	}
 }
 
-// PRWatchState is a point-in-time snapshot of the mutable PR state that
-// watch mode polls: head commit, open/closed/merged state, and pending
-// review requests.
 type PRWatchState struct {
 	HeadSHA        string
-	State          string   // "OPEN", "CLOSED", or "MERGED"
-	ReviewRequests []string // user logins with pending review requests
-	TeamRequests   []string // team slugs with pending review requests
+	State          string
+	ReviewRequests []string
+	TeamRequests   []string
 }
 
-// Closed reports whether the PR is closed without being merged.
 func (s PRWatchState) Closed() bool { return strings.EqualFold(s.State, "CLOSED") }
 
-// Merged reports whether the PR has been merged.
 func (s PRWatchState) Merged() bool { return strings.EqualFold(s.State, "MERGED") }
 
-// ReviewRequestedFrom reports whether the user login has a pending review
-// request on the PR. Team requests never match: a team slug that collides
-// with a login must not trigger, and team-routed requests are out of scope.
 func (s PRWatchState) ReviewRequestedFrom(login string) bool {
 	if login == "" {
 		return false
@@ -328,7 +320,6 @@ func (s PRWatchState) ReviewRequestedFrom(login string) bool {
 	return false
 }
 
-// GetPRWatchState fetches the current watch-relevant state of a PR.
 func GetPRWatchState(ctx context.Context, prNumber string) (PRWatchState, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "headRefOid,state,reviewRequests")
 	out, err := cmd.Output()
@@ -338,8 +329,6 @@ func GetPRWatchState(ctx context.Context, prNumber string) (PRWatchState, error)
 	return ParsePRWatchState(out)
 }
 
-// ParsePRWatchState parses the gh pr view JSON for watch-relevant fields.
-// Review request entries carry a login for users and a slug for teams.
 func ParsePRWatchState(data []byte) (PRWatchState, error) {
 	var resp struct {
 		HeadRefOid     string `json:"headRefOid"`

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -297,6 +297,74 @@ func ParseCIChecks(data []byte) CIStatus {
 	}
 }
 
+// PRWatchState is a point-in-time snapshot of the mutable PR state that
+// watch mode polls: head commit, open/closed/merged state, and pending
+// review requests.
+type PRWatchState struct {
+	HeadSHA        string
+	State          string   // "OPEN", "CLOSED", or "MERGED"
+	ReviewRequests []string // user logins and team slugs with pending review requests
+}
+
+// Closed reports whether the PR is closed without being merged.
+func (s PRWatchState) Closed() bool { return strings.EqualFold(s.State, "CLOSED") }
+
+// Merged reports whether the PR has been merged.
+func (s PRWatchState) Merged() bool { return strings.EqualFold(s.State, "MERGED") }
+
+// ReviewRequestedFrom reports whether login has a pending review request on the PR.
+func (s PRWatchState) ReviewRequestedFrom(login string) bool {
+	if login == "" {
+		return false
+	}
+	for _, r := range s.ReviewRequests {
+		if strings.EqualFold(r, login) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetPRWatchState fetches the current watch-relevant state of a PR.
+func GetPRWatchState(ctx context.Context, prNumber string) (PRWatchState, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "headRefOid,state,reviewRequests")
+	out, err := cmd.Output()
+	if err != nil {
+		return PRWatchState{}, classifyGHError(err)
+	}
+	return ParsePRWatchState(out)
+}
+
+// ParsePRWatchState parses the gh pr view JSON for watch-relevant fields.
+// Review request entries carry a login for users and a slug for teams.
+func ParsePRWatchState(data []byte) (PRWatchState, error) {
+	var resp struct {
+		HeadRefOid     string `json:"headRefOid"`
+		State          string `json:"state"`
+		ReviewRequests []struct {
+			Login string `json:"login"`
+			Slug  string `json:"slug"`
+		} `json:"reviewRequests"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return PRWatchState{}, fmt.Errorf("failed to parse PR state response: %w", err)
+	}
+
+	state := PRWatchState{
+		HeadSHA: resp.HeadRefOid,
+		State:   resp.State,
+	}
+	for _, r := range resp.ReviewRequests {
+		switch {
+		case r.Login != "":
+			state.ReviewRequests = append(state.ReviewRequests, r.Login)
+		case r.Slug != "":
+			state.ReviewRequests = append(state.ReviewRequests, r.Slug)
+		}
+	}
+	return state, nil
+}
+
 // IsGHAvailable checks if the gh CLI is available.
 func IsGHAvailable() bool {
 	_, err := exec.LookPath("gh")

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -597,3 +597,61 @@ func TestUrlMatches_SameURL(t *testing.T) {
 		}
 	}
 }
+
+func TestParsePRWatchState(t *testing.T) {
+	data := []byte(`{
+		"headRefOid": "abc123def456",
+		"state": "OPEN",
+		"reviewRequests": [
+			{"__typename": "User", "login": "octocat"},
+			{"__typename": "Team", "name": "Core", "slug": "core-team"}
+		]
+	}`)
+
+	state, err := ParsePRWatchState(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.HeadSHA != "abc123def456" {
+		t.Errorf("HeadSHA = %q, want %q", state.HeadSHA, "abc123def456")
+	}
+	if state.Closed() || state.Merged() {
+		t.Errorf("expected open state, got %q", state.State)
+	}
+	if len(state.ReviewRequests) != 2 {
+		t.Fatalf("ReviewRequests = %v, want 2 entries", state.ReviewRequests)
+	}
+	if !state.ReviewRequestedFrom("OctoCat") {
+		t.Error("expected case-insensitive match for user login")
+	}
+	if !state.ReviewRequestedFrom("core-team") {
+		t.Error("expected match for team slug")
+	}
+	if state.ReviewRequestedFrom("someone-else") {
+		t.Error("unexpected match for absent reviewer")
+	}
+	if state.ReviewRequestedFrom("") {
+		t.Error("empty login must never match")
+	}
+}
+
+func TestParsePRWatchState_MergedNoRequests(t *testing.T) {
+	data := []byte(`{"headRefOid": "abc", "state": "MERGED", "reviewRequests": []}`)
+
+	state, err := ParsePRWatchState(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !state.Merged() {
+		t.Errorf("expected merged, got %q", state.State)
+	}
+	if len(state.ReviewRequests) != 0 {
+		t.Errorf("expected no review requests, got %v", state.ReviewRequests)
+	}
+}
+
+func TestParsePRWatchState_InvalidJSON(t *testing.T) {
+	if _, err := ParsePRWatchState([]byte("not json")); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -618,14 +618,17 @@ func TestParsePRWatchState(t *testing.T) {
 	if state.Closed() || state.Merged() {
 		t.Errorf("expected open state, got %q", state.State)
 	}
-	if len(state.ReviewRequests) != 2 {
-		t.Fatalf("ReviewRequests = %v, want 2 entries", state.ReviewRequests)
+	if len(state.ReviewRequests) != 1 {
+		t.Fatalf("ReviewRequests = %v, want 1 user entry", state.ReviewRequests)
+	}
+	if len(state.TeamRequests) != 1 || state.TeamRequests[0] != "core-team" {
+		t.Fatalf("TeamRequests = %v, want [core-team]", state.TeamRequests)
 	}
 	if !state.ReviewRequestedFrom("OctoCat") {
 		t.Error("expected case-insensitive match for user login")
 	}
-	if !state.ReviewRequestedFrom("core-team") {
-		t.Error("expected match for team slug")
+	if state.ReviewRequestedFrom("core-team") {
+		t.Error("team slug must not match as a user login (slug/login collision)")
 	}
 	if state.ReviewRequestedFrom("someone-else") {
 		t.Error("unexpected match for absent reviewer")

--- a/internal/watch/clock.go
+++ b/internal/watch/clock.go
@@ -5,22 +5,15 @@ import (
 	"time"
 )
 
-// Clock abstracts wall-clock time so the watch loop can be tested
-// deterministically.
 type Clock interface {
 	Now() time.Time
-	// Sleep blocks for d or until ctx is canceled, returning ctx.Err() in the
-	// latter case.
 	Sleep(ctx context.Context, d time.Duration) error
 }
 
-// RealClock implements Clock with the system clock.
 type RealClock struct{}
 
-// Now returns the current time.
 func (RealClock) Now() time.Time { return time.Now() }
 
-// Sleep waits for d or context cancellation.
 func (RealClock) Sleep(ctx context.Context, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()

--- a/internal/watch/clock.go
+++ b/internal/watch/clock.go
@@ -1,0 +1,33 @@
+package watch
+
+import (
+	"context"
+	"time"
+)
+
+// Clock abstracts wall-clock time so the watch loop can be tested
+// deterministically.
+type Clock interface {
+	Now() time.Time
+	// Sleep blocks for d or until ctx is canceled, returning ctx.Err() in the
+	// latter case.
+	Sleep(ctx context.Context, d time.Duration) error
+}
+
+// RealClock implements Clock with the system clock.
+type RealClock struct{}
+
+// Now returns the current time.
+func (RealClock) Now() time.Time { return time.Now() }
+
+// Sleep waits for d or context cancellation.
+func (RealClock) Sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -61,6 +61,9 @@ const (
 	CycleLGTMDeclined
 	// CycleLGTMSkipped means an LGTM result could not be posted at all.
 	CycleLGTMSkipped
+	// CycleStaleHead means nothing was posted because the PR head moved while
+	// the review ran; the new head re-enters normal watching.
+	CycleStaleHead
 )
 
 // Cycle is the outcome of one review cycle.
@@ -338,6 +341,21 @@ func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 	if !green {
 		return 0, false
 	}
+	// Re-check the head immediately before approving: a commit landing after
+	// the poll must not receive an approval it was never reviewed for. On a
+	// mismatch the next poll invalidates the pending approval.
+	st, err := l.deps.State(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ReasonInterrupted, true
+		}
+		l.logf("PR state check before approval failed: %v", err)
+		return 0, false
+	}
+	if st.HeadSHA != l.lastHead {
+		l.logf("New commit %s arrived before the approval could post; deferring.", shortSHA(st.HeadSHA))
+		return 0, false
+	}
 	if err := l.deps.Approve(ctx, l.pendingApproval); err != nil {
 		if ctx.Err() != nil {
 			return ReasonInterrupted, true
@@ -365,11 +383,13 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 	if ctx.Err() != nil {
 		return ReasonInterrupted, true
 	}
-	if cycleCtx.Err() == context.DeadlineExceeded {
-		l.logf("Reached maximum duration (%s) during review #%d; stopping.", l.cfg.MaxDuration, l.reviews)
-		return ReasonMaxDuration, true
-	}
 	if err != nil {
+		// The deadline only wins when the cycle actually failed: a result
+		// posted just before the deadline is still a result.
+		if cycleCtx.Err() == context.DeadlineExceeded {
+			l.logf("Reached maximum duration (%s) during review #%d; stopping.", l.cfg.MaxDuration, l.reviews)
+			return ReasonMaxDuration, true
+		}
 		l.logf("Review #%d failed: %v", l.reviews, err)
 		return ReasonError, true
 	}
@@ -407,6 +427,9 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 	case CycleLGTMSkipped:
 		l.logf("Review #%d produced an LGTM that could not be posted; stopping.", l.reviews)
 		return ReasonError, true
+	case CycleStaleHead:
+		l.logf("Review #%d discarded: PR head moved during the review; resuming watch.", l.reviews)
+		return 0, false
 	case CycleNoChanges:
 		l.logf("Review #%d: no changes to review; resuming watch.", l.reviews)
 		return 0, false

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -67,6 +67,10 @@ const (
 type Cycle struct {
 	Result   CycleResult
 	LGTMBody string // rendered LGTM body, for a deferred approval
+	// HeadSHA is the commit the cycle actually reviewed (the worktree HEAD),
+	// which can be newer than the SHA observed at poll time if commits landed
+	// in between. Empty means unknown; the loop falls back to the polled SHA.
+	HeadSHA string
 }
 
 // Deps are the injected effects the watch loop drives.
@@ -145,6 +149,7 @@ type loop struct {
 	cfg  Config
 	deps Deps
 
+	deadline        time.Time // wall-clock bound from MaxDuration
 	reviews         int
 	lastHead        string    // head SHA covered by the last review
 	pendingHead     string    // head SHA waiting out the settle period
@@ -170,7 +175,8 @@ func shortSHA(sha string) string {
 func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 	l := &loop{cfg: cfg, deps: deps, requestArmed: true}
 	clock := deps.Clock
-	deadline := clock.Now().Add(cfg.MaxDuration)
+	l.deadline = clock.Now().Add(cfg.MaxDuration)
+	deadline := l.deadline
 
 	st, err := deps.State(ctx)
 	if err != nil {
@@ -277,6 +283,13 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 
 		if l.reviews >= cfg.MaxReviews {
+			// With an approval pending on CI, dropping the wait because a
+			// trigger arrived would make the trigger strictly worse than
+			// doing nothing; ignore it and keep waiting.
+			if l.pendingApproval != "" {
+				l.logf("Review budget exhausted; ignoring trigger (%s) and continuing to wait for CI.", trigger)
+				continue
+			}
 			l.logf("Reached maximum of %d reviews without a terminal LGTM; stopping.", cfg.MaxReviews)
 			return ReasonMaxReviews
 		}
@@ -342,16 +355,31 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 	l.reviews++
 	l.logf("Review #%d/%d starting (%s)", l.reviews, l.cfg.MaxReviews, trigger)
 
-	c, err := l.deps.RunCycle(ctx, l.reviews, trigger)
+	// Bound the cycle by the remaining max-duration budget so a hung reviewer
+	// cannot exceed the advertised wall-clock bound. The timeout is relative
+	// (not a deadline) so it composes with an injected test clock.
+	cycleCtx, cancel := context.WithTimeout(ctx, l.deadline.Sub(l.deps.Clock.Now()))
+	defer cancel()
+
+	c, err := l.deps.RunCycle(cycleCtx, l.reviews, trigger)
 	if ctx.Err() != nil {
 		return ReasonInterrupted, true
+	}
+	if cycleCtx.Err() == context.DeadlineExceeded {
+		l.logf("Reached maximum duration (%s) during review #%d; stopping.", l.cfg.MaxDuration, l.reviews)
+		return ReasonMaxDuration, true
 	}
 	if err != nil {
 		l.logf("Review #%d failed: %v", l.reviews, err)
 		return ReasonError, true
 	}
 
+	// Prefer the head the cycle actually reviewed (commits may have landed
+	// between the poll and the worktree fetch).
 	l.lastHead = head
+	if c.HeadSHA != "" {
+		l.lastHead = c.HeadSHA
+	}
 	l.pendingHead = ""
 	l.pendingApproval = ""
 

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,0 +1,391 @@
+// Package watch implements the acr watch loop: it runs review cycles against
+// a single PR, re-reviewing on re-review requests or settled commits, until a
+// terminal LGTM is posted or a safety bound is reached. All effects (GitHub
+// state, review cycles, CI checks, time) are injected so the loop is
+// deterministic under test.
+package watch
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// PostMode controls how watch cycles post results.
+type PostMode string
+
+const (
+	// PostModeInteractive preserves the human-in-the-loop submission flow.
+	PostModeInteractive PostMode = "interactive"
+	// PostModeComment posts every result as a comment review only.
+	PostModeComment PostMode = "comment"
+	// PostModeApprove runs unattended with the automated approval flow.
+	PostModeApprove PostMode = "approve"
+)
+
+// ParsePostMode validates a --post-mode flag value.
+func ParsePostMode(s string) (PostMode, error) {
+	switch PostMode(s) {
+	case PostModeInteractive, PostModeComment, PostModeApprove:
+		return PostMode(s), nil
+	}
+	return "", fmt.Errorf("invalid post mode %q: must be interactive, comment, or approve", s)
+}
+
+// PRState is a snapshot of the watched PR.
+type PRState struct {
+	HeadSHA         string
+	Closed          bool // closed without merging
+	Merged          bool
+	ReviewRequested bool // pending re-review request for the authenticated user
+}
+
+// CycleResult classifies what a review cycle produced and posted.
+type CycleResult int
+
+const (
+	// CycleError means the cycle failed.
+	CycleError CycleResult = iota
+	// CycleNoChanges means the diff was empty; nothing was reviewed.
+	CycleNoChanges
+	// CycleFindings means findings were posted or handled; keep watching.
+	CycleFindings
+	// CycleLGTMApproved means an approval was posted.
+	CycleLGTMApproved
+	// CycleLGTMComment means an LGTM comment was posted (not a CI downgrade).
+	CycleLGTMComment
+	// CycleLGTMCommentCIPending means an intended approval was posted as a
+	// comment because CI was not green; the approval is still wanted.
+	CycleLGTMCommentCIPending
+	// CycleLGTMDeclined means the user chose not to post an LGTM result.
+	CycleLGTMDeclined
+	// CycleLGTMSkipped means an LGTM result could not be posted at all.
+	CycleLGTMSkipped
+)
+
+// Cycle is the outcome of one review cycle.
+type Cycle struct {
+	Result   CycleResult
+	LGTMBody string // rendered LGTM body, for a deferred approval
+}
+
+// Deps are the injected effects the watch loop drives.
+type Deps struct {
+	// State fetches the current PR state.
+	State func(ctx context.Context) (PRState, error)
+	// RunCycle runs one full review cycle (worktree, review, post) and
+	// reports what it did.
+	RunCycle func(ctx context.Context, reviewNum int, trigger string) (Cycle, error)
+	// CIGreen reports whether all CI checks on the PR pass.
+	CIGreen func(ctx context.Context) (bool, error)
+	// Approve posts an approval with the given body.
+	Approve func(ctx context.Context, body string) error
+	Clock   Clock
+	// Logf emits a status transition; may be nil.
+	Logf func(format string, args ...any)
+}
+
+// Config bounds and paces the watch loop.
+type Config struct {
+	Mode         PostMode
+	PollInterval time.Duration
+	SettleTime   time.Duration
+	MaxReviews   int
+	MaxDuration  time.Duration
+}
+
+// ExitReason says why the watch loop stopped.
+type ExitReason int
+
+const (
+	// ReasonLGTM means the terminal LGTM for the post mode was posted.
+	ReasonLGTM ExitReason = iota
+	// ReasonDeclined means the user declined to post an LGTM (interactive).
+	ReasonDeclined
+	// ReasonMerged means the PR was merged.
+	ReasonMerged
+	// ReasonClosed means the PR was closed without merging.
+	ReasonClosed
+	// ReasonMaxReviews means the review-count bound was reached.
+	ReasonMaxReviews
+	// ReasonMaxDuration means the wall-clock bound was reached.
+	ReasonMaxDuration
+	// ReasonInterrupted means the process was signaled or canceled.
+	ReasonInterrupted
+	// ReasonError means a cycle or GitHub operation failed.
+	ReasonError
+)
+
+func (r ExitReason) String() string {
+	switch r {
+	case ReasonLGTM:
+		return "LGTM posted"
+	case ReasonDeclined:
+		return "LGTM declined by user"
+	case ReasonMerged:
+		return "PR merged"
+	case ReasonClosed:
+		return "PR closed"
+	case ReasonMaxReviews:
+		return "maximum reviews reached"
+	case ReasonMaxDuration:
+		return "maximum duration reached"
+	case ReasonInterrupted:
+		return "interrupted"
+	default:
+		return "error"
+	}
+}
+
+// maxConsecutivePollErrors bounds transient PR-state fetch failures before
+// the loop gives up.
+const maxConsecutivePollErrors = 5
+
+type loop struct {
+	cfg  Config
+	deps Deps
+
+	reviews         int
+	lastHead        string    // head SHA covered by the last review
+	pendingHead     string    // head SHA waiting out the settle period
+	settleDeadline  time.Time // when pendingHead is considered settled
+	requestArmed    bool      // rising-edge detector for re-review requests
+	pendingApproval string    // LGTM body awaiting green CI (approve mode)
+}
+
+func (l *loop) logf(format string, args ...any) {
+	if l.deps.Logf != nil {
+		l.deps.Logf(format, args...)
+	}
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}
+
+// Run drives the watch loop until a terminal state and returns why it stopped.
+func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
+	l := &loop{cfg: cfg, deps: deps, requestArmed: true}
+	clock := deps.Clock
+	deadline := clock.Now().Add(cfg.MaxDuration)
+
+	st, err := deps.State(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ReasonInterrupted
+		}
+		l.logf("Failed to fetch PR state: %v", err)
+		return ReasonError
+	}
+	if reason, done := l.checkOpen(st); done {
+		return reason
+	}
+
+	// A review request pending at startup is consumed by the initial review.
+	l.requestArmed = !st.ReviewRequested
+
+	if reason, done := l.cycle(ctx, st.HeadSHA, "initial review"); done {
+		return reason
+	}
+	if reason, done := l.checkMaxReviews(); done {
+		return reason
+	}
+
+	pollErrors := 0
+	for {
+		now := clock.Now()
+		if !now.Before(deadline) {
+			l.logf("Reached maximum duration (%s) without a terminal LGTM; stopping.", cfg.MaxDuration)
+			return ReasonMaxDuration
+		}
+		sleep := cfg.PollInterval
+		if remaining := deadline.Sub(now); remaining < sleep {
+			sleep = remaining
+		}
+		if err := clock.Sleep(ctx, sleep); err != nil {
+			return ReasonInterrupted
+		}
+		if !clock.Now().Before(deadline) {
+			l.logf("Reached maximum duration (%s) without a terminal LGTM; stopping.", cfg.MaxDuration)
+			return ReasonMaxDuration
+		}
+
+		st, err := deps.State(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ReasonInterrupted
+			}
+			pollErrors++
+			l.logf("Failed to fetch PR state (%d/%d): %v", pollErrors, maxConsecutivePollErrors, err)
+			if pollErrors >= maxConsecutivePollErrors {
+				return ReasonError
+			}
+			continue
+		}
+		pollErrors = 0
+
+		if reason, done := l.checkOpen(st); done {
+			return reason
+		}
+
+		// Rising-edge detection: a serviced request must clear (GitHub clears
+		// it when the review posts) before a request can trigger again.
+		if !st.ReviewRequested {
+			l.requestArmed = true
+		}
+
+		trigger := ""
+		if st.ReviewRequested && l.requestArmed {
+			trigger = "re-review requested"
+			l.requestArmed = false
+		}
+
+		if trigger == "" && l.pendingApproval != "" {
+			if st.HeadSHA == l.lastHead {
+				if reason, done := l.tryApprove(ctx); done {
+					return reason
+				}
+				continue
+			}
+			// New commits invalidate the pending approval; fall through to
+			// normal settle tracking for the new head.
+			l.logf("New commit %s invalidates the pending approval.", shortSHA(st.HeadSHA))
+			l.pendingApproval = ""
+			if reason, done := l.checkMaxReviews(); done {
+				return reason
+			}
+		}
+
+		if trigger == "" {
+			switch {
+			case st.HeadSHA == l.lastHead:
+				l.pendingHead = "" // head is back to the reviewed state
+			case st.HeadSHA != l.pendingHead:
+				l.pendingHead = st.HeadSHA
+				l.settleDeadline = clock.Now().Add(cfg.SettleTime)
+				l.logf("New head %s; waiting %s for commits to settle.", shortSHA(st.HeadSHA), cfg.SettleTime)
+			case !clock.Now().Before(l.settleDeadline):
+				trigger = "commits settled"
+			}
+		}
+
+		if trigger == "" {
+			continue
+		}
+
+		if l.reviews >= cfg.MaxReviews {
+			l.logf("Reached maximum of %d reviews without a terminal LGTM; stopping.", cfg.MaxReviews)
+			return ReasonMaxReviews
+		}
+		if reason, done := l.cycle(ctx, st.HeadSHA, trigger); done {
+			return reason
+		}
+		if reason, done := l.checkMaxReviews(); done {
+			return reason
+		}
+	}
+}
+
+// checkOpen maps a merged or closed PR to its exit reason.
+func (l *loop) checkOpen(st PRState) (ExitReason, bool) {
+	if st.Merged {
+		l.logf("PR merged; stopping watch.")
+		return ReasonMerged, true
+	}
+	if st.Closed {
+		l.logf("PR closed; stopping watch.")
+		return ReasonClosed, true
+	}
+	return 0, false
+}
+
+// checkMaxReviews stops the loop once the review budget is spent, unless an
+// approval is still pending on CI (the CI wait consumes no review runs).
+func (l *loop) checkMaxReviews() (ExitReason, bool) {
+	if l.reviews >= l.cfg.MaxReviews && l.pendingApproval == "" {
+		l.logf("Reached maximum of %d reviews without a terminal LGTM; stopping.", l.cfg.MaxReviews)
+		return ReasonMaxReviews, true
+	}
+	return 0, false
+}
+
+// tryApprove checks CI and posts the pending approval when green.
+func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
+	green, err := l.deps.CIGreen(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ReasonInterrupted, true
+		}
+		l.logf("CI status check failed: %v", err)
+		return 0, false
+	}
+	if !green {
+		return 0, false
+	}
+	if err := l.deps.Approve(ctx, l.pendingApproval); err != nil {
+		if ctx.Err() != nil {
+			return ReasonInterrupted, true
+		}
+		l.logf("Failed to post approval: %v", err)
+		return ReasonError, true
+	}
+	l.logf("CI green; approval posted. Watch complete.")
+	return ReasonLGTM, true
+}
+
+// cycle runs one review cycle and maps its outcome. The bool reports whether
+// the loop should stop with the returned reason.
+func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, bool) {
+	l.reviews++
+	l.logf("Review #%d/%d starting (%s)", l.reviews, l.cfg.MaxReviews, trigger)
+
+	c, err := l.deps.RunCycle(ctx, l.reviews, trigger)
+	if ctx.Err() != nil {
+		return ReasonInterrupted, true
+	}
+	if err != nil {
+		l.logf("Review #%d failed: %v", l.reviews, err)
+		return ReasonError, true
+	}
+
+	l.lastHead = head
+	l.pendingHead = ""
+	l.pendingApproval = ""
+
+	switch c.Result {
+	case CycleLGTMApproved:
+		l.logf("Approval posted; watch complete.")
+		return ReasonLGTM, true
+	case CycleLGTMComment:
+		// Terminal in comment and interactive modes; in approve mode this
+		// only happens when approval is impossible (self-review).
+		l.logf("LGTM comment posted; watch complete.")
+		return ReasonLGTM, true
+	case CycleLGTMCommentCIPending:
+		if l.cfg.Mode == PostModeApprove {
+			l.pendingApproval = c.LGTMBody
+			l.logf("LGTM comment posted; waiting for CI to go green before approving.")
+			return 0, false
+		}
+		// Interactive: the user chose the comment downgrade — a posted LGTM.
+		l.logf("LGTM comment posted; watch complete.")
+		return ReasonLGTM, true
+	case CycleLGTMDeclined:
+		l.logf("LGTM result declined by user; ending watch without posting.")
+		return ReasonDeclined, true
+	case CycleLGTMSkipped:
+		l.logf("Review #%d produced an LGTM that could not be posted; stopping.", l.reviews)
+		return ReasonError, true
+	case CycleNoChanges:
+		l.logf("Review #%d: no changes to review; resuming watch.", l.reviews)
+		return 0, false
+	case CycleFindings:
+		l.logf("Review #%d complete (findings); resuming watch.", l.reviews)
+		return 0, false
+	default:
+		return ReasonError, true
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -181,7 +181,7 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 	l.deadline = clock.Now().Add(cfg.MaxDuration)
 	deadline := l.deadline
 
-	st, err := deps.State(ctx)
+	st, err := l.fetchInitialState(ctx)
 	if err != nil {
 		if ctx.Err() != nil {
 			return ReasonInterrupted
@@ -301,6 +301,24 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 		if reason, done := l.checkMaxReviews(); done {
 			return reason
+		}
+	}
+}
+
+// fetchInitialState fetches the PR state at startup with the same
+// transient-error tolerance as the poll loop.
+func (l *loop) fetchInitialState(ctx context.Context) (PRState, error) {
+	for attempt := 1; ; attempt++ {
+		st, err := l.deps.State(ctx)
+		if err == nil {
+			return st, nil
+		}
+		if ctx.Err() != nil || attempt >= maxConsecutivePollErrors {
+			return PRState{}, err
+		}
+		l.logf("Failed to fetch PR state (%d/%d): %v", attempt, maxConsecutivePollErrors, err)
+		if err := l.deps.Clock.Sleep(ctx, l.cfg.PollInterval); err != nil {
+			return PRState{}, err
 		}
 	}
 }

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -113,6 +113,7 @@ type loop struct {
 	settleDeadline  time.Time
 	requestArmed    bool
 	pendingApproval string
+	ciErrors        int
 }
 
 func (l *loop) logf(format string, args ...any) {
@@ -292,9 +293,14 @@ func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 		if ctx.Err() != nil {
 			return ReasonInterrupted, true
 		}
-		l.logf("CI status check failed: %v", err)
+		l.ciErrors++
+		l.logf("CI status check failed (%d/%d): %v", l.ciErrors, maxConsecutivePollErrors, err)
+		if l.ciErrors >= maxConsecutivePollErrors {
+			return ReasonError, true
+		}
 		return 0, false
 	}
+	l.ciErrors = 0
 	if !green {
 		return 0, false
 	}
@@ -341,9 +347,11 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 		return ReasonError, true
 	}
 
-	l.lastHead = head
-	if c.HeadSHA != "" {
-		l.lastHead = c.HeadSHA
+	if c.Result != CycleStaleHead {
+		l.lastHead = head
+		if c.HeadSHA != "" {
+			l.lastHead = c.HeadSHA
+		}
 	}
 	l.pendingHead = ""
 	l.pendingApproval = ""

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,8 +1,3 @@
-// Package watch implements the acr watch loop: it runs review cycles against
-// a single PR, re-reviewing on re-review requests or settled commits, until a
-// terminal LGTM is posted or a safety bound is reached. All effects (GitHub
-// state, review cycles, CI checks, time) are injected so the loop is
-// deterministic under test.
 package watch
 
 import (
@@ -11,19 +6,14 @@ import (
 	"time"
 )
 
-// PostMode controls how watch cycles post results.
 type PostMode string
 
 const (
-	// PostModeInteractive preserves the human-in-the-loop submission flow.
 	PostModeInteractive PostMode = "interactive"
-	// PostModeComment posts every result as a comment review only.
-	PostModeComment PostMode = "comment"
-	// PostModeApprove runs unattended with the automated approval flow.
-	PostModeApprove PostMode = "approve"
+	PostModeComment     PostMode = "comment"
+	PostModeApprove     PostMode = "approve"
 )
 
-// ParsePostMode validates a --post-mode flag value.
 func ParsePostMode(s string) (PostMode, error) {
 	switch PostMode(s) {
 	case PostModeInteractive, PostModeComment, PostModeApprove:
@@ -32,67 +22,42 @@ func ParsePostMode(s string) (PostMode, error) {
 	return "", fmt.Errorf("invalid post mode %q: must be interactive, comment, or approve", s)
 }
 
-// PRState is a snapshot of the watched PR.
 type PRState struct {
 	HeadSHA         string
-	Closed          bool // closed without merging
+	Closed          bool
 	Merged          bool
-	ReviewRequested bool // pending re-review request for the authenticated user
+	ReviewRequested bool
 }
 
-// CycleResult classifies what a review cycle produced and posted.
 type CycleResult int
 
 const (
-	// CycleError means the cycle failed.
 	CycleError CycleResult = iota
-	// CycleNoChanges means the diff was empty; nothing was reviewed.
 	CycleNoChanges
-	// CycleFindings means findings were posted or handled; keep watching.
 	CycleFindings
-	// CycleLGTMApproved means an approval was posted.
 	CycleLGTMApproved
-	// CycleLGTMComment means an LGTM comment was posted (not a CI downgrade).
 	CycleLGTMComment
-	// CycleLGTMCommentCIPending means an intended approval was posted as a
-	// comment because CI was not green; the approval is still wanted.
 	CycleLGTMCommentCIPending
-	// CycleLGTMDeclined means the user chose not to post an LGTM result.
 	CycleLGTMDeclined
-	// CycleLGTMSkipped means an LGTM result could not be posted at all.
 	CycleLGTMSkipped
-	// CycleStaleHead means nothing was posted because the PR head moved while
-	// the review ran; the new head re-enters normal watching.
 	CycleStaleHead
 )
 
-// Cycle is the outcome of one review cycle.
 type Cycle struct {
 	Result   CycleResult
-	LGTMBody string // rendered LGTM body, for a deferred approval
-	// HeadSHA is the commit the cycle actually reviewed (the worktree HEAD),
-	// which can be newer than the SHA observed at poll time if commits landed
-	// in between. Empty means unknown; the loop falls back to the polled SHA.
-	HeadSHA string
+	LGTMBody string
+	HeadSHA  string
 }
 
-// Deps are the injected effects the watch loop drives.
 type Deps struct {
-	// State fetches the current PR state.
-	State func(ctx context.Context) (PRState, error)
-	// RunCycle runs one full review cycle (worktree, review, post) and
-	// reports what it did.
+	State    func(ctx context.Context) (PRState, error)
 	RunCycle func(ctx context.Context, reviewNum int, trigger string) (Cycle, error)
-	// CIGreen reports whether all CI checks on the PR pass.
-	CIGreen func(ctx context.Context) (bool, error)
-	// Approve posts an approval with the given body.
-	Approve func(ctx context.Context, body string) error
-	Clock   Clock
-	// Logf emits a status transition; may be nil.
-	Logf func(format string, args ...any)
+	CIGreen  func(ctx context.Context) (bool, error)
+	Approve  func(ctx context.Context, body string) error
+	Clock    Clock
+	Logf     func(format string, args ...any)
 }
 
-// Config bounds and paces the watch loop.
 type Config struct {
 	Mode         PostMode
 	PollInterval time.Duration
@@ -101,25 +66,16 @@ type Config struct {
 	MaxDuration  time.Duration
 }
 
-// ExitReason says why the watch loop stopped.
 type ExitReason int
 
 const (
-	// ReasonLGTM means the terminal LGTM for the post mode was posted.
 	ReasonLGTM ExitReason = iota
-	// ReasonDeclined means the user declined to post an LGTM (interactive).
 	ReasonDeclined
-	// ReasonMerged means the PR was merged.
 	ReasonMerged
-	// ReasonClosed means the PR was closed without merging.
 	ReasonClosed
-	// ReasonMaxReviews means the review-count bound was reached.
 	ReasonMaxReviews
-	// ReasonMaxDuration means the wall-clock bound was reached.
 	ReasonMaxDuration
-	// ReasonInterrupted means the process was signaled or canceled.
 	ReasonInterrupted
-	// ReasonError means a cycle or GitHub operation failed.
 	ReasonError
 )
 
@@ -144,21 +100,19 @@ func (r ExitReason) String() string {
 	}
 }
 
-// maxConsecutivePollErrors bounds transient PR-state fetch failures before
-// the loop gives up.
 const maxConsecutivePollErrors = 5
 
 type loop struct {
 	cfg  Config
 	deps Deps
 
-	deadline        time.Time // wall-clock bound from MaxDuration
+	deadline        time.Time
 	reviews         int
-	lastHead        string    // head SHA covered by the last review
-	pendingHead     string    // head SHA waiting out the settle period
-	settleDeadline  time.Time // when pendingHead is considered settled
-	requestArmed    bool      // rising-edge detector for re-review requests
-	pendingApproval string    // LGTM body awaiting green CI (approve mode)
+	lastHead        string
+	pendingHead     string
+	settleDeadline  time.Time
+	requestArmed    bool
+	pendingApproval string
 }
 
 func (l *loop) logf(format string, args ...any) {
@@ -174,7 +128,6 @@ func shortSHA(sha string) string {
 	return sha
 }
 
-// Run drives the watch loop until a terminal state and returns why it stopped.
 func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 	l := &loop{cfg: cfg, deps: deps, requestArmed: true}
 	clock := deps.Clock
@@ -193,7 +146,6 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		return reason
 	}
 
-	// A review request pending at startup is consumed by the initial review.
 	l.requestArmed = !st.ReviewRequested
 
 	if reason, done := l.cycle(ctx, st.HeadSHA, "initial review"); done {
@@ -240,8 +192,6 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			return reason
 		}
 
-		// Rising-edge detection: a serviced request must clear (GitHub clears
-		// it when the review posts) before a request can trigger again.
 		if !st.ReviewRequested {
 			l.requestArmed = true
 		}
@@ -259,8 +209,6 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 				}
 				continue
 			}
-			// New commits invalidate the pending approval; fall through to
-			// normal settle tracking for the new head.
 			l.logf("New commit %s invalidates the pending approval.", shortSHA(st.HeadSHA))
 			l.pendingApproval = ""
 			if reason, done := l.checkMaxReviews(); done {
@@ -271,7 +219,7 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		if trigger == "" {
 			switch {
 			case st.HeadSHA == l.lastHead:
-				l.pendingHead = "" // head is back to the reviewed state
+				l.pendingHead = ""
 			case st.HeadSHA != l.pendingHead:
 				l.pendingHead = st.HeadSHA
 				l.settleDeadline = clock.Now().Add(cfg.SettleTime)
@@ -286,9 +234,6 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 
 		if l.reviews >= cfg.MaxReviews {
-			// With an approval pending on CI, dropping the wait because a
-			// trigger arrived would make the trigger strictly worse than
-			// doing nothing; ignore it and keep waiting.
 			if l.pendingApproval != "" {
 				l.logf("Review budget exhausted; ignoring trigger (%s) and continuing to wait for CI.", trigger)
 				continue
@@ -305,8 +250,6 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 	}
 }
 
-// fetchInitialState fetches the PR state at startup with the same
-// transient-error tolerance as the poll loop.
 func (l *loop) fetchInitialState(ctx context.Context) (PRState, error) {
 	for attempt := 1; ; attempt++ {
 		st, err := l.deps.State(ctx)
@@ -323,7 +266,6 @@ func (l *loop) fetchInitialState(ctx context.Context) (PRState, error) {
 	}
 }
 
-// checkOpen maps a merged or closed PR to its exit reason.
 func (l *loop) checkOpen(st PRState) (ExitReason, bool) {
 	if st.Merged {
 		l.logf("PR merged; stopping watch.")
@@ -336,8 +278,6 @@ func (l *loop) checkOpen(st PRState) (ExitReason, bool) {
 	return 0, false
 }
 
-// checkMaxReviews stops the loop once the review budget is spent, unless an
-// approval is still pending on CI (the CI wait consumes no review runs).
 func (l *loop) checkMaxReviews() (ExitReason, bool) {
 	if l.reviews >= l.cfg.MaxReviews && l.pendingApproval == "" {
 		l.logf("Reached maximum of %d reviews without a terminal LGTM; stopping.", l.cfg.MaxReviews)
@@ -346,7 +286,6 @@ func (l *loop) checkMaxReviews() (ExitReason, bool) {
 	return 0, false
 }
 
-// tryApprove checks CI and posts the pending approval when green.
 func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 	green, err := l.deps.CIGreen(ctx)
 	if err != nil {
@@ -359,9 +298,6 @@ func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 	if !green {
 		return 0, false
 	}
-	// Re-check the head immediately before approving: a commit landing after
-	// the poll must not receive an approval it was never reviewed for. On a
-	// mismatch the next poll invalidates the pending approval.
 	st, err := l.deps.State(ctx)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -385,15 +321,10 @@ func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 	return ReasonLGTM, true
 }
 
-// cycle runs one review cycle and maps its outcome. The bool reports whether
-// the loop should stop with the returned reason.
 func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, bool) {
 	l.reviews++
 	l.logf("Review #%d/%d starting (%s)", l.reviews, l.cfg.MaxReviews, trigger)
 
-	// Bound the cycle by the remaining max-duration budget so a hung reviewer
-	// cannot exceed the advertised wall-clock bound. The timeout is relative
-	// (not a deadline) so it composes with an injected test clock.
 	cycleCtx, cancel := context.WithTimeout(ctx, l.deadline.Sub(l.deps.Clock.Now()))
 	defer cancel()
 
@@ -402,8 +333,6 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 		return ReasonInterrupted, true
 	}
 	if err != nil {
-		// The deadline only wins when the cycle actually failed: a result
-		// posted just before the deadline is still a result.
 		if cycleCtx.Err() == context.DeadlineExceeded {
 			l.logf("Reached maximum duration (%s) during review #%d; stopping.", l.cfg.MaxDuration, l.reviews)
 			return ReasonMaxDuration, true
@@ -412,8 +341,6 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 		return ReasonError, true
 	}
 
-	// Prefer the head the cycle actually reviewed (commits may have landed
-	// between the poll and the worktree fetch).
 	l.lastHead = head
 	if c.HeadSHA != "" {
 		l.lastHead = c.HeadSHA
@@ -426,8 +353,6 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 		l.logf("Approval posted; watch complete.")
 		return ReasonLGTM, true
 	case CycleLGTMComment:
-		// Terminal in comment and interactive modes; in approve mode this
-		// only happens when approval is impossible (self-review).
 		l.logf("LGTM comment posted; watch complete.")
 		return ReasonLGTM, true
 	case CycleLGTMCommentCIPending:
@@ -436,7 +361,6 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 			l.logf("LGTM comment posted; waiting for CI to go green before approving.")
 			return 0, false
 		}
-		// Interactive: the user chose the comment downgrade — a posted LGTM.
 		l.logf("LGTM comment posted; watch complete.")
 		return ReasonLGTM, true
 	case CycleLGTMDeclined:

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -594,3 +594,27 @@ func TestTerminalResultWinsOverExpiredDeadline(t *testing.T) {
 		t.Fatalf("reason = %v, want ReasonLGTM (a posted result beats an expired deadline)", reason)
 	}
 }
+
+func TestStartupStateToleratesTransientErrors(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+
+	deps := h.deps()
+	inner := deps.State
+	calls := 0
+	deps.State = func(ctx context.Context) (PRState, error) {
+		calls++
+		if calls <= 2 {
+			return PRState{}, errors.New("transient gh failure")
+		}
+		return inner(ctx)
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM after transient startup failures", reason)
+	}
+	if calls != 3 {
+		t.Errorf("state calls = %d, want 3 (two failures then success)", calls)
+	}
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -455,3 +455,71 @@ func TestParsePostMode(t *testing.T) {
 		}
 	}
 }
+
+func TestExhaustedBudgetTriggerDoesNotAbandonPendingApproval(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		requested("aaa"), // trigger arrives after the budget is spent
+	}
+	h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "promised"}}
+	h.ci = []bool{false, true}
+	cfg := defaultConfig(PostModeApprove)
+	cfg.MaxReviews = 1
+
+	reason := Run(context.Background(), cfg, h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM (trigger must not abandon the CI wait)", reason)
+	}
+	if len(h.approvedWith) != 1 || h.approvedWith[0] != "promised" {
+		t.Errorf("approvals = %v, want the promised body", h.approvedWith)
+	}
+	if len(h.triggers) != 1 {
+		t.Errorf("cycles = %d, want 1 (no budget for the trigger)", len(h.triggers))
+	}
+}
+
+func TestCycleContextCarriesMaxDurationBound(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+	cfg := defaultConfig(PostModeApprove)
+
+	deps := h.deps()
+	inner := deps.RunCycle
+	var sawDeadline bool
+	deps.RunCycle = func(ctx context.Context, n int, trigger string) (Cycle, error) {
+		_, sawDeadline = ctx.Deadline()
+		return inner(ctx, n, trigger)
+	}
+
+	if reason := Run(context.Background(), cfg, deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if !sawDeadline {
+		t.Error("cycle context must carry a deadline bounding it by --max-duration")
+	}
+}
+
+func TestReviewedHeadPreferredOverPolledHead(t *testing.T) {
+	h := newHarness(t)
+	// Commits land between the poll (aaa) and the worktree fetch (bbb); the
+	// cycle reports it reviewed bbb, so bbb must not re-trigger a review.
+	h.states = []PRState{
+		open("aaa"),
+		open("bbb"),
+	}
+	h.cycles = []Cycle{{Result: CycleFindings, HeadSHA: "bbb"}}
+	cfg := defaultConfig(PostModeComment)
+	cfg.MaxDuration = time.Hour
+
+	reason := Run(context.Background(), cfg, h.deps())
+
+	if reason != ReasonMaxDuration {
+		t.Fatalf("reason = %v, want ReasonMaxDuration", reason)
+	}
+	if len(h.triggers) != 1 {
+		t.Errorf("cycles = %d, want 1 (bbb was already reviewed)", len(h.triggers))
+	}
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -523,3 +523,74 @@ func TestReviewedHeadPreferredOverPolledHead(t *testing.T) {
 		t.Errorf("cycles = %d, want 1 (bbb was already reviewed)", len(h.triggers))
 	}
 }
+
+func TestStaleHeadCycleResumesWatching(t *testing.T) {
+	h := newHarness(t)
+	// Cycle 1 discards its result because the head moved during the review;
+	// the new head must re-enter normal watching and get reviewed.
+	h.states = []PRState{
+		open("aaa"),
+		open("bbb"),
+	}
+	h.cycles = []Cycle{
+		{Result: CycleStaleHead, HeadSHA: "aaa"},
+		{Result: CycleLGTMApproved},
+	}
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "commits settled" {
+		t.Fatalf("triggers = %v, want stale cycle followed by a settled re-review", h.triggers)
+	}
+}
+
+func TestDeferredApprovalRechecksHeadBeforePosting(t *testing.T) {
+	h := newHarness(t)
+	// CI goes green, but a commit lands between the poll and the approval:
+	// the stale approval must not post; the new head gets re-reviewed.
+	h.states = []PRState{
+		open("aaa"), // startup
+		open("aaa"), // poll: enters CI wait
+		open("bbb"), // tryApprove head recheck: head moved
+		open("bbb"), // subsequent polls
+	}
+	h.cycles = []Cycle{
+		{Result: CycleLGTMCommentCIPending, LGTMBody: "stale"},
+		{Result: CycleLGTMApproved},
+	}
+	h.ci = []bool{true}
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.approvedWith) != 0 {
+		t.Errorf("stale approval posted for an unreviewed head: %v", h.approvedWith)
+	}
+	if len(h.triggers) != 2 {
+		t.Errorf("cycles = %d, want 2 (new head re-reviewed)", len(h.triggers))
+	}
+}
+
+func TestTerminalResultWinsOverExpiredDeadline(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+	cfg := defaultConfig(PostModeApprove)
+	cfg.MaxDuration = 30 * time.Minute
+
+	deps := h.deps()
+	inner := deps.RunCycle
+	deps.RunCycle = func(ctx context.Context, n int, trigger string) (Cycle, error) {
+		h.clock.now = h.clock.now.Add(time.Hour) // review outlives the deadline
+		return inner(ctx, n, trigger)
+	}
+
+	if reason := Run(context.Background(), cfg, deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM (a posted result beats an expired deadline)", reason)
+	}
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -602,3 +602,37 @@ func TestStartupStateToleratesTransientErrors(t *testing.T) {
 		t.Errorf("state calls = %d, want 3 (two failures then success)", calls)
 	}
 }
+
+func TestForcePushBackToDiscardedHeadRetriggersReview(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{
+		{Result: CycleStaleHead, HeadSHA: "aaa"},
+		{Result: CycleLGTMApproved},
+	}
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 2 {
+		t.Errorf("cycles = %d, want 2 (discarded head must not count as reviewed)", len(h.triggers))
+	}
+}
+
+func TestPersistentCIErrorsDuringApprovalWaitAreFatal(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "x"}}
+	h.ci = nil
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonError {
+		t.Fatalf("reason = %v, want ReasonError after repeated CI-check failures", reason)
+	}
+	if len(h.approvedWith) != 0 {
+		t.Errorf("no approval should post: %v", h.approvedWith)
+	}
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 )
 
-// fakeClock advances instantly on Sleep so loop tests are deterministic.
 type fakeClock struct {
 	now time.Time
 }
@@ -22,21 +21,20 @@ func (c *fakeClock) Sleep(ctx context.Context, d time.Duration) error {
 	return nil
 }
 
-// harness scripts the injected effects and records what the loop did.
 type harness struct {
 	t     *testing.T
 	clock *fakeClock
 
-	states []PRState // consumed per State call; last entry repeats
+	states []PRState
 	stateI int
 
-	cycles []Cycle // consumed per RunCycle call; must not run dry
+	cycles []Cycle
 	cycleI int
 
-	ci  []bool // consumed per CIGreen call; last entry repeats
+	ci  []bool
 	ciI int
 
-	cancelAfterCycle int // cancel ctx after this many cycles (0 = never)
+	cancelAfterCycle int
 	cancel           context.CancelFunc
 
 	triggers     []string
@@ -138,9 +136,9 @@ func TestInteractiveDeclinedLGTMEndsWatch(t *testing.T) {
 func TestReReviewRequestTriggersWithoutSettleWait(t *testing.T) {
 	h := newHarness(t)
 	h.states = []PRState{
-		open("aaa"),      // startup
-		open("aaa"),      // first poll: quiet
-		requested("aaa"), // second poll: re-review requested (same head)
+		open("aaa"),
+		open("aaa"),
+		requested("aaa"),
 	}
 	h.cycles = []Cycle{
 		{Result: CycleFindings},
@@ -156,7 +154,6 @@ func TestReReviewRequestTriggersWithoutSettleWait(t *testing.T) {
 	if len(h.triggers) != 2 || h.triggers[1] != "re-review requested" {
 		t.Fatalf("triggers = %v", h.triggers)
 	}
-	// Two polls at 1m each: the request must not wait out the 10m settle time.
 	if elapsed := h.clock.now.Sub(start); elapsed > 5*time.Minute {
 		t.Errorf("request trigger waited %s; settle time must not apply", elapsed)
 	}
@@ -164,8 +161,6 @@ func TestReReviewRequestTriggersWithoutSettleWait(t *testing.T) {
 
 func TestPersistentRequestIsConsumedOnce(t *testing.T) {
 	h := newHarness(t)
-	// The request never clears (e.g. posting failed to consume it); the loop
-	// must not re-trigger for the same request every poll.
 	h.states = []PRState{
 		open("aaa"),
 		requested("aaa"),
@@ -189,7 +184,7 @@ func TestPersistentRequestIsConsumedOnce(t *testing.T) {
 
 func TestRequestPendingAtStartupIsConsumedByInitialReview(t *testing.T) {
 	h := newHarness(t)
-	h.states = []PRState{requested("aaa")} // request visible before and after the initial review
+	h.states = []PRState{requested("aaa")}
 	h.cycles = []Cycle{{Result: CycleFindings}}
 	cfg := defaultConfig(PostModeComment)
 	cfg.MaxDuration = 30 * time.Minute
@@ -208,9 +203,9 @@ func TestRequestClearsAndReturnsRetriggering(t *testing.T) {
 	h := newHarness(t)
 	h.states = []PRState{
 		open("aaa"),
-		requested("aaa"), // poll 1: triggers review #2
-		open("aaa"),      // poll 2: cleared, re-arms
-		requested("aaa"), // poll 3: triggers review #3
+		requested("aaa"),
+		open("aaa"),
+		requested("aaa"),
 	}
 	h.cycles = []Cycle{
 		{Result: CycleFindings},
@@ -230,7 +225,7 @@ func TestNewCommitsWaitOutSettleTime(t *testing.T) {
 	h := newHarness(t)
 	h.states = []PRState{
 		open("aaa"),
-		open("bbb"), // new head appears and stays
+		open("bbb"),
 	}
 	h.cycles = []Cycle{
 		{Result: CycleFindings},
@@ -246,7 +241,6 @@ func TestNewCommitsWaitOutSettleTime(t *testing.T) {
 	if len(h.triggers) != 2 || h.triggers[1] != "commits settled" {
 		t.Fatalf("triggers = %v", h.triggers)
 	}
-	// The second review must not start before the settle period elapsed.
 	if elapsed := h.clock.now.Sub(start); elapsed < 10*time.Minute {
 		t.Errorf("second review after %s, want >= settle time (10m)", elapsed)
 	}
@@ -255,7 +249,6 @@ func TestNewCommitsWaitOutSettleTime(t *testing.T) {
 func TestAdditionalCommitRestartsSettleTimer(t *testing.T) {
 	h := newHarness(t)
 	states := []PRState{open("aaa")}
-	// Head bbb for 5 polls (less than the 10m settle), then ccc appears.
 	for range 5 {
 		states = append(states, open("bbb"))
 	}
@@ -272,7 +265,6 @@ func TestAdditionalCommitRestartsSettleTimer(t *testing.T) {
 	if reason != ReasonLGTM {
 		t.Fatalf("reason = %v, want ReasonLGTM", reason)
 	}
-	// bbb seen at minute 1, ccc at minute 6, settled at minute 16.
 	if elapsed := h.clock.now.Sub(start); elapsed < 16*time.Minute {
 		t.Errorf("second review after %s, want >= 16m (timer restarted by ccc)", elapsed)
 	}
@@ -371,8 +363,8 @@ func TestNewCommitInvalidatesPendingApproval(t *testing.T) {
 	h := newHarness(t)
 	h.states = []PRState{
 		open("aaa"),
-		open("aaa"), // CI not green yet
-		open("bbb"), // new commit invalidates pending approval
+		open("aaa"),
+		open("bbb"),
 	}
 	h.cycles = []Cycle{
 		{Result: CycleLGTMCommentCIPending, LGTMBody: "stale"},
@@ -407,8 +399,6 @@ func TestInterruptDuringWatch(t *testing.T) {
 }
 
 func TestCommentModeCIPendingIsTerminal(t *testing.T) {
-	// Interactive mode: the user accepted the comment downgrade after the CI
-	// prompt; that is a posted LGTM and must be terminal.
 	h := newHarness(t)
 	h.states = []PRState{open("aaa")}
 	h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "x"}}
@@ -460,7 +450,7 @@ func TestExhaustedBudgetTriggerDoesNotAbandonPendingApproval(t *testing.T) {
 	h := newHarness(t)
 	h.states = []PRState{
 		open("aaa"),
-		requested("aaa"), // trigger arrives after the budget is spent
+		requested("aaa"),
 	}
 	h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "promised"}}
 	h.ci = []bool{false, true}
@@ -504,8 +494,6 @@ func TestCycleContextCarriesMaxDurationBound(t *testing.T) {
 
 func TestReviewedHeadPreferredOverPolledHead(t *testing.T) {
 	h := newHarness(t)
-	// Commits land between the poll (aaa) and the worktree fetch (bbb); the
-	// cycle reports it reviewed bbb, so bbb must not re-trigger a review.
 	h.states = []PRState{
 		open("aaa"),
 		open("bbb"),
@@ -526,8 +514,6 @@ func TestReviewedHeadPreferredOverPolledHead(t *testing.T) {
 
 func TestStaleHeadCycleResumesWatching(t *testing.T) {
 	h := newHarness(t)
-	// Cycle 1 discards its result because the head moved during the review;
-	// the new head must re-enter normal watching and get reviewed.
 	h.states = []PRState{
 		open("aaa"),
 		open("bbb"),
@@ -549,13 +535,11 @@ func TestStaleHeadCycleResumesWatching(t *testing.T) {
 
 func TestDeferredApprovalRechecksHeadBeforePosting(t *testing.T) {
 	h := newHarness(t)
-	// CI goes green, but a commit lands between the poll and the approval:
-	// the stale approval must not post; the new head gets re-reviewed.
 	h.states = []PRState{
-		open("aaa"), // startup
-		open("aaa"), // poll: enters CI wait
-		open("bbb"), // tryApprove head recheck: head moved
-		open("bbb"), // subsequent polls
+		open("aaa"),
+		open("aaa"),
+		open("bbb"),
+		open("bbb"),
 	}
 	h.cycles = []Cycle{
 		{Result: CycleLGTMCommentCIPending, LGTMBody: "stale"},
@@ -586,7 +570,7 @@ func TestTerminalResultWinsOverExpiredDeadline(t *testing.T) {
 	deps := h.deps()
 	inner := deps.RunCycle
 	deps.RunCycle = func(ctx context.Context, n int, trigger string) (Cycle, error) {
-		h.clock.now = h.clock.now.Add(time.Hour) // review outlives the deadline
+		h.clock.now = h.clock.now.Add(time.Hour)
 		return inner(ctx, n, trigger)
 	}
 

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1,0 +1,457 @@
+package watch
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeClock advances instantly on Sleep so loop tests are deterministic.
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) Sleep(ctx context.Context, d time.Duration) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	c.now = c.now.Add(d)
+	return nil
+}
+
+// harness scripts the injected effects and records what the loop did.
+type harness struct {
+	t     *testing.T
+	clock *fakeClock
+
+	states []PRState // consumed per State call; last entry repeats
+	stateI int
+
+	cycles []Cycle // consumed per RunCycle call; must not run dry
+	cycleI int
+
+	ci  []bool // consumed per CIGreen call; last entry repeats
+	ciI int
+
+	cancelAfterCycle int // cancel ctx after this many cycles (0 = never)
+	cancel           context.CancelFunc
+
+	triggers     []string
+	approvedWith []string
+}
+
+func newHarness(t *testing.T) *harness {
+	return &harness{t: t, clock: &fakeClock{now: time.Unix(1_700_000_000, 0)}}
+}
+
+func (h *harness) deps() Deps {
+	return Deps{
+		Clock: h.clock,
+		State: func(ctx context.Context) (PRState, error) {
+			if h.stateI < len(h.states)-1 {
+				h.stateI++
+				return h.states[h.stateI-1], nil
+			}
+			return h.states[len(h.states)-1], nil
+		},
+		RunCycle: func(ctx context.Context, reviewNum int, trigger string) (Cycle, error) {
+			if h.cycleI >= len(h.cycles) {
+				h.t.Fatalf("unexpected review cycle #%d (trigger %q)", reviewNum, trigger)
+			}
+			h.triggers = append(h.triggers, trigger)
+			c := h.cycles[h.cycleI]
+			h.cycleI++
+			if h.cancelAfterCycle > 0 && h.cycleI >= h.cancelAfterCycle && h.cancel != nil {
+				h.cancel()
+			}
+			return c, nil
+		},
+		CIGreen: func(ctx context.Context) (bool, error) {
+			if h.ciI < len(h.ci)-1 {
+				h.ciI++
+				return h.ci[h.ciI-1], nil
+			}
+			if len(h.ci) == 0 {
+				return false, errors.New("no CI script")
+			}
+			return h.ci[len(h.ci)-1], nil
+		},
+		Approve: func(ctx context.Context, body string) error {
+			h.approvedWith = append(h.approvedWith, body)
+			return nil
+		},
+	}
+}
+
+func defaultConfig(mode PostMode) Config {
+	return Config{
+		Mode:         mode,
+		PollInterval: time.Minute,
+		SettleTime:   10 * time.Minute,
+		MaxReviews:   10,
+		MaxDuration:  24 * time.Hour,
+	}
+}
+
+func open(head string) PRState { return PRState{HeadSHA: head} }
+
+func requested(head string) PRState { return PRState{HeadSHA: head, ReviewRequested: true} }
+
+func TestInitialReviewLGTMExitsImmediately(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 1 || h.triggers[0] != "initial review" {
+		t.Errorf("triggers = %v, want [initial review]", h.triggers)
+	}
+}
+
+func TestCommentModeLGTMCommentIsTerminal(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMComment}}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), h.deps()); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+}
+
+func TestInteractiveDeclinedLGTMEndsWatch(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMDeclined}}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeInteractive), h.deps()); reason != ReasonDeclined {
+		t.Fatalf("reason = %v, want ReasonDeclined", reason)
+	}
+}
+
+func TestReReviewRequestTriggersWithoutSettleWait(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),      // startup
+		open("aaa"),      // first poll: quiet
+		requested("aaa"), // second poll: re-review requested (same head)
+	}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved},
+	}
+
+	start := h.clock.now
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "re-review requested" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	// Two polls at 1m each: the request must not wait out the 10m settle time.
+	if elapsed := h.clock.now.Sub(start); elapsed > 5*time.Minute {
+		t.Errorf("request trigger waited %s; settle time must not apply", elapsed)
+	}
+}
+
+func TestPersistentRequestIsConsumedOnce(t *testing.T) {
+	h := newHarness(t)
+	// The request never clears (e.g. posting failed to consume it); the loop
+	// must not re-trigger for the same request every poll.
+	h.states = []PRState{
+		open("aaa"),
+		requested("aaa"),
+	}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleFindings},
+	}
+	cfg := defaultConfig(PostModeComment)
+	cfg.MaxDuration = 30 * time.Minute
+
+	reason := Run(context.Background(), cfg, h.deps())
+
+	if reason != ReasonMaxDuration {
+		t.Fatalf("reason = %v, want ReasonMaxDuration", reason)
+	}
+	if len(h.triggers) != 2 {
+		t.Errorf("cycles = %d, want 2 (initial + one request trigger)", len(h.triggers))
+	}
+}
+
+func TestRequestPendingAtStartupIsConsumedByInitialReview(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{requested("aaa")} // request visible before and after the initial review
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	cfg := defaultConfig(PostModeComment)
+	cfg.MaxDuration = 30 * time.Minute
+
+	reason := Run(context.Background(), cfg, h.deps())
+
+	if reason != ReasonMaxDuration {
+		t.Fatalf("reason = %v, want ReasonMaxDuration", reason)
+	}
+	if len(h.triggers) != 1 {
+		t.Errorf("cycles = %d, want 1 (startup request consumed by initial review)", len(h.triggers))
+	}
+}
+
+func TestRequestClearsAndReturnsRetriggering(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		requested("aaa"), // poll 1: triggers review #2
+		open("aaa"),      // poll 2: cleared, re-arms
+		requested("aaa"), // poll 3: triggers review #3
+	}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved},
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps()); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 3 {
+		t.Errorf("cycles = %d, want 3", len(h.triggers))
+	}
+}
+
+func TestNewCommitsWaitOutSettleTime(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		open("bbb"), // new head appears and stays
+	}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved},
+	}
+
+	start := h.clock.now
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "commits settled" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	// The second review must not start before the settle period elapsed.
+	if elapsed := h.clock.now.Sub(start); elapsed < 10*time.Minute {
+		t.Errorf("second review after %s, want >= settle time (10m)", elapsed)
+	}
+}
+
+func TestAdditionalCommitRestartsSettleTimer(t *testing.T) {
+	h := newHarness(t)
+	states := []PRState{open("aaa")}
+	// Head bbb for 5 polls (less than the 10m settle), then ccc appears.
+	for range 5 {
+		states = append(states, open("bbb"))
+	}
+	states = append(states, open("ccc"))
+	h.states = states
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved},
+	}
+
+	start := h.clock.now
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	// bbb seen at minute 1, ccc at minute 6, settled at minute 16.
+	if elapsed := h.clock.now.Sub(start); elapsed < 16*time.Minute {
+		t.Errorf("second review after %s, want >= 16m (timer restarted by ccc)", elapsed)
+	}
+}
+
+func TestUnchangedHeadNeverRetriggers(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	cfg := defaultConfig(PostModeComment)
+	cfg.MaxDuration = time.Hour
+
+	reason := Run(context.Background(), cfg, h.deps())
+
+	if reason != ReasonMaxDuration {
+		t.Fatalf("reason = %v, want ReasonMaxDuration", reason)
+	}
+	if len(h.triggers) != 1 {
+		t.Errorf("cycles = %d, want 1", len(h.triggers))
+	}
+}
+
+func TestMaxReviewsBound(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		requested("aaa"),
+		open("aaa"),
+		requested("aaa"),
+		open("aaa"),
+		requested("aaa"),
+	}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleFindings},
+		{Result: CycleFindings},
+	}
+	cfg := defaultConfig(PostModeComment)
+	cfg.MaxReviews = 3
+
+	reason := Run(context.Background(), cfg, h.deps())
+
+	if reason != ReasonMaxReviews {
+		t.Fatalf("reason = %v, want ReasonMaxReviews", reason)
+	}
+	if len(h.triggers) != 3 {
+		t.Errorf("cycles = %d, want 3", len(h.triggers))
+	}
+}
+
+func TestMergedPRStopsWatch(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		{HeadSHA: "aaa", Merged: true},
+	}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), h.deps()); reason != ReasonMerged {
+		t.Fatalf("reason = %v, want ReasonMerged", reason)
+	}
+}
+
+func TestClosedPRBeforeFirstReview(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{{HeadSHA: "aaa", Closed: true}}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), h.deps()); reason != ReasonClosed {
+		t.Fatalf("reason = %v, want ReasonClosed", reason)
+	}
+	if len(h.triggers) != 0 {
+		t.Errorf("cycles = %d, want 0", len(h.triggers))
+	}
+}
+
+func TestApproveModeWaitsForCIThenApproves(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "LGTM body"}}
+	h.ci = []bool{false, false, true}
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.approvedWith) != 1 || h.approvedWith[0] != "LGTM body" {
+		t.Errorf("approvals = %v, want the retained LGTM body", h.approvedWith)
+	}
+	if len(h.triggers) != 1 {
+		t.Errorf("cycles = %d, want 1 (CI wait must not consume review runs)", len(h.triggers))
+	}
+}
+
+func TestNewCommitInvalidatesPendingApproval(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		open("aaa"), // CI not green yet
+		open("bbb"), // new commit invalidates pending approval
+	}
+	h.cycles = []Cycle{
+		{Result: CycleLGTMCommentCIPending, LGTMBody: "stale"},
+		{Result: CycleLGTMApproved},
+	}
+	h.ci = []bool{false}
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), h.deps())
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.approvedWith) != 0 {
+		t.Errorf("stale approval posted: %v", h.approvedWith)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "commits settled" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+}
+
+func TestInterruptDuringWatch(t *testing.T) {
+	h := newHarness(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	h.cancel = cancel
+	h.cancelAfterCycle = 1
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+
+	if reason := Run(ctx, defaultConfig(PostModeComment), h.deps()); reason != ReasonInterrupted {
+		t.Fatalf("reason = %v, want ReasonInterrupted", reason)
+	}
+}
+
+func TestCommentModeCIPendingIsTerminal(t *testing.T) {
+	// Interactive mode: the user accepted the comment downgrade after the CI
+	// prompt; that is a posted LGTM and must be terminal.
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "x"}}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeInteractive), h.deps()); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.approvedWith) != 0 {
+		t.Errorf("no approval should be posted outside approve mode: %v", h.approvedWith)
+	}
+}
+
+func TestStateErrorsAreToleratedThenFatal(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	deps := h.deps()
+	stateCalls := 0
+	deps.State = func(ctx context.Context) (PRState, error) {
+		stateCalls++
+		if stateCalls == 1 {
+			return open("aaa"), nil
+		}
+		return PRState{}, errors.New("transient gh failure")
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), deps); reason != ReasonError {
+		t.Fatalf("reason = %v, want ReasonError after repeated poll failures", reason)
+	}
+	if stateCalls != 1+maxConsecutivePollErrors {
+		t.Errorf("state calls = %d, want %d", stateCalls, 1+maxConsecutivePollErrors)
+	}
+}
+
+func TestParsePostMode(t *testing.T) {
+	for _, valid := range []string{"interactive", "comment", "approve"} {
+		if _, err := ParsePostMode(valid); err != nil {
+			t.Errorf("ParsePostMode(%q) error: %v", valid, err)
+		}
+	}
+	for _, invalid := range []string{"", "auto", "yes", "Interactive"} {
+		if _, err := ParsePostMode(invalid); err == nil {
+			t.Errorf("ParsePostMode(%q) should fail", invalid)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements #188: `acr watch` runs a review against one PR, posts the result per an explicit `--post-mode` policy, then keeps watching the PR and re-reviews until a terminal LGTM is posted or a safety bound is reached.

```bash
acr watch                                  # interactive, current branch's PR
acr watch --pr 123 --post-mode comment     # unattended, comment reviews only
acr watch --pr 123 --post-mode approve     # unattended, approves once CI is green
```

## Design

- **`internal/watch`** — the loop is a state machine with every effect injected (clock, PR state, review cycle, CI check, approve), so polling, settle debounce, and bounds are tested deterministically with a fake clock (16 loop tests, no sleeps).
- **Triggers** — a re-review request for the authenticated `gh` user fires on the next poll (rising-edge detection so a consumed request can't re-trigger); new commits start the `--settle-time` quiet period (default 10m), restarted by each push.
- **Post modes** — `interactive` (default; requires a TTY at startup, declining an LGTM ends the watch cleanly with exit 0), `comment` (comment reviews only — structurally unable to request changes or approve; skips the pre-approval CI check), `approve` (existing `--yes` rules; a non-green-CI LGTM posts the comment downgrade once, then the watch polls CI and approves when green for the same head; new commits invalidate the pending approval; the CI wait consumes no review runs).
- **Fresh worktree per cycle** — every cycle fetches the PR head into a new temporary worktree and re-resolves config, so the watch never reviews stale state.
- **Flag surface** — review flags are registered via a shared helper; `--yes`, `--local`, and `--worktree-branch` remain root-only, so `acr watch` rejects them with a usage error.
- **Config** — `watch.poll_interval` / `settle_time` / `max_reviews` / `max_duration` in `.acr.yaml` with flag > config > default precedence; the post mode is deliberately flag-only.
- **Bounds & exits** — max-reviews (default 10), max-duration (default 24h), PR closed/merged, and signals all exit cleanly; safety bounds exit non-zero. Exit codes documented in `acr watch --help`.
- **One-shot review behavior is unchanged** — the post-mode policy and outcome recording are layered onto the existing submission flow behind new opt-in fields.

## Acceptance criteria from #188

All checked: initial review runs immediately; interactive is the default and errors without a TTY; declined LGTM exits cleanly; comment mode can only comment and never CI-checks; approve mode keeps watching until a real approval; new commits during the CI wait invalidate the pending approval; `--yes`/`--local`/`-B` are usage errors; only the authenticated user's re-review requests trigger; settle debounce restarts per push; pacing/bounds configurable with the specified defaults; consumed requests and unchanged heads never re-trigger; terminal/bound/closed/merged/signal exits handled; watch-loop tests use injectable GitHub state and time.

## Testing

- `make check` green (fmt, lint, vet, staticcheck, unit tests).
- Integration suite passes on a plain checkout. (`TestVersion` fails only inside a linked git worktree because Go's VCS stamping can't resolve tags there — environmental, not from this change.)
- Live smoke test: `acr watch --pr 189 --post-mode comment` against the merged doc PR resolved state via `gh` and exited 0 with "PR merged; stopping watch" without spawning agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015otXszWuogekKEyvbeDqRF