### PR TITLE
[P1] Enforce trusted review-configuration sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Optional:
 
 | Tool | Installation | Purpose |
 |------|--------------|---------|
-| gh CLI | [cli.github.com](https://cli.github.com) | Post reviews to GitHub PRs |
+| gh CLI | [cli.github.com](https://cli.github.com) | GitHub PR operations and canonical selection in multi-remote repositories |
 
 ## How It Works
 
@@ -151,6 +151,13 @@ the canonical remote default branch. When no canonical remote is configured,
 ACR uses the local `main` commit; when neither exists, it uses built-in
 defaults. A `.acr.yaml` from the current target, PR head, or temporary review
 worktree is never allowed to configure the review evaluating that code.
+
+Trusted remote snapshots use an ACR-owned ref namespace, so refreshing review
+configuration cannot advance or rewind the remote-tracking ref used for the
+review diff. In a repository with multiple remotes, ACR uses `gh` repository
+identity to select the matching canonical fetch remote and fails closed when
+that identity is unavailable or ambiguous. Use `--no-config` to run without a
+repository policy source; ACR never guesses among multiple remotes.
 
 Repository-relative inputs such as `guidance_file` are read from the same
 immutable canonical commit. Invalid trusted configuration or an unavailable

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ acr
 
 ## Prerequisites
 
+Git 2.29 or newer is required. ACR checks this floor before isolated
+trusted-configuration fetches and reports the installed version when it is too
+old.
+
 You need **at least one** of the following LLM CLIs installed and authenticated:
 
 | Agent | Installation |
@@ -229,10 +233,11 @@ Every cycle fetches the PR head into a fresh temporary worktree, so local
 branch state never goes stale mid-watch. Review configuration is independently
 refreshed and snapshotted from the canonical remote default branch; neither the
 launch checkout nor the PR worktree supplies `.acr.yaml` or relative guidance.
-Trusted-configuration preparation failures are retried on the watch poll
-interval up to five consecutive attempts and do not consume the review budget.
-Startup uses the explicit `--poll-interval`, or the default interval until the
-trusted configuration snapshot is available.
+Startup gives trusted-source preparation and trusted config/guidance loading a
+shared five-attempt retry budget. Retry pacing follows `--poll-interval`,
+`ACR_WATCH_POLL_INTERVAL`, a safely parsed canonical config value, then the
+built-in default. During an active watch, transient source-refresh failures are
+retryable without consuming review budget; invalid loaded policy fails fast.
 If the PR head moves while a review is running, the result is discarded instead
 of posted, and the new head is re-reviewed after the settle period.
 
@@ -360,6 +365,7 @@ PR feedback summarization runs in parallel with the reviewers and is enabled by 
 | `ACR_FP_FILTER_TIMEOUT`   | Timeout for false positive filter phase (e.g., "5m" or "300") |
 | `ACR_GUIDANCE`            | Steering context appended to review prompt |
 | `ACR_GUIDANCE_FILE`       | Path to file containing review guidance    |
+| `ACR_WATCH_POLL_INTERVAL` | Watch polling and startup retry interval (e.g., "1m") |
 
 ## Configuration
 
@@ -403,6 +409,7 @@ Configuration is resolved with the following precedence (highest to lowest):
 ### Behavior
 
 - Review commands load the config file from an immutable canonical/default-branch snapshot, never from the code being reviewed
+- Reviewer agents run in the reviewed checkout, while aggregation, feedback, and false-positive-filter agents run in isolated ACR-owned directories so reviewed instruction files cannot steer post-processing
 - Missing config file is not an error (empty defaults used)
 - Invalid YAML or regex patterns produce an error
 - Unknown keys in config file produce a warning with "did you mean?" suggestions

--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ worktree is never allowed to configure the review evaluating that code.
 Repository-relative inputs such as `guidance_file` are read from the same
 immutable canonical commit. Invalid trusted configuration or an unavailable
 trusted relative input stops the review rather than falling back to target
-files. Use `--no-config` to explicitly disable repository configuration while
-retaining CLI and environment overrides.
+files. Paths declared by repository configuration must remain relative to that
+repository; absolute and escaping paths are rejected. Repository symlinks are
+resolved only within the same immutable commit. Use `--no-config` to explicitly
+disable repository configuration while retaining CLI and environment overrides.
 
 `--no-fetch` controls fetching the base ref used to produce the review diff.
 It does not disable the independent refresh that selects and snapshots trusted
@@ -222,6 +224,8 @@ refreshed and snapshotted from the canonical remote default branch; neither the
 launch checkout nor the PR worktree supplies `.acr.yaml` or relative guidance.
 Trusted-configuration preparation failures are retried on the watch poll
 interval up to five consecutive attempts and do not consume the review budget.
+Startup uses the explicit `--poll-interval`, or the default interval until the
+trusted configuration snapshot is available.
 If the PR head moves while a review is running, the result is discarded instead
 of posted, and the new head is re-reviewed after the settle period.
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Every cycle fetches the PR head into a fresh temporary worktree, so local
 branch state never goes stale mid-watch. Review configuration is independently
 refreshed and snapshotted from the canonical remote default branch; neither the
 launch checkout nor the PR worktree supplies `.acr.yaml` or relative guidance.
+Trusted-configuration preparation failures are retried on the watch poll
+interval up to five consecutive attempts and do not consume the review budget.
 If the PR head moves while a review is running, the result is discarded instead
 of posted, and the new head is re-reviewed after the settle period.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ acr --verbose
 | `--local`           | `-l`  | false   | Skip posting to GitHub PR                |
 | `--worktree-branch` | `-B`  |         | Review a branch in a temp worktree (supports `user:branch` for forks) |
 | `--yes`             | `-y`  | false   | Auto-submit without prompting            |
-| `--fetch/--no-fetch`|       | true    | Fetch base ref from origin before diff   |
+| `--fetch/--no-fetch`|       | true    | Fetch the review base ref before diffing |
 | `--no-fp-filter`    |       | false   | Disable false positive filtering          |
 | `--fp-threshold`    |       | 75      | False positive confidence threshold 1-100 |
 | `--no-pr-feedback`  |       | false   | Disable PR feedback summarization         |
@@ -137,11 +137,30 @@ acr --verbose
 | `--guidance-file`   |       |         | Path to file containing review guidance (env: ACR_GUIDANCE_FILE) |
 | `--ref-file`        |       | false   | Write diff to temp file instead of embedding in prompt (auto for large diffs) |
 | `--exclude-pattern` |       |         | Exclude findings matching regex (repeat)  |
-| `--no-config`       |       | false   | Skip loading .acr.yaml config file        |
+| `--no-config`       |       | false   | Disable repository `.acr.yaml` for this review |
 | `--reviewer-agent`  | `-a`  | codex   | Agent(s) for reviews, comma-separated (agy, codex, claude, gemini) |
 | `--summarizer-agent`| `-s`  | codex   | Agent for summarization (agy, codex, claude, gemini) |
 | `--reviewer-model`  |       |         | LLM model for review agents (env: ACR_REVIEWER_MODEL) |
 | `--summarizer-model`|       |         | LLM model for summarizer/FP filter agents (env: ACR_SUMMARIZER_MODEL) |
+
+### Trusted Review Configuration
+
+Every review entry point (`acr`, `acr --pr`, `acr --worktree-branch`, and
+`acr watch`) resolves repository configuration from an immutable snapshot of
+the canonical remote default branch. When no canonical remote is configured,
+ACR uses the local `main` commit; when neither exists, it uses built-in
+defaults. A `.acr.yaml` from the current target, PR head, or temporary review
+worktree is never allowed to configure the review evaluating that code.
+
+Repository-relative inputs such as `guidance_file` are read from the same
+immutable canonical commit. Invalid trusted configuration or an unavailable
+trusted relative input stops the review rather than falling back to target
+files. Use `--no-config` to explicitly disable repository configuration while
+retaining CLI and environment overrides.
+
+`--no-fetch` controls fetching the base ref used to produce the review diff.
+It does not disable the independent refresh that selects and snapshots trusted
+review configuration.
 
 ### Concurrency Control
 
@@ -198,11 +217,11 @@ A new review cycle starts when:
   once the head stops moving.
 
 Every cycle fetches the PR head into a fresh temporary worktree, so local
-branch state never goes stale mid-watch. Configuration (`.acr.yaml`) is read
-from the checkout the watch is launched from — never from the PR head — so
-run unattended watches from a trusted base-branch checkout. If the PR head
-moves while a review is running, the result is discarded instead of posted,
-and the new head is re-reviewed after the settle period.
+branch state never goes stale mid-watch. Review configuration is independently
+refreshed and snapshotted from the canonical remote default branch; neither the
+launch checkout nor the PR worktree supplies `.acr.yaml` or relative guidance.
+If the PR head moves while a review is running, the result is discarded instead
+of posted, and the new head is re-reviewed after the settle period.
 
 Post modes control what gets posted:
 
@@ -331,7 +350,8 @@ PR feedback summarization runs in parallel with the reviewers and is enabled by 
 
 ## Configuration
 
-Create `.acr.yaml` in your repository root to configure persistent settings:
+Create `.acr.yaml` in the root of the canonical branch to configure persistent
+review settings:
 
 ```yaml
 reviewers: 5
@@ -364,17 +384,18 @@ pr_feedback:
 Configuration is resolved with the following precedence (highest to lowest):
 1. CLI flags (e.g., `--reviewers 10`)
 2. Environment variables (e.g., `ACR_REVIEWERS=10`)
-3. Config file (`.acr.yaml`)
+3. Trusted canonical-branch config file (`.acr.yaml`)
 4. Built-in defaults
 
 ### Behavior
 
-- Config file is loaded from the git repository root
+- Review commands load the config file from an immutable canonical/default-branch snapshot, never from the code being reviewed
 - Missing config file is not an error (empty defaults used)
 - Invalid YAML or regex patterns produce an error
 - Unknown keys in config file produce a warning with "did you mean?" suggestions
 - CLI `--exclude-pattern` flags are merged with config patterns (union)
 - Use `--no-config` to skip loading the config file for a single run
+- `acr config show`, `acr config validate`, and `acr config init` operate on the working checkout for configuration management; `config show` is not necessarily the configuration snapshot an immediate review will use
 
 ## Exit Codes
 

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -30,8 +30,8 @@ func newConfigCmd() *cobra.Command {
 func newConfigShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show",
-		Short: "Display resolved configuration",
-		Long:  "Show the fully resolved configuration from defaults, config file, and environment variables.",
+		Short: "Display resolved working-checkout configuration",
+		Long:  "Show configuration-management state from defaults, the working checkout, and environment variables. Review commands independently snapshot canonical-branch configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := config.LoadWithWarnings()
 			if err != nil {
@@ -42,7 +42,7 @@ func newConfigShowCmd() *cobra.Command {
 
 			resolved := config.Resolve(result.Config, envState, config.FlagState{}, config.Defaults)
 
-			fmt.Println("Resolved configuration:")
+			fmt.Println("Resolved working-checkout configuration:")
 			fmt.Println()
 			fmt.Printf("  %-22s %d\n", "reviewers:", resolved.Reviewers)
 			fmt.Printf("  %-22s %d\n", "concurrency:", resolved.Concurrency)

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -149,6 +149,11 @@ func newConfigValidateCmd() *cobra.Command {
 				configDir = result.ConfigDir
 				warnings = append(warnings, result.Warnings...)
 			}
+			if cfg.GuidanceFile != nil && *cfg.GuidanceFile != "" {
+				if err := git.ValidateRepositoryPath(*cfg.GuidanceFile); err != nil {
+					errors = append(errors, fmt.Sprintf("guidance_file: %v", err))
+				}
+			}
 
 			envState, envWarnings := config.LoadEnvState()
 			errors = append(errors, envWarnings...)

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -137,7 +138,6 @@ func newConfigValidateCmd() *cobra.Command {
 			var warnings []string
 
 			cfg := &config.Config{}
-			configDir := ""
 			configFileError := false
 			result, err := config.LoadWithWarnings()
 			if err != nil {
@@ -146,7 +146,6 @@ func newConfigValidateCmd() *cobra.Command {
 			}
 			if result != nil {
 				cfg = result.Config
-				configDir = result.ConfigDir
 				warnings = append(warnings, result.Warnings...)
 			}
 			if cfg.GuidanceFile != nil && *cfg.GuidanceFile != "" {
@@ -166,7 +165,7 @@ func newConfigValidateCmd() *cobra.Command {
 			validationErrs := resolved.ValidateAll()
 			errors = append(errors, validationErrs...)
 
-			_, guidanceErr := config.ResolveGuidance(cfg, envState, config.FlagState{}, config.Defaults, configDir)
+			_, guidanceErr := config.ResolveGuidanceFromLoadResult(context.Background(), result, envState, config.FlagState{}, config.Defaults)
 			if guidanceErr != nil {
 				errors = append(errors, guidanceErr.Error())
 			}

--- a/cmd/acr/config_cmd_test.go
+++ b/cmd/acr/config_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -219,5 +220,55 @@ func TestConfigValidate_ValidGuidanceFile(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("expected valid guidance file to pass, got: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsNonRepositoryGuidancePaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(string, string) string
+	}{
+		{
+			name: "absolute",
+			path: func(_ string, guidancePath string) string {
+				return guidancePath
+			},
+		},
+		{
+			name: "escaping",
+			path: func(_ string, _ string) string {
+				return "../guidance.md"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			repositoryRoot := filepath.Join(root, "repository")
+			if err := os.MkdirAll(repositoryRoot, 0755); err != nil {
+				t.Fatal(err)
+			}
+			chdir(t, repositoryRoot)
+			initGitRepo(t, repositoryRoot)
+			guidancePath := filepath.Join(root, "guidance.md")
+			if err := os.WriteFile(guidancePath, []byte("review carefully"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(repositoryRoot, config.ConfigFileName)
+			configData := fmt.Sprintf("guidance_file: %q\n", tt.path(repositoryRoot, guidancePath))
+			if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := newConfigCmd()
+			buf := new(bytes.Buffer)
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetArgs([]string{"validate"})
+			if err := cmd.Execute(); err == nil {
+				t.Fatal("expected repository guidance path validation error")
+			}
+		})
 	}
 }

--- a/cmd/acr/config_cmd_test.go
+++ b/cmd/acr/config_cmd_test.go
@@ -272,3 +272,52 @@ func TestConfigValidateRejectsNonRepositoryGuidancePaths(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigValidateRejectsEscapingGuidanceSymlink(t *testing.T) {
+	root := t.TempDir()
+	repositoryRoot := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, repositoryRoot)
+	initGitRepo(t, repositoryRoot)
+	if err := os.WriteFile(filepath.Join(root, "guidance.md"), []byte("outside guidance"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../guidance.md", filepath.Join(repositoryRoot, "guidance.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryRoot, config.ConfigFileName), []byte("guidance_file: guidance.md\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"validate"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected escaping guidance symlink validation error")
+	}
+}
+
+func TestConfigValidateAcceptsRepositoryGuidanceSymlink(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	chdir(t, repositoryRoot)
+	initGitRepo(t, repositoryRoot)
+	if err := os.MkdirAll(filepath.Join(repositoryRoot, "guidance"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryRoot, "guidance", "review.md"), []byte("repository guidance"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("guidance/review.md", filepath.Join(repositoryRoot, "review.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryRoot, config.ConfigFileName), []byte("guidance_file: review.md\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"validate"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repository guidance symlink rejected: %v", err)
+	}
+}

--- a/cmd/acr/config_source.go
+++ b/cmd/acr/config_source.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/git"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+)
+
+func resolveTrustedReviewConfigSource(ctx context.Context, disabled bool) (config.Source, error) {
+	if disabled {
+		return config.ResolveTrustedSource(ctx, config.TrustedSourceRequest{Disabled: true})
+	}
+
+	repositoryRoot, err := git.GetRoot()
+	if err != nil {
+		return nil, err
+	}
+	remote := github.GetRepoRemote(ctx)
+	remoteExists, err := git.RemoteExists(ctx, repositoryRoot, remote)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect trusted review configuration remote: %w", err)
+	}
+	if remoteExists {
+		return config.ResolveTrustedSource(ctx, config.TrustedSourceRequest{
+			RepositoryRoot: repositoryRoot,
+			Remote:         remote,
+			Policy:         config.CanonicalRemoteDefault,
+		})
+	}
+	return config.ResolveTrustedSource(ctx, config.TrustedSourceRequest{
+		RepositoryRoot: repositoryRoot,
+		Branch:         "main",
+		Policy:         config.CanonicalNamedBranch,
+	})
+}

--- a/cmd/acr/config_source.go
+++ b/cmd/acr/config_source.go
@@ -18,12 +18,15 @@ func resolveTrustedReviewConfigSource(ctx context.Context, disabled bool) (confi
 	if err != nil {
 		return nil, err
 	}
-	remote := github.GetRepoRemote(ctx)
-	remoteExists, err := git.RemoteExists(ctx, repositoryRoot, remote)
+	remotes, err := git.Remotes(ctx, repositoryRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect trusted review configuration remote: %w", err)
 	}
-	if remoteExists {
+	remote, hasRemote, err := selectTrustedReviewConfigRemote(ctx, repositoryRoot, remotes)
+	if err != nil {
+		return nil, err
+	}
+	if hasRemote {
 		return config.ResolveTrustedSource(ctx, config.TrustedSourceRequest{
 			RepositoryRoot: repositoryRoot,
 			Remote:         remote,
@@ -35,4 +38,23 @@ func resolveTrustedReviewConfigSource(ctx context.Context, disabled bool) (confi
 		Branch:         "main",
 		Policy:         config.CanonicalNamedBranch,
 	})
+}
+
+func selectTrustedReviewConfigRemote(ctx context.Context, repositoryRoot string, remotes []string) (string, bool, error) {
+	if len(remotes) == 0 {
+		return "", false, nil
+	}
+	if len(remotes) == 1 {
+		return remotes[0], true, nil
+	}
+	remote, err := github.FindRepoRemote(ctx, repositoryRoot)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to select a canonical remote from %v: %w", remotes, err)
+	}
+	for _, configured := range remotes {
+		if configured == remote {
+			return remote, true, nil
+		}
+	}
+	return "", false, fmt.Errorf("selected canonical remote %q is not configured", remote)
 }

--- a/cmd/acr/config_source_test.go
+++ b/cmd/acr/config_source_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+)
+
+func TestResolveTrustedReviewConfigSourceUsesRemoteDefaultBranch(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	originRoot := filepath.Join(root, "origin.git")
+	seedRoot := filepath.Join(root, "seed")
+	workingRoot := filepath.Join(root, "working")
+	if err := os.MkdirAll(seedRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runConfigSourceGit(t, seedRoot, "init", "-b", "main")
+	runConfigSourceGit(t, seedRoot, "config", "user.email", "test@example.com")
+	runConfigSourceGit(t, seedRoot, "config", "user.name", "Test User")
+	writeReviewConfigSourceFile(t, seedRoot, config.ConfigFileName, "reviewers: 8\nguidance_file: guidance/review.md\n")
+	writeReviewConfigSourceFile(t, seedRoot, "guidance/review.md", "trusted guidance")
+	runConfigSourceGit(t, seedRoot, "add", ".")
+	runConfigSourceGit(t, seedRoot, "commit", "-m", "trusted")
+	runConfigSourceGit(t, root, "clone", "--bare", seedRoot, originRoot)
+	runConfigSourceGit(t, root, "clone", originRoot, workingRoot)
+	runConfigSourceGit(t, workingRoot, "checkout", "-b", "incoming")
+	writeReviewConfigSourceFile(t, workingRoot, config.ConfigFileName, "reviewers: [broken\n")
+	writeReviewConfigSourceFile(t, workingRoot, "guidance/review.md", "target guidance")
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(workingRoot); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalDir)
+
+	source, err := resolveTrustedReviewConfigSource(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := config.Resolve(result.Config, config.EnvState{}, config.FlagState{}, config.ResolvedConfig{})
+	if resolved.Reviewers != 8 {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+	guidance, err := config.ResolveGuidanceFromLoadResult(ctx, result, config.EnvState{}, config.FlagState{}, config.ResolvedConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if guidance != "trusted guidance" {
+		t.Fatalf("guidance = %q", guidance)
+	}
+	if result.Source.Ref != "origin/main" {
+		t.Fatalf("source ref = %q", result.Source.Ref)
+	}
+}
+
+func TestResolveTrustedReviewConfigSourceUsesLocalMainWithoutRemote(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := t.TempDir()
+	runConfigSourceGit(t, repositoryRoot, "init", "-b", "main")
+	runConfigSourceGit(t, repositoryRoot, "config", "user.email", "test@example.com")
+	runConfigSourceGit(t, repositoryRoot, "config", "user.name", "Test User")
+	writeReviewConfigSourceFile(t, repositoryRoot, config.ConfigFileName, "reviewers: 9\n")
+	runConfigSourceGit(t, repositoryRoot, "add", ".")
+	runConfigSourceGit(t, repositoryRoot, "commit", "-m", "trusted")
+	runConfigSourceGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writeReviewConfigSourceFile(t, repositoryRoot, config.ConfigFileName, "reviewers: 1\n")
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repositoryRoot); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalDir)
+
+	source, err := resolveTrustedReviewConfigSource(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := config.Resolve(result.Config, config.EnvState{}, config.FlagState{}, config.ResolvedConfig{})
+	if resolved.Reviewers != 9 {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+}
+
+func TestResolveTrustedReviewConfigSourceUsesDefaultsWithoutCanonicalBranch(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := t.TempDir()
+	runConfigSourceGit(t, repositoryRoot, "init", "-b", "feature")
+	runConfigSourceGit(t, repositoryRoot, "config", "user.email", "test@example.com")
+	runConfigSourceGit(t, repositoryRoot, "config", "user.name", "Test User")
+	writeReviewConfigSourceFile(t, repositoryRoot, config.ConfigFileName, "reviewers: 1\n")
+	runConfigSourceGit(t, repositoryRoot, "add", ".")
+	runConfigSourceGit(t, repositoryRoot, "commit", "-m", "target")
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repositoryRoot); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalDir)
+
+	source, err := resolveTrustedReviewConfigSource(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := config.Resolve(result.Config, config.EnvState{}, config.FlagState{}, config.ResolvedConfig{})
+	if resolved.Reviewers != config.Defaults.Reviewers {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+	if result.Source.Kind != config.SourceKindDefaults {
+		t.Fatalf("source = %+v", result.Source)
+	}
+}
+
+func TestResolveTrustedReviewConfigSourceAllowsExplicitExclusion(t *testing.T) {
+	ctx := context.Background()
+	source, err := resolveTrustedReviewConfigSource(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source.Kind != config.SourceKindDisabled {
+		t.Fatalf("source = %+v", result.Source)
+	}
+}
+
+func runConfigSourceGit(t *testing.T, directory string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = directory
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func writeReviewConfigSourceFile(t *testing.T, root, relativePath, content string) {
+	t.Helper()
+	filePath := filepath.Join(root, relativePath)
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/acr/config_source_test.go
+++ b/cmd/acr/config_source_test.go
@@ -154,7 +154,7 @@ func TestResolveTrustedReviewConfigSourceAllowsExplicitExclusion(t *testing.T) {
 	}
 }
 
-func TestPrepareReviewBaseDoesNotFetchWhenDisabled(t *testing.T) {
+func TestPrepareReviewBaseQualifiesWithoutFetchingWhenDisabled(t *testing.T) {
 	root := t.TempDir()
 	seedRoot := filepath.Join(root, "seed")
 	remoteRoot := filepath.Join(root, "origin.git")
@@ -178,8 +178,8 @@ func TestPrepareReviewBaseDoesNotFetchWhenDisabled(t *testing.T) {
 	runConfigSourceGit(t, seedRoot, "push", "origin", "main")
 
 	resolved := config.ResolvedConfig{Base: "main", Fetch: false}
-	prepareReviewBase(context.Background(), worktreeResult{prRemote: "origin", prRepoRoot: repositoryRoot}, &resolved, terminal.NewLogger())
-	if resolved.Base != "main" {
+	prepareReviewBase(context.Background(), worktreeResult{prRemote: "origin", prRepoRoot: repositoryRoot, baseAutoDetected: true}, &resolved, terminal.NewLogger())
+	if resolved.Base != "origin/main" {
 		t.Fatalf("base = %q", resolved.Base)
 	}
 	if got := configSourceGitOutput(t, repositoryRoot, "rev-parse", "refs/remotes/origin/main"); got != trackingRevision {

--- a/cmd/acr/config_source_test.go
+++ b/cmd/acr/config_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
 )
 
-func TestResolveTrustedReviewConfigSourceUsesRemoteDefaultBranch(t *testing.T) {
+func TestResolveTrustedReviewConfigSourceUsesSoleConfiguredRemoteDefaultBranch(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	originRoot := filepath.Join(root, "origin.git")
@@ -28,6 +28,7 @@ func TestResolveTrustedReviewConfigSourceUsesRemoteDefaultBranch(t *testing.T) {
 	runConfigSourceGit(t, seedRoot, "commit", "-m", "trusted")
 	runConfigSourceGit(t, root, "clone", "--bare", seedRoot, originRoot)
 	runConfigSourceGit(t, root, "clone", originRoot, workingRoot)
+	runConfigSourceGit(t, workingRoot, "remote", "rename", "origin", "upstream")
 	runConfigSourceGit(t, workingRoot, "checkout", "-b", "incoming")
 	writeReviewConfigSourceFile(t, workingRoot, config.ConfigFileName, "reviewers: [broken\n")
 	writeReviewConfigSourceFile(t, workingRoot, "guidance/review.md", "target guidance")
@@ -60,7 +61,7 @@ func TestResolveTrustedReviewConfigSourceUsesRemoteDefaultBranch(t *testing.T) {
 	if guidance != "trusted guidance" {
 		t.Fatalf("guidance = %q", guidance)
 	}
-	if result.Source.Ref != "origin/main" {
+	if result.Source.Ref != "upstream/main" {
 		t.Fatalf("source ref = %q", result.Source.Ref)
 	}
 }

--- a/cmd/acr/config_source_test.go
+++ b/cmd/acr/config_source_test.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
 
 func TestResolveTrustedReviewConfigSourceUsesSoleConfiguredRemoteDefaultBranch(t *testing.T) {
@@ -61,7 +63,7 @@ func TestResolveTrustedReviewConfigSourceUsesSoleConfiguredRemoteDefaultBranch(t
 	if guidance != "trusted guidance" {
 		t.Fatalf("guidance = %q", guidance)
 	}
-	if result.Source.Ref != "refs/remotes/upstream/main" {
+	if result.Source.Ref != "refs/acr/trusted-config/upstream/main" {
 		t.Fatalf("source ref = %q", result.Source.Ref)
 	}
 }
@@ -152,6 +154,39 @@ func TestResolveTrustedReviewConfigSourceAllowsExplicitExclusion(t *testing.T) {
 	}
 }
 
+func TestPrepareReviewBaseDoesNotFetchWhenDisabled(t *testing.T) {
+	root := t.TempDir()
+	seedRoot := filepath.Join(root, "seed")
+	remoteRoot := filepath.Join(root, "origin.git")
+	repositoryRoot := filepath.Join(root, "working")
+	if err := os.MkdirAll(seedRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runConfigSourceGit(t, seedRoot, "init", "-b", "main")
+	runConfigSourceGit(t, seedRoot, "config", "user.email", "test@example.com")
+	runConfigSourceGit(t, seedRoot, "config", "user.name", "Test User")
+	writeReviewConfigSourceFile(t, seedRoot, "tracked.txt", "initial")
+	runConfigSourceGit(t, seedRoot, "add", ".")
+	runConfigSourceGit(t, seedRoot, "commit", "-m", "initial")
+	runConfigSourceGit(t, root, "clone", "--bare", seedRoot, remoteRoot)
+	runConfigSourceGit(t, root, "clone", remoteRoot, repositoryRoot)
+	trackingRevision := configSourceGitOutput(t, repositoryRoot, "rev-parse", "refs/remotes/origin/main")
+	runConfigSourceGit(t, seedRoot, "remote", "add", "origin", remoteRoot)
+	writeReviewConfigSourceFile(t, seedRoot, "tracked.txt", "updated")
+	runConfigSourceGit(t, seedRoot, "add", "tracked.txt")
+	runConfigSourceGit(t, seedRoot, "commit", "-m", "updated")
+	runConfigSourceGit(t, seedRoot, "push", "origin", "main")
+
+	resolved := config.ResolvedConfig{Base: "main", Fetch: false}
+	prepareReviewBase(context.Background(), worktreeResult{prRemote: "origin", prRepoRoot: repositoryRoot}, &resolved, terminal.NewLogger())
+	if resolved.Base != "main" {
+		t.Fatalf("base = %q", resolved.Base)
+	}
+	if got := configSourceGitOutput(t, repositoryRoot, "rev-parse", "refs/remotes/origin/main"); got != trackingRevision {
+		t.Fatalf("remote-tracking ref moved from %s to %s", trackingRevision, got)
+	}
+}
+
 func runConfigSourceGit(t *testing.T, directory string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -159,6 +194,17 @@ func runConfigSourceGit(t *testing.T, directory string, args ...string) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
+}
+
+func configSourceGitOutput(t *testing.T, directory string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = directory
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func writeReviewConfigSourceFile(t *testing.T, root, relativePath, content string) {

--- a/cmd/acr/config_source_test.go
+++ b/cmd/acr/config_source_test.go
@@ -61,7 +61,7 @@ func TestResolveTrustedReviewConfigSourceUsesSoleConfiguredRemoteDefaultBranch(t
 	if guidance != "trusted guidance" {
 		t.Fatalf("guidance = %q", guidance)
 	}
-	if result.Source.Ref != "upstream/main" {
+	if result.Source.Ref != "refs/remotes/upstream/main" {
 		t.Fatalf("source ref = %q", result.Source.Ref)
 	}
 }

--- a/cmd/acr/helpers.go
+++ b/cmd/acr/helpers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
@@ -43,4 +44,11 @@ func exitCode(code domain.ExitCode) error {
 		return nil
 	}
 	return exitCodeError{code: code}
+}
+
+func contextualExit(ctx context.Context, fallback error) error {
+	if ctx.Err() != nil {
+		return exitCode(domain.ExitInterrupted)
+	}
+	return fallback
 }

--- a/cmd/acr/helpers_test.go
+++ b/cmd/acr/helpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -126,6 +127,20 @@ func TestExitCode_ReturnsErrorForOtherCodes(t *testing.T) {
 		if exitErr.code != code {
 			t.Errorf("expected code %d, got %d", code, exitErr.code)
 		}
+	}
+}
+
+func TestContextualExitUsesInterruptedCodeAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := contextualExit(ctx, exitCode(domain.ExitError))
+	exitErr, ok := err.(exitCodeError)
+	if !ok {
+		t.Fatalf("error type = %T, want exitCodeError", err)
+	}
+	if exitErr.code != domain.ExitInterrupted {
+		t.Fatalf("exit code = %d, want %d", exitErr.code, domain.ExitInterrupted)
 	}
 }
 

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -391,7 +391,7 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 
 	if wt.prRemote != "" && git.ShouldQualifyBaseRef(resolved.Base, wt.baseAutoDetected) {
 
-		if err := git.FetchBaseRef(wt.prRepoRoot, wt.prRemote, resolved.Base); err != nil {
+		if err := git.FetchBaseRef(ctx, wt.prRepoRoot, wt.prRemote, resolved.Base); err != nil {
 			logger.Logf(terminal.StyleWarning, "Could not fetch base ref: %v", err)
 
 		} else {

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -208,7 +208,11 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 		}
 		result.prRepoRoot = repoRoot
 
-		remote := github.GetRepoRemote(ctx)
+		remote, err := github.FindRepoRemote(ctx, repoRoot)
+		if err != nil {
+			logger.Logf(terminal.StyleError, "Failed to select PR fetch remote: %v", err)
+			return result, exitCode(domain.ExitError)
+		}
 		result.prRemote = remote
 
 		wt, err := git.CreateWorktreeFromPR(repoRoot, remote, prNumber)

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -456,7 +456,7 @@ func runReview(cmd *cobra.Command, _ []string) error {
 	configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
 	if err != nil {
 		logger.Logf(terminal.StyleError, "%v", err)
-		return exitCode(domain.ExitError)
+		return contextualExit(ctx, exitCode(domain.ExitError))
 	}
 
 	wt, err := setupWorktree(ctx, cmd, logger)
@@ -469,7 +469,7 @@ func runReview(cmd *cobra.Command, _ []string) error {
 
 	cfgResult, err := loadAndResolveConfig(ctx, cmd, wt, configSource, logger)
 	if err != nil {
-		return err
+		return contextualExit(ctx, err)
 	}
 
 	detectedPR := prNumber

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -420,17 +420,18 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 }
 
 func prepareReviewBase(ctx context.Context, wt worktreeResult, resolved *config.ResolvedConfig, logger *terminal.Logger) {
-	if wt.prRemote == "" || !resolved.Fetch || !git.ShouldQualifyBaseRef(resolved.Base, wt.baseAutoDetected) {
+	if wt.prRemote == "" || !git.ShouldQualifyBaseRef(resolved.Base, wt.baseAutoDetected) {
 		return
 	}
 
-	if err := git.FetchBaseRef(ctx, wt.prRepoRoot, wt.prRemote, resolved.Base); err != nil {
-		logger.Logf(terminal.StyleWarning, "Could not fetch base ref: %v", err)
-
-	} else {
-
-		resolved.Base = git.QualifyBaseRef(wt.prRemote, resolved.Base)
+	if resolved.Fetch {
+		if err := git.FetchBaseRef(ctx, wt.prRepoRoot, wt.prRemote, resolved.Base); err != nil {
+			logger.Logf(terminal.StyleWarning, "Could not fetch base ref: %v", err)
+			return
+		}
 	}
+
+	resolved.Base = git.QualifyBaseRef(wt.prRemote, resolved.Base)
 }
 
 func runReview(cmd *cobra.Command, _ []string) error {

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -305,14 +305,18 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 
 	var cfg *config.Config
 	var loadResult *config.LoadResult
+	result := configResult{}
 	if source == nil {
 		logger.Log("Config error: no trusted review configuration source was selected", terminal.StyleError)
-		return configResult{}, exitCode(domain.ExitError)
+		return result, exitCode(domain.ExitError)
 	}
 	loaded, err := source.LoadWithWarnings(ctx)
+	if loaded != nil {
+		result.resolved.WatchPollInterval = resolveWatchPollInterval(cmd, loaded.Config)
+	}
 	if err != nil {
 		logger.Logf(terminal.StyleError, "Config error: %v", err)
-		return configResult{}, exitCode(domain.ExitError)
+		return result, exitCode(domain.ExitError)
 	}
 	loadResult = loaded
 	cfg = loaded.Config
@@ -388,11 +392,12 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 	}
 
 	resolved := config.Resolve(cfg, envState, flagState, flagValues)
+	result.resolved = resolved
 	prepareReviewBase(ctx, wt, &resolved, logger)
 
 	if err := resolved.Validate(); err != nil {
 		logger.Logf(terminal.StyleError, "%v", err)
-		return configResult{}, exitCode(domain.ExitError)
+		return result, exitCode(domain.ExitError)
 	}
 
 	if resolved.Concurrency <= 0 {
@@ -407,16 +412,25 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 	resolvedGuidance, err := config.ResolveGuidanceFromLoadResult(ctx, loadResult, envState, flagState, flagValues)
 	if err != nil {
 		logger.Logf(terminal.StyleError, "Failed to resolve guidance: %v", err)
-		return configResult{}, exitCode(domain.ExitError)
+		result.resolved = resolved
+		return result, exitCode(domain.ExitError)
 	}
 	resolved.Guidance = resolvedGuidance
 
-	result := configResult{
-		resolved:        resolved,
-		excludePatterns: allExcludePatterns,
-	}
+	result.resolved = resolved
+	result.excludePatterns = allExcludePatterns
 	result.source = loadResult.Source
 	return result, nil
+}
+
+func resolveWatchPollInterval(cmd *cobra.Command, cfg *config.Config) time.Duration {
+	envState, _ := config.LoadEnvState()
+	return config.Resolve(
+		cfg,
+		envState,
+		config.FlagState{WatchPollIntervalSet: cmd.Flags().Changed("poll-interval")},
+		config.ResolvedConfig{WatchPollInterval: watchPollInterval},
+	).WatchPollInterval
 }
 
 func prepareReviewBase(ctx context.Context, wt worktreeResult, resolved *config.ResolvedConfig, logger *terminal.Logger) {

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -313,6 +313,9 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 	loaded, err := source.LoadWithWarnings(ctx)
 	if loaded != nil {
 		result.resolved.WatchPollInterval = resolveWatchPollInterval(cmd, loaded.Config)
+		for _, warning := range loaded.Warnings {
+			logger.Logf(terminal.StyleWarning, "Warning: %s", warning)
+		}
 	}
 	if err != nil {
 		logger.Logf(terminal.StyleError, "Config error: %v", err)
@@ -320,10 +323,6 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 	}
 	loadResult = loaded
 	cfg = loaded.Config
-
-	for _, warning := range loaded.Warnings {
-		logger.Logf(terminal.StyleWarning, "Warning: %s", warning)
-	}
 	if verbose {
 		logger.Logf(terminal.StyleDim, "Review configuration source: %s %s %s", loaded.Source.Kind, loaded.Source.Ref, loaded.Source.Revision)
 	}

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -117,7 +117,7 @@ func registerSharedReviewFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&fetch, "fetch", true,
 		"Fetch latest base ref from origin before diff (default: true, env: ACR_FETCH)")
 	cmd.Flags().BoolVar(&noFetch, "no-fetch", false,
-		"Disable fetching base ref from origin (use local state)")
+		"Disable fetching the review base ref; trusted config refresh still runs")
 	cmd.Flags().StringVar(&guidance, "guidance", "",
 		"Steering context appended to the review prompt (env: ACR_GUIDANCE)")
 	cmd.Flags().StringVar(&guidanceFile, "guidance-file", "",
@@ -130,7 +130,7 @@ func registerSharedReviewFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVar(&excludePatterns, "exclude-pattern", nil,
 		"Exclude findings matching regex pattern (repeatable)")
 	cmd.Flags().BoolVar(&noConfig, "no-config", false,
-		"Skip loading .acr.yaml config file")
+		"Disable trusted repository .acr.yaml for this review")
 	cmd.Flags().StringVarP(&agentName, "reviewer-agent", "a", "codex",
 		"Agent(s) for reviews (comma-separated): agy, codex, claude, gemini (env: ACR_REVIEWER_AGENT)")
 	cmd.Flags().StringVarP(&summarizerAgentName, "summarizer-agent", "s", "codex",
@@ -298,30 +298,30 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 type configResult struct {
 	resolved        config.ResolvedConfig
 	excludePatterns []string
+	source          config.SourceIdentity
 }
 
-func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *terminal.Logger) (configResult, error) {
+func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeResult, source config.Source, logger *terminal.Logger) (configResult, error) {
 
 	var cfg *config.Config
-	var configDir string
-	if !noConfig {
-		var result *config.LoadResult
-		var err error
-		if wt.workDir != "" {
-			result, err = config.LoadFromDirWithWarnings(wt.workDir)
-		} else {
-			result, err = config.LoadWithWarnings()
-		}
-		if err != nil {
-			logger.Logf(terminal.StyleError, "Config error: %v", err)
-			return configResult{}, exitCode(domain.ExitError)
-		}
-		cfg = result.Config
-		configDir = result.ConfigDir
+	var loadResult *config.LoadResult
+	if source == nil {
+		logger.Log("Config error: no trusted review configuration source was selected", terminal.StyleError)
+		return configResult{}, exitCode(domain.ExitError)
+	}
+	loaded, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "Config error: %v", err)
+		return configResult{}, exitCode(domain.ExitError)
+	}
+	loadResult = loaded
+	cfg = loaded.Config
 
-		for _, warning := range result.Warnings {
-			logger.Logf(terminal.StyleWarning, "Warning: %s", warning)
-		}
+	for _, warning := range loaded.Warnings {
+		logger.Logf(terminal.StyleWarning, "Warning: %s", warning)
+	}
+	if verbose {
+		logger.Logf(terminal.StyleDim, "Review configuration source: %s %s %s", loaded.Source.Kind, loaded.Source.Ref, loaded.Source.Revision)
 	}
 
 	fetchFlagSet := cmd.Flags().Changed("fetch") || cmd.Flags().Changed("no-fetch")
@@ -414,17 +414,19 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 
 	allExcludePatterns := config.Merge(cfg, excludePatterns)
 
-	resolvedGuidance, err := config.ResolveGuidance(cfg, envState, flagState, flagValues, configDir)
+	resolvedGuidance, err := config.ResolveGuidanceFromLoadResult(ctx, loadResult, envState, flagState, flagValues)
 	if err != nil {
 		logger.Logf(terminal.StyleError, "Failed to resolve guidance: %v", err)
 		return configResult{}, exitCode(domain.ExitError)
 	}
 	resolved.Guidance = resolvedGuidance
 
-	return configResult{
+	result := configResult{
 		resolved:        resolved,
 		excludePatterns: allExcludePatterns,
-	}, nil
+	}
+	result.source = loadResult.Source
+	return result, nil
 }
 
 func runReview(cmd *cobra.Command, _ []string) error {
@@ -451,6 +453,12 @@ func runReview(cmd *cobra.Command, _ []string) error {
 		cancel()
 	}()
 
+	configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "%v", err)
+		return exitCode(domain.ExitError)
+	}
+
 	wt, err := setupWorktree(ctx, cmd, logger)
 	if err != nil {
 		return err
@@ -459,7 +467,7 @@ func runReview(cmd *cobra.Command, _ []string) error {
 		defer wt.cleanup()
 	}
 
-	cfgResult, err := loadAndResolveConfig(cmd, wt, logger)
+	cfgResult, err := loadAndResolveConfig(ctx, cmd, wt, configSource, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -321,6 +321,10 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 		logger.Logf(terminal.StyleError, "Config error: %v", err)
 		return result, exitCode(domain.ExitError)
 	}
+	if loaded == nil {
+		logger.Log("Config error: trusted review configuration source returned no result", terminal.StyleError)
+		return result, exitCode(domain.ExitError)
+	}
 	loadResult = loaded
 	cfg = loaded.Config
 	if verbose {

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -388,17 +388,7 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 	}
 
 	resolved := config.Resolve(cfg, envState, flagState, flagValues)
-
-	if wt.prRemote != "" && git.ShouldQualifyBaseRef(resolved.Base, wt.baseAutoDetected) {
-
-		if err := git.FetchBaseRef(ctx, wt.prRepoRoot, wt.prRemote, resolved.Base); err != nil {
-			logger.Logf(terminal.StyleWarning, "Could not fetch base ref: %v", err)
-
-		} else {
-
-			resolved.Base = git.QualifyBaseRef(wt.prRemote, resolved.Base)
-		}
-	}
+	prepareReviewBase(ctx, wt, &resolved, logger)
 
 	if err := resolved.Validate(); err != nil {
 		logger.Logf(terminal.StyleError, "%v", err)
@@ -427,6 +417,20 @@ func loadAndResolveConfig(ctx context.Context, cmd *cobra.Command, wt worktreeRe
 	}
 	result.source = loadResult.Source
 	return result, nil
+}
+
+func prepareReviewBase(ctx context.Context, wt worktreeResult, resolved *config.ResolvedConfig, logger *terminal.Logger) {
+	if wt.prRemote == "" || !resolved.Fetch || !git.ShouldQualifyBaseRef(resolved.Base, wt.baseAutoDetected) {
+		return
+	}
+
+	if err := git.FetchBaseRef(ctx, wt.prRepoRoot, wt.prRemote, resolved.Base); err != nil {
+		logger.Logf(terminal.StyleWarning, "Could not fetch base ref: %v", err)
+
+	} else {
+
+		resolved.Base = git.QualifyBaseRef(wt.prRemote, resolved.Base)
+	}
 }
 
 func runReview(cmd *cobra.Command, _ []string) error {

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -142,7 +142,10 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			feedbackCtx, feedbackCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 			defer feedbackCancel()
 
-			summary, err := summarizer.Summarize(feedbackCtx, opts.DetectedPR)
+			summary, err := summarizer.SummarizeFromDir(feedbackCtx, opts.DetectedPR, opts.WorkDir)
+			if summary != "" {
+				priorFeedback = summary
+			}
 			if err != nil {
 
 				if ctx.Err() != nil {
@@ -161,11 +164,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			} else {
 				logger.Log("No relevant PR feedback found", terminal.StyleDim)
 			}
-			priorFeedback = summary
 		}()
 	}
 
 	results, wallClock, err := r.Run(ctx)
+	if !opts.Verbose {
+		for _, result := range results {
+			for _, warning := range result.Warnings {
+				logger.Logf(terminal.StyleWarning, "Reviewer #%d: %s", result.ReviewerID, warning.Message)
+			}
+		}
+	}
 	if err != nil {
 		if ctx.Err() != nil {
 			return domain.ExitInterrupted
@@ -194,9 +203,14 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 	summarizerCtx, summarizerCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 	defer summarizerCancel()
-	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, opts.SummarizerModel, aggregated, opts.Verbose, logger)
+	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, opts.SummarizerModel, aggregated, opts.WorkDir, opts.Verbose, logger)
 	spinnerCancel()
 	<-spinnerDone
+	if summaryResult != nil && !opts.Verbose {
+		for _, warning := range summaryResult.Warnings {
+			logger.Log(warning, terminal.StyleWarning)
+		}
+	}
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -227,7 +241,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 		fpCtx, fpCancel := context.WithTimeout(ctx, opts.FPFilterTimeout)
 		defer fpCancel()
-		fpFilter := fpfilter.New(opts.SummarizerAgent, opts.SummarizerModel, opts.FPThreshold, opts.Verbose, logger)
+		fpFilter := fpfilter.New(opts.SummarizerAgent, opts.SummarizerModel, opts.FPThreshold, opts.WorkDir, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, priorFeedback, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone
@@ -236,6 +250,11 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			logger.Logf(terminal.StyleWarning, "FP filter skipped (%s): showing all findings", fpResult.SkipReason)
 		}
 		if fpResult != nil {
+			if !opts.Verbose {
+				for _, warning := range fpResult.Warnings {
+					logger.Log(warning, terminal.StyleWarning)
+				}
+			}
 			summaryResult.Grouped = fpResult.Grouped
 			fpFilteredCount = fpResult.RemovedCount
 			stats.FPFilterDuration = fpResult.Duration

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -100,6 +100,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		logger.Logf(terminal.StyleDim, "Diff size: %d bytes", len(diff))
 	}
 
+	postProcessDir, cleanupPostProcessDir, err := agent.NewIsolatedWorkDir()
+	if err != nil {
+		logger.Logf(terminal.StyleError, "Failed to create isolated post-processing workspace: %v", err)
+		return domain.ExitError
+	}
+	defer cleanupPostProcessDir()
+
 	diffPrecomputed := agent.AgentsNeedDiff(reviewAgents)
 
 	if opts.Verbose && opts.UseRefFile {
@@ -126,7 +133,22 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 	var priorFeedback string
 	var feedbackWg sync.WaitGroup
+	feedbackParentCtx, feedbackCancel := context.WithCancel(ctx)
+	var cleanupFeedbackDir func()
+	defer func() {
+		feedbackCancel()
+		feedbackWg.Wait()
+		if cleanupFeedbackDir != nil {
+			cleanupFeedbackDir()
+		}
+	}()
 	if opts.PRFeedbackEnabled && opts.DetectedPR != "" && opts.FPFilterEnabled {
+		feedbackDir, cleanup, err := agent.NewIsolatedWorkDir()
+		if err != nil {
+			logger.Logf(terminal.StyleError, "Failed to create isolated feedback workspace: %v", err)
+			return domain.ExitError
+		}
+		cleanupFeedbackDir = cleanup
 		logger.Logf(terminal.StyleInfo, "Summarizing PR #%s feedback %s(in parallel)%s",
 			opts.DetectedPR, terminal.Color(terminal.Dim), terminal.Color(terminal.Reset))
 		feedbackWg.Add(1)
@@ -139,10 +161,10 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			}
 
 			summarizer := feedback.NewSummarizer(feedbackAgentName, opts.SummarizerModel, opts.Verbose, logger)
-			feedbackCtx, feedbackCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
-			defer feedbackCancel()
+			feedbackCtx, cancelFeedbackTimeout := context.WithTimeout(feedbackParentCtx, opts.SummarizerTimeout)
+			defer cancelFeedbackTimeout()
 
-			summary, err := summarizer.SummarizeFromDir(feedbackCtx, opts.DetectedPR, opts.WorkDir)
+			summary, err := summarizer.SummarizeFromDirs(feedbackCtx, opts.DetectedPR, opts.WorkDir, feedbackDir)
 			if summary != "" {
 				priorFeedback = summary
 			}
@@ -203,7 +225,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 	summarizerCtx, summarizerCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 	defer summarizerCancel()
-	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, opts.SummarizerModel, aggregated, opts.WorkDir, opts.Verbose, logger)
+	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, opts.SummarizerModel, aggregated, postProcessDir, opts.Verbose, logger)
 	spinnerCancel()
 	<-spinnerDone
 	if summaryResult != nil && !opts.Verbose {
@@ -241,7 +263,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 		fpCtx, fpCancel := context.WithTimeout(ctx, opts.FPFilterTimeout)
 		defer fpCancel()
-		fpFilter := fpfilter.New(opts.SummarizerAgent, opts.SummarizerModel, opts.FPThreshold, opts.WorkDir, opts.Verbose, logger)
+		fpFilter := fpfilter.New(opts.SummarizerAgent, opts.SummarizerModel, opts.FPThreshold, postProcessDir, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, priorFeedback, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/agent"
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
@@ -169,16 +170,10 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				priorFeedback = summary
 			}
 			if err != nil {
-
-				if ctx.Err() != nil {
-
-					return
+				warning := priorFeedbackFailureWarning(feedbackParentCtx.Err(), feedbackCtx.Err(), err, opts.SummarizerTimeout)
+				if warning != "" {
+					logger.Log(warning, terminal.StyleWarning)
 				}
-				if feedbackCtx.Err() == context.DeadlineExceeded {
-					logger.Logf(terminal.StyleWarning, "PR feedback summarizer timed out after %s", opts.SummarizerTimeout)
-					return
-				}
-				logger.Logf(terminal.StyleWarning, "PR feedback summarizer failed: %v", err)
 				return
 			}
 			if summary != "" {
@@ -329,6 +324,16 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	}
 
 	return handleFindings(ctx, opts, summaryResult.Grouped, aggregated, stats, logger)
+}
+
+func priorFeedbackFailureWarning(parentErr, taskErr, failure error, timeout time.Duration) string {
+	if parentErr != nil {
+		return ""
+	}
+	if taskErr == context.DeadlineExceeded {
+		return fmt.Sprintf("PR feedback summarizer timed out after %s", timeout)
+	}
+	return fmt.Sprintf("PR feedback summarizer failed: %v", failure)
 }
 
 func usesGeminiAgent(opts ReviewOpts) bool {

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1,10 +1,49 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
 )
+
+func TestPriorFeedbackFailureWarning(t *testing.T) {
+	tests := []struct {
+		name      string
+		parentErr error
+		taskErr   error
+		failure   error
+		want      string
+	}{
+		{
+			name:      "deliberate teardown",
+			parentErr: context.Canceled,
+			taskErr:   context.Canceled,
+			failure:   context.Canceled,
+		},
+		{
+			name:    "timeout",
+			taskErr: context.DeadlineExceeded,
+			failure: context.DeadlineExceeded,
+			want:    "PR feedback summarizer timed out after 5s",
+		},
+		{
+			name:    "failure",
+			failure: errors.New("agent failed"),
+			want:    "PR feedback summarizer failed: agent failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := priorFeedbackFailureWarning(tt.parentErr, tt.taskErr, tt.failure, 5*time.Second)
+			if got != tt.want {
+				t.Fatalf("warning = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestUsesGeminiAgent(t *testing.T) {
 	tests := []struct {

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -126,16 +126,20 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 
 	prNumber = watchPR
 
-	initialPollInterval := config.Defaults.WatchPollInterval
-	if cmd.Flags().Changed("poll-interval") && watchPollInterval > 0 {
-		initialPollInterval = watchPollInterval
+	initialPollInterval := resolveWatchPollInterval(cmd, nil)
+	if initialPollInterval <= 0 {
+		initialPollInterval = config.Defaults.WatchPollInterval
 	}
 	clock := watch.RealClock{}
-	configSource, err := resolveInitialTrustedReviewConfigSource(
+	cfgResult, err := resolveInitialTrustedReviewConfiguration(
 		ctx,
 		initialPollInterval,
-		func(ctx context.Context) (config.Source, error) {
-			return resolveTrustedReviewConfigSource(ctx, noConfig)
+		func(ctx context.Context) (configResult, error) {
+			configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
+			if err != nil {
+				return configResult{}, err
+			}
+			return loadAndResolveConfig(ctx, cmd, worktreeResult{}, configSource, logger)
 		},
 		clock.Sleep,
 		func(format string, args ...any) {
@@ -145,10 +149,6 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		logger.Logf(terminal.StyleError, "%v", err)
 		return contextualExit(ctx, exitCode(domain.ExitError))
-	}
-	cfgResult, err := loadAndResolveConfig(ctx, cmd, worktreeResult{}, configSource, logger)
-	if err != nil {
-		return contextualExit(ctx, err)
 	}
 	wcfg := watch.Config{
 		Mode:         mode,
@@ -213,34 +213,37 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	}
 }
 
-func resolveInitialTrustedReviewConfigSource(
+func resolveInitialTrustedReviewConfiguration(
 	ctx context.Context,
 	pollInterval time.Duration,
-	resolve func(context.Context) (config.Source, error),
+	load func(context.Context) (configResult, error),
 	sleep func(context.Context, time.Duration) error,
 	logf func(string, ...any),
-) (config.Source, error) {
+) (configResult, error) {
 	var lastErr error
 	for attempt := 1; attempt <= maxInitialTrustedConfigAttempts; attempt++ {
-		source, err := resolve(ctx)
+		result, err := load(ctx)
+		if result.resolved.WatchPollInterval > 0 {
+			pollInterval = result.resolved.WatchPollInterval
+		}
 		if err == nil {
-			return source, nil
+			return result, nil
 		}
 		lastErr = err
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return configResult{}, ctx.Err()
 		}
 		if attempt == maxInitialTrustedConfigAttempts {
 			break
 		}
 		if logf != nil {
-			logf("Trusted configuration preparation failed (%d/%d); retrying in %s: %v", attempt, maxInitialTrustedConfigAttempts, pollInterval, err)
+			logf("Trusted configuration initialization failed (%d/%d); retrying in %s: %v", attempt, maxInitialTrustedConfigAttempts, pollInterval, err)
 		}
 		if err := sleep(ctx, pollInterval); err != nil {
-			return nil, err
+			return configResult{}, err
 		}
 	}
-	return nil, fmt.Errorf("trusted configuration preparation failed after %d attempts: %w", maxInitialTrustedConfigAttempts, lastErr)
+	return configResult{}, fmt.Errorf("trusted configuration initialization failed after %d attempts: %w", maxInitialTrustedConfigAttempts, lastErr)
 }
 
 func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode watch.PostMode, logger *terminal.Logger) (watch.Cycle, error) {
@@ -274,7 +277,7 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		if ctx.Err() != nil {
 			return watch.Cycle{Result: watch.CycleError}, ctx.Err()
 		}
-		return watch.Cycle{Result: watch.CycleError}, fmt.Errorf("%w: trusted configuration load failed: %v", watch.ErrRetryableCycle, err)
+		return watch.Cycle{Result: watch.CycleError}, fmt.Errorf("trusted configuration load failed: %w", err)
 	}
 
 	outcome := &CycleOutcome{}

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -7,15 +7,19 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/git"
 	"github.com/richhaase/agentic-code-reviewer/internal/github"
 	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
+
+const maxInitialTrustedConfigAttempts = 5
 
 func newWatchCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -122,7 +126,22 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 
 	prNumber = watchPR
 
-	configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
+	initialPollInterval := config.Defaults.WatchPollInterval
+	if cmd.Flags().Changed("poll-interval") && watchPollInterval > 0 {
+		initialPollInterval = watchPollInterval
+	}
+	clock := watch.RealClock{}
+	configSource, err := resolveInitialTrustedReviewConfigSource(
+		ctx,
+		initialPollInterval,
+		func(ctx context.Context) (config.Source, error) {
+			return resolveTrustedReviewConfigSource(ctx, noConfig)
+		},
+		clock.Sleep,
+		func(format string, args ...any) {
+			logger.Logf(terminal.StyleWarning, format, args...)
+		},
+	)
 	if err != nil {
 		logger.Logf(terminal.StyleError, "%v", err)
 		return contextualExit(ctx, exitCode(domain.ExitError))
@@ -192,6 +211,36 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	default:
 		return exitCode(domain.ExitFindings)
 	}
+}
+
+func resolveInitialTrustedReviewConfigSource(
+	ctx context.Context,
+	pollInterval time.Duration,
+	resolve func(context.Context) (config.Source, error),
+	sleep func(context.Context, time.Duration) error,
+	logf func(string, ...any),
+) (config.Source, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxInitialTrustedConfigAttempts; attempt++ {
+		source, err := resolve(ctx)
+		if err == nil {
+			return source, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if attempt == maxInitialTrustedConfigAttempts {
+			break
+		}
+		if logf != nil {
+			logf("Trusted configuration preparation failed (%d/%d); retrying in %s: %v", attempt, maxInitialTrustedConfigAttempts, pollInterval, err)
+		}
+		if err := sleep(ctx, pollInterval); err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("trusted configuration preparation failed after %d attempts: %w", maxInitialTrustedConfigAttempts, lastErr)
 }
 
 func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode watch.PostMode, logger *terminal.Logger) (watch.Cycle, error) {

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -122,7 +122,12 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 
 	prNumber = watchPR
 
-	cfgResult, err := loadAndResolveConfig(cmd, worktreeResult{}, logger)
+	configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "%v", err)
+		return exitCode(domain.ExitError)
+	}
+	cfgResult, err := loadAndResolveConfig(ctx, cmd, worktreeResult{}, configSource, logger)
 	if err != nil {
 		return err
 	}
@@ -190,6 +195,10 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 }
 
 func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode watch.PostMode, logger *terminal.Logger) (watch.Cycle, error) {
+	configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
+	if err != nil {
+		return watch.Cycle{Result: watch.CycleError}, err
+	}
 	wt, err := setupWorktree(ctx, cmd, logger)
 	if err != nil {
 		return watch.Cycle{Result: watch.CycleError}, err
@@ -208,9 +217,7 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		}
 	}
 
-	cfgSource := wt
-	cfgSource.workDir = ""
-	cfgResult, err := loadAndResolveConfig(cmd, cfgSource, logger)
+	cfgResult, err := loadAndResolveConfig(ctx, cmd, wt, configSource, logger)
 	if err != nil {
 		return watch.Cycle{Result: watch.CycleError}, err
 	}

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -125,11 +125,11 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
 	if err != nil {
 		logger.Logf(terminal.StyleError, "%v", err)
-		return exitCode(domain.ExitError)
+		return contextualExit(ctx, exitCode(domain.ExitError))
 	}
 	cfgResult, err := loadAndResolveConfig(ctx, cmd, worktreeResult{}, configSource, logger)
 	if err != nil {
-		return err
+		return contextualExit(ctx, err)
 	}
 	wcfg := watch.Config{
 		Mode:         mode,
@@ -197,7 +197,10 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode watch.PostMode, logger *terminal.Logger) (watch.Cycle, error) {
 	configSource, err := resolveTrustedReviewConfigSource(ctx, noConfig)
 	if err != nil {
-		return watch.Cycle{Result: watch.CycleError}, err
+		if ctx.Err() != nil {
+			return watch.Cycle{Result: watch.CycleError}, ctx.Err()
+		}
+		return watch.Cycle{Result: watch.CycleError}, fmt.Errorf("%w: trusted configuration refresh failed: %v", watch.ErrRetryableCycle, err)
 	}
 	wt, err := setupWorktree(ctx, cmd, logger)
 	if err != nil {
@@ -219,7 +222,10 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 
 	cfgResult, err := loadAndResolveConfig(ctx, cmd, wt, configSource, logger)
 	if err != nil {
-		return watch.Cycle{Result: watch.CycleError}, err
+		if ctx.Err() != nil {
+			return watch.Cycle{Result: watch.CycleError}, ctx.Err()
+		}
+		return watch.Cycle{Result: watch.CycleError}, fmt.Errorf("%w: trusted configuration load failed: %v", watch.ErrRetryableCycle, err)
 	}
 
 	outcome := &CycleOutcome{}

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
 	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
 
@@ -66,5 +70,94 @@ func TestWatchRejectsPositionalArgs(t *testing.T) {
 	cmd := newWatchCmd()
 	if err := cmd.ValidateArgs([]string{"123"}); err == nil {
 		t.Error("watch must reject positional args; a bare PR number would be silently ignored")
+	}
+}
+
+func TestInitialTrustedConfigPreparationRetries(t *testing.T) {
+	attempts := 0
+	sleeps := 0
+	pollInterval := 30 * time.Second
+
+	source, err := resolveInitialTrustedReviewConfigSource(
+		context.Background(),
+		pollInterval,
+		func(context.Context) (config.Source, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, errors.New("remote unavailable")
+			}
+			return config.DefaultsSource{Reason: "test"}, nil
+		},
+		func(_ context.Context, duration time.Duration) error {
+			if duration != pollInterval {
+				t.Fatalf("sleep duration = %s", duration)
+			}
+			sleeps++
+			return nil
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 3 || sleeps != 2 {
+		t.Fatalf("attempts = %d, sleeps = %d", attempts, sleeps)
+	}
+	result, err := source.LoadWithWarnings(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source.Kind != config.SourceKindDefaults {
+		t.Fatalf("source = %+v", result.Source)
+	}
+}
+
+func TestInitialTrustedConfigPreparationStopsAfterLimit(t *testing.T) {
+	attempts := 0
+	sleeps := 0
+
+	_, err := resolveInitialTrustedReviewConfigSource(
+		context.Background(),
+		time.Second,
+		func(context.Context) (config.Source, error) {
+			attempts++
+			return nil, errors.New("remote unavailable")
+		},
+		func(context.Context, time.Duration) error {
+			sleeps++
+			return nil
+		},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("resolveInitialTrustedReviewConfigSource succeeded")
+	}
+	if attempts != maxInitialTrustedConfigAttempts || sleeps != maxInitialTrustedConfigAttempts-1 {
+		t.Fatalf("attempts = %d, sleeps = %d", attempts, sleeps)
+	}
+}
+
+func TestInitialTrustedConfigPreparationHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+
+	_, err := resolveInitialTrustedReviewConfigSource(
+		ctx,
+		time.Second,
+		func(context.Context) (config.Source, error) {
+			attempts++
+			return nil, errors.New("remote unavailable")
+		},
+		func(ctx context.Context, _ time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+		nil,
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d", attempts)
 	}
 }

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -253,6 +253,22 @@ func TestFailedTrustedConfigLoadEmitsWarnings(t *testing.T) {
 	}
 }
 
+func TestTrustedConfigSourceReturningNoResultFailsClosed(t *testing.T) {
+	source := watchConfigSource{}
+	cmd := newWatchCmd()
+	var loadErr error
+
+	output := captureWatchStderr(t, func() {
+		_, loadErr = loadAndResolveConfig(context.Background(), cmd, worktreeResult{}, source, terminal.NewLogger())
+	})
+	if loadErr == nil {
+		t.Fatal("loadAndResolveConfig succeeded")
+	}
+	if !strings.Contains(output, "trusted review configuration source returned no result") {
+		t.Fatalf("stderr = %q", output)
+	}
+}
+
 func captureWatchStderr(t *testing.T, run func()) string {
 	t.Helper()
 	original := os.Stderr

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -230,4 +233,47 @@ func TestFailedTrustedConfigLoadRetainsSafeRetryInterval(t *testing.T) {
 	if result.resolved.WatchPollInterval != 19*time.Second {
 		t.Fatalf("retry interval = %s", result.resolved.WatchPollInterval)
 	}
+}
+
+func TestFailedTrustedConfigLoadEmitsWarnings(t *testing.T) {
+	source := watchConfigSource{
+		result: &config.LoadResult{
+			Config:   &config.Config{},
+			Warnings: []string{"unknown trusted configuration key"},
+		},
+		err: errors.New("trusted config validation failed"),
+	}
+	cmd := newWatchCmd()
+
+	output := captureWatchStderr(t, func() {
+		_, _ = loadAndResolveConfig(context.Background(), cmd, worktreeResult{}, source, terminal.NewLogger())
+	})
+	if !strings.Contains(output, "Warning: unknown trusted configuration key") {
+		t.Fatalf("stderr = %q", output)
+	}
+}
+
+func captureWatchStderr(t *testing.T, run func()) string {
+	t.Helper()
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	func() {
+		os.Stderr = writer
+		defer func() { os.Stderr = original }()
+		run()
+	}()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -7,8 +7,18 @@ import (
 	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
+
+type watchConfigSource struct {
+	result *config.LoadResult
+	err    error
+}
+
+func (s watchConfigSource) LoadWithWarnings(context.Context) (*config.LoadResult, error) {
+	return s.result, s.err
+}
 
 func TestWatchRejectsOneShotOnlyFlags(t *testing.T) {
 	for _, args := range [][]string{
@@ -73,20 +83,20 @@ func TestWatchRejectsPositionalArgs(t *testing.T) {
 	}
 }
 
-func TestInitialTrustedConfigPreparationRetries(t *testing.T) {
+func TestInitialTrustedConfigurationRetries(t *testing.T) {
 	attempts := 0
 	sleeps := 0
 	pollInterval := 30 * time.Second
 
-	source, err := resolveInitialTrustedReviewConfigSource(
+	result, err := resolveInitialTrustedReviewConfiguration(
 		context.Background(),
 		pollInterval,
-		func(context.Context) (config.Source, error) {
+		func(context.Context) (configResult, error) {
 			attempts++
 			if attempts < 3 {
-				return nil, errors.New("remote unavailable")
+				return configResult{}, errors.New("remote unavailable")
 			}
-			return config.DefaultsSource{Reason: "test"}, nil
+			return configResult{resolved: config.ResolvedConfig{WatchPollInterval: pollInterval}}, nil
 		},
 		func(_ context.Context, duration time.Duration) error {
 			if duration != pollInterval {
@@ -103,25 +113,21 @@ func TestInitialTrustedConfigPreparationRetries(t *testing.T) {
 	if attempts != 3 || sleeps != 2 {
 		t.Fatalf("attempts = %d, sleeps = %d", attempts, sleeps)
 	}
-	result, err := source.LoadWithWarnings(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Source.Kind != config.SourceKindDefaults {
-		t.Fatalf("source = %+v", result.Source)
+	if result.resolved.WatchPollInterval != pollInterval {
+		t.Fatalf("poll interval = %s", result.resolved.WatchPollInterval)
 	}
 }
 
-func TestInitialTrustedConfigPreparationStopsAfterLimit(t *testing.T) {
+func TestInitialTrustedConfigurationStopsAfterLimit(t *testing.T) {
 	attempts := 0
 	sleeps := 0
 
-	_, err := resolveInitialTrustedReviewConfigSource(
+	_, err := resolveInitialTrustedReviewConfiguration(
 		context.Background(),
 		time.Second,
-		func(context.Context) (config.Source, error) {
+		func(context.Context) (configResult, error) {
 			attempts++
-			return nil, errors.New("remote unavailable")
+			return configResult{}, errors.New("remote unavailable")
 		},
 		func(context.Context, time.Duration) error {
 			sleeps++
@@ -130,23 +136,23 @@ func TestInitialTrustedConfigPreparationStopsAfterLimit(t *testing.T) {
 		nil,
 	)
 	if err == nil {
-		t.Fatal("resolveInitialTrustedReviewConfigSource succeeded")
+		t.Fatal("resolveInitialTrustedReviewConfiguration succeeded")
 	}
 	if attempts != maxInitialTrustedConfigAttempts || sleeps != maxInitialTrustedConfigAttempts-1 {
 		t.Fatalf("attempts = %d, sleeps = %d", attempts, sleeps)
 	}
 }
 
-func TestInitialTrustedConfigPreparationHonorsCancellation(t *testing.T) {
+func TestInitialTrustedConfigurationHonorsCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	attempts := 0
 
-	_, err := resolveInitialTrustedReviewConfigSource(
+	_, err := resolveInitialTrustedReviewConfiguration(
 		ctx,
 		time.Second,
-		func(context.Context) (config.Source, error) {
+		func(context.Context) (configResult, error) {
 			attempts++
-			return nil, errors.New("remote unavailable")
+			return configResult{}, errors.New("remote unavailable")
 		},
 		func(ctx context.Context, _ time.Duration) error {
 			cancel()
@@ -159,5 +165,69 @@ func TestInitialTrustedConfigPreparationHonorsCancellation(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Fatalf("attempts = %d", attempts)
+	}
+}
+
+func TestInitialTrustedConfigurationUsesTrustedConfigRetryInterval(t *testing.T) {
+	attempts := 0
+	var sleeps []time.Duration
+	trustedInterval := 17 * time.Second
+
+	_, err := resolveInitialTrustedReviewConfiguration(
+		context.Background(),
+		time.Minute,
+		func(context.Context) (configResult, error) {
+			attempts++
+			result := configResult{resolved: config.ResolvedConfig{WatchPollInterval: trustedInterval}}
+			if attempts == 1 {
+				return result, errors.New("guidance unavailable")
+			}
+			return result, nil
+		},
+		func(_ context.Context, duration time.Duration) error {
+			sleeps = append(sleeps, duration)
+			return nil
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sleeps) != 1 || sleeps[0] != trustedInterval {
+		t.Fatalf("sleeps = %v", sleeps)
+	}
+}
+
+func TestResolveWatchPollIntervalUsesEnvironmentAndFlagPrecedence(t *testing.T) {
+	originalPollInterval := watchPollInterval
+	t.Cleanup(func() { watchPollInterval = originalPollInterval })
+	t.Setenv("ACR_WATCH_POLL_INTERVAL", "23s")
+	cmd := newWatchCmd()
+	if got := resolveWatchPollInterval(cmd, nil); got != 23*time.Second {
+		t.Fatalf("environment poll interval = %s", got)
+	}
+	if err := cmd.ParseFlags([]string{"--poll-interval", "7s"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveWatchPollInterval(cmd, nil); got != 7*time.Second {
+		t.Fatalf("flag poll interval = %s", got)
+	}
+}
+
+func TestFailedTrustedConfigLoadRetainsSafeRetryInterval(t *testing.T) {
+	originalPollInterval := watchPollInterval
+	t.Cleanup(func() { watchPollInterval = originalPollInterval })
+	interval := config.Duration(19 * time.Second)
+	source := watchConfigSource{
+		result: &config.LoadResult{Config: &config.Config{Watch: config.WatchConfig{PollInterval: &interval}}},
+		err:    errors.New("trusted config validation failed"),
+	}
+	cmd := newWatchCmd()
+	result, err := loadAndResolveConfig(context.Background(), cmd, worktreeResult{}, source, terminal.NewLogger())
+	if err == nil {
+		t.Fatal("loadAndResolveConfig succeeded")
+	}
+	if result.resolved.WatchPollInterval != 19*time.Second {
+		t.Fatalf("retry interval = %s", result.resolved.WatchPollInterval)
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,5 +11,5 @@ type Agent interface {
 
 	ExecuteReview(ctx context.Context, config *ReviewConfig) (*ExecutionResult, error)
 
-	ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error)
+	ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error)
 }

--- a/internal/agent/antigravity.go
+++ b/internal/agent/antigravity.go
@@ -47,15 +47,15 @@ func (a *AntigravityAgent) ExecuteReview(ctx context.Context, config *ReviewConf
 	})
 }
 
-func (a *AntigravityAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (a *AntigravityAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := a.IsAvailable(); err != nil {
 		return nil, err
 	}
 
 	stdin := io.MultiReader(
-		strings.NewReader(prompt),
+		strings.NewReader(config.Prompt),
 		strings.NewReader("\n\nINPUT JSON:\n"),
-		bytes.NewReader(input),
+		bytes.NewReader(config.Input),
 		strings.NewReader("\n"),
 	)
 
@@ -63,6 +63,7 @@ func (a *AntigravityAgent) ExecuteSummary(ctx context.Context, prompt string, in
 		Command: "agy",
 		Args:    antigravityPrintArgs(antigravityPrintTimeoutCeilingFromContext(ctx, time.Now())),
 		Stdin:   stdin,
+		WorkDir: config.WorkDir,
 	})
 }
 

--- a/internal/agent/antigravity_test.go
+++ b/internal/agent/antigravity_test.go
@@ -82,7 +82,7 @@ func TestAntigravityAgent_ExecuteSummary_AgyNotAvailable(t *testing.T) {
 	agent := NewAntigravityAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -276,7 +276,7 @@ func TestAntigravityAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewAntigravityAgent("ignored-model")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -48,7 +48,7 @@ func (c *ClaudeAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (
 	})
 }
 
-func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := c.IsAvailable(); err != nil {
 		return nil, err
 	}
@@ -56,18 +56,18 @@ func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 	var stdin io.Reader
 	var tempFilePath string
 
-	if len(input) > RefFileSizeThreshold {
+	if len(config.Input) > RefFileSizeThreshold {
 
-		absPath, err := WriteInputToTempFile("", input, "summary-input.json")
+		absPath, err := WriteInputToTempFile(config.WorkDir, config.Input, "summary-input.json")
 		if err != nil {
 			return nil, err
 		}
 		tempFilePath = absPath
-		fullPrompt := fmt.Sprintf("%s\n\nThe input JSON is in file: %s\nUse the Read tool to examine it.", prompt, absPath)
+		fullPrompt := fmt.Sprintf("%s\n\nThe input JSON is in file: %s\nUse the Read tool to examine it.", config.Prompt, absPath)
 		stdin = bytes.NewReader([]byte(fullPrompt))
 	} else {
 
-		fullPrompt := prompt + "\n\nINPUT JSON:\n" + string(input) + "\n"
+		fullPrompt := config.Prompt + "\n\nINPUT JSON:\n" + string(config.Input) + "\n"
 		stdin = bytes.NewReader([]byte(fullPrompt))
 	}
 
@@ -80,6 +80,7 @@ func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 		Command:      "claude",
 		Args:         args,
 		Stdin:        stdin,
+		WorkDir:      config.WorkDir,
 		TempFilePath: tempFilePath,
 	})
 }

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -87,7 +87,7 @@ func TestClaudeAgent_ExecuteSummary_ClaudeNotAvailable(t *testing.T) {
 	agent := NewClaudeAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -329,7 +329,7 @@ func TestClaudeAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewClaudeAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}
@@ -353,5 +353,45 @@ func TestClaudeAgent_ExecuteSummary_Args(t *testing.T) {
 
 	if strings.Contains(outputStr, "ARG:--json-schema") {
 		t.Errorf("unexpected --json-schema in args — ExecuteSummary must not constrain output format")
+	}
+}
+
+func TestClaudeAgentExecuteSummaryUsesWorkDirForLargeInput(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := t.TempDir()
+	mockScript := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\ncat\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", originalPath)
+	os.Setenv("PATH", binDir+":"+originalPath)
+
+	claudeAgent := NewClaudeAgent("")
+	result, err := claudeAgent.ExecuteSummary(context.Background(), &SummaryConfig{
+		Prompt:  "summarize",
+		Input:   []byte(strings.Repeat("x", RefFileSizeThreshold+1)),
+		WorkDir: workDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(output), workDir) {
+		t.Fatalf("summary prompt did not reference workdir temp file: %q", output)
+	}
+	if err := result.Close(); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(workDir, ".acr-summary-input.json-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("summary temp files remain: %v", matches)
 	}
 }

--- a/internal/agent/cmd_reader.go
+++ b/internal/agent/cmd_reader.go
@@ -16,6 +16,7 @@ type cmdReader struct {
 	stderr       stderrBuffer
 	exitCode     int
 	closeOnce    sync.Once
+	closeErr     error
 	tempFilePath string
 }
 
@@ -41,10 +42,10 @@ func (r *cmdReader) Close() error {
 			}
 		}
 
-		CleanupTempFile(r.tempFilePath)
+		r.closeErr = CleanupTempFile(r.tempFilePath)
 	})
 
-	return nil
+	return r.closeErr
 }
 
 func (r *cmdReader) ExitCode() int {

--- a/internal/agent/cmd_reader_test.go
+++ b/internal/agent/cmd_reader_test.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -131,6 +133,27 @@ func TestCmdReader_Close_Idempotent(t *testing.T) {
 	}
 	if err := reader.Close(); err != nil {
 		t.Errorf("Second Close() error = %v, want nil", err)
+	}
+}
+
+func TestCmdReader_CloseReturnsStoredCleanupError(t *testing.T) {
+	cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+	if err := os.Mkdir(cleanupPath, 0700); err != nil {
+		t.Fatalf("create cleanup directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+		t.Fatalf("create cleanup child: %v", err)
+	}
+	reader := &cmdReader{Reader: strings.NewReader(""), tempFilePath: cleanupPath}
+
+	firstErr := reader.Close()
+	secondErr := reader.Close()
+
+	if firstErr == nil || !strings.Contains(firstErr.Error(), "failed to clean up temp file") {
+		t.Fatalf("first Close() error = %v", firstErr)
+	}
+	if secondErr == nil || secondErr.Error() != firstErr.Error() {
+		t.Fatalf("second Close() error = %v, want %v", secondErr, firstErr)
 	}
 }
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -36,7 +36,7 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 		return nil, err
 	}
 
-	if config.Guidance != "" {
+	if config.Guidance != "" || config.DiffPrecomputed {
 		args := []string{"exec", "--json", "--color", "never", "-"}
 		if c.model != "" {
 			args = append([]string{"--model", c.model}, args...)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -61,7 +61,7 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 	})
 }
 
-func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (c *CodexAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := c.IsAvailable(); err != nil {
 		return nil, err
 	}
@@ -72,9 +72,9 @@ func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []
 	}
 
 	stdin := io.MultiReader(
-		strings.NewReader(prompt),
+		strings.NewReader(config.Prompt),
 		strings.NewReader("\n\nINPUT JSON:\n"),
-		bytes.NewReader(input),
+		bytes.NewReader(config.Input),
 		strings.NewReader("\n"),
 	)
 
@@ -82,5 +82,6 @@ func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []
 		Command: "codex",
 		Args:    args,
 		Stdin:   stdin,
+		WorkDir: config.WorkDir,
 	})
 }

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -221,6 +221,29 @@ func TestCodexAgent_ExecuteReview_ArgsWithGuidance(t *testing.T) {
 	if !strings.Contains(outputStr, "Focus on security issues") {
 		t.Errorf("expected guidance in stdin prompt, got:\n%s", outputStr)
 	}
+
+	pinnedConfig := &ReviewConfig{
+		BaseRef:         "base-object-id",
+		WorkDir:         tmpDir,
+		Diff:            "pinned diff content",
+		DiffPrecomputed: true,
+	}
+	pinnedResult, err := agent.ExecuteReview(ctx, pinnedConfig)
+	if err != nil {
+		t.Fatalf("ExecuteReview() with pinned diff error: %v", err)
+	}
+	defer pinnedResult.Close()
+	pinnedOutput, err := io.ReadAll(pinnedResult)
+	if err != nil {
+		t.Fatalf("read pinned review output: %v", err)
+	}
+	pinnedOutputText := string(pinnedOutput)
+	if strings.Contains(pinnedOutputText, "ARG:review") || strings.Contains(pinnedOutputText, "ARG:--base") {
+		t.Fatalf("pinned review used mutable native review mode:\n%s", pinnedOutputText)
+	}
+	if !strings.Contains(pinnedOutputText, "pinned diff content") {
+		t.Fatalf("pinned review omitted captured diff:\n%s", pinnedOutputText)
+	}
 }
 
 func TestCodexAgent_ExecuteSummary_Args(t *testing.T) {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -87,7 +87,7 @@ func TestCodexAgent_ExecuteSummary_CodexNotAvailable(t *testing.T) {
 	agent := NewCodexAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -103,7 +103,7 @@ func TestCodexAgent_ExecuteSummary_CodexNotAvailable(t *testing.T) {
 func TestCodexAgent_ExecuteReview_ArgsWithoutGuidance(t *testing.T) {
 	tmpDir := t.TempDir()
 	mockScript := filepath.Join(tmpDir, "codex")
-	err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"$arg\"; done\n"), 0755)
+	err := os.WriteFile(mockScript, []byte("#!/bin/sh\npwd -P\nfor arg in \"$@\"; do echo \"$arg\"; done\n"), 0755)
 	if err != nil {
 		t.Fatalf("failed to write mock script: %v", err)
 	}
@@ -130,7 +130,15 @@ func TestCodexAgent_ExecuteReview_ArgsWithoutGuidance(t *testing.T) {
 		t.Fatalf("failed to read output: %v", err)
 	}
 
-	args := strings.Split(strings.TrimSpace(string(output)), "\n")
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	wantWorkDir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) == 0 || lines[0] != wantWorkDir {
+		t.Fatalf("summary workdir = %q, want %q", lines[0], wantWorkDir)
+	}
+	args := lines[1:]
 	expected := []string{"exec", "--json", "--color", "never", "review", "--base", "main"}
 	if len(args) != len(expected) {
 		t.Fatalf("got %d args %v, want %d args %v", len(args), args, len(expected), expected)
@@ -261,7 +269,7 @@ func TestCodexAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewCodexAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize this", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize this", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}

--- a/internal/agent/cohort_test.go
+++ b/internal/agent/cohort_test.go
@@ -322,6 +322,6 @@ func (m *mockAgent) ExecuteReview(_ context.Context, _ *ReviewConfig) (*Executio
 	return nil, nil
 }
 
-func (m *mockAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*ExecutionResult, error) {
+func (m *mockAgent) ExecuteSummary(_ context.Context, _ *SummaryConfig) (*ExecutionResult, error) {
 	return nil, nil
 }

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -21,3 +21,9 @@ type ReviewConfig struct {
 
 	DiffPrecomputed bool
 }
+
+type SummaryConfig struct {
+	Prompt  string
+	Input   []byte
+	WorkDir string
+}

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -78,13 +79,17 @@ func executeCommand(ctx context.Context, opts executeOptions) (*ExecutionResult,
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		CleanupTempFile(opts.TempFilePath)
-		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to create stdout pipe: %w", err),
+			CleanupTempFile(opts.TempFilePath),
+		)
 	}
 
 	if err := cmd.Start(); err != nil {
-		CleanupTempFile(opts.TempFilePath)
-		return nil, fmt.Errorf("failed to start %s: %w", opts.Command, err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to start %s: %w", opts.Command, err),
+			CleanupTempFile(opts.TempFilePath),
+		)
 	}
 
 	reader := &cmdReader{

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -83,5 +85,53 @@ func TestExecuteCommand_StartFailureCleansTempFile(t *testing.T) {
 	}
 	if _, statErr := os.Stat(tempPath); !os.IsNotExist(statErr) {
 		t.Fatalf("expected temp file to be removed, stat err: %v", statErr)
+	}
+}
+
+func TestExecuteCommand_StartFailureIncludesCleanupFailure(t *testing.T) {
+	cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+	if err := os.Mkdir(cleanupPath, 0700); err != nil {
+		t.Fatalf("create cleanup directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+		t.Fatalf("create cleanup child: %v", err)
+	}
+
+	_, err := executeCommand(context.Background(), executeOptions{
+		Command:      "definitely-not-a-real-acr-command",
+		TempFilePath: cleanupPath,
+	})
+
+	if err == nil {
+		t.Fatal("expected executeCommand to fail")
+	}
+	if !strings.Contains(err.Error(), "failed to start") || !strings.Contains(err.Error(), "failed to clean up temp file") {
+		t.Fatalf("combined setup and cleanup error = %v", err)
+	}
+}
+
+func TestExecuteCommand_CloseReturnsCleanupFailure(t *testing.T) {
+	cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+	if err := os.Mkdir(cleanupPath, 0700); err != nil {
+		t.Fatalf("create cleanup directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+		t.Fatalf("create cleanup child: %v", err)
+	}
+
+	result, err := executeCommand(context.Background(), executeOptions{
+		Command:      "true",
+		TempFilePath: cleanupPath,
+	})
+	if err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+	if _, err := io.ReadAll(result); err != nil {
+		t.Fatalf("read command output: %v", err)
+	}
+	firstErr := result.Close()
+
+	if firstErr == nil || !strings.Contains(firstErr.Error(), "failed to clean up temp file") {
+		t.Fatalf("first Close() error = %v", firstErr)
 	}
 }

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -49,7 +49,7 @@ func (g *GeminiAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (
 	})
 }
 
-func (g *GeminiAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (g *GeminiAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := g.IsAvailable(); err != nil {
 		return nil, err
 	}
@@ -60,9 +60,9 @@ func (g *GeminiAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 	}
 
 	stdin := io.MultiReader(
-		strings.NewReader(prompt),
+		strings.NewReader(config.Prompt),
 		strings.NewReader("\n\nINPUT JSON:\n"),
-		bytes.NewReader(input),
+		bytes.NewReader(config.Input),
 		strings.NewReader("\n"),
 	)
 
@@ -70,5 +70,6 @@ func (g *GeminiAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 		Command: "gemini",
 		Args:    args,
 		Stdin:   stdin,
+		WorkDir: config.WorkDir,
 	})
 }

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -87,7 +87,7 @@ func TestGeminiAgent_ExecuteSummary_GeminiNotAvailable(t *testing.T) {
 	agent := NewGeminiAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -261,7 +261,7 @@ func TestGeminiAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewGeminiAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}

--- a/internal/agent/reffile.go
+++ b/internal/agent/reffile.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,11 +35,10 @@ func WriteDiffToTempFile(workDir, diff string) (string, error) {
 
 	absPath, err := filepath.Abs(tempPath)
 	if err != nil {
-
-		if rmErr := os.Remove(tempPath); rmErr != nil && !os.IsNotExist(rmErr) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to clean up temp file %s during error handling: %v\n", tempPath, rmErr)
-		}
-		return "", fmt.Errorf("failed to get absolute path for temp file: %w", err)
+		return "", errors.Join(
+			fmt.Errorf("failed to get absolute path for temp file: %w", err),
+			CleanupTempFile(tempPath),
+		)
 	}
 
 	return absPath, nil
@@ -57,21 +57,21 @@ func WriteInputToTempFile(workDir string, input []byte, suffix string) (string, 
 
 	absPath, err := filepath.Abs(tempPath)
 	if err != nil {
-
-		if rmErr := os.Remove(tempPath); rmErr != nil && !os.IsNotExist(rmErr) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to clean up temp file %s during error handling: %v\n", tempPath, rmErr)
-		}
-		return "", fmt.Errorf("failed to get absolute path for temp file: %w", err)
+		return "", errors.Join(
+			fmt.Errorf("failed to get absolute path for temp file: %w", err),
+			CleanupTempFile(tempPath),
+		)
 	}
 
 	return absPath, nil
 }
 
-func CleanupTempFile(path string) {
+func CleanupTempFile(path string) error {
 	if path == "" {
-		return
+		return nil
 	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Warning: failed to clean up temp file %s: %v\n", path, err)
+		return fmt.Errorf("failed to clean up temp file %s: %w", path, err)
 	}
+	return nil
 }

--- a/internal/agent/reffile_test.go
+++ b/internal/agent/reffile_test.go
@@ -71,7 +71,9 @@ func TestWriteDiffToTempFile(t *testing.T) {
 		t.Errorf("WriteDiffToTempFile() path = %s, want absolute path", absPath)
 	}
 
-	CleanupTempFile(absPath)
+	if err := CleanupTempFile(absPath); err != nil {
+		t.Fatalf("CleanupTempFile() error = %v", err)
+	}
 	if _, err := os.Stat(absPath); !os.IsNotExist(err) {
 		t.Errorf("CleanupTempFile() failed to remove file")
 	}
@@ -102,7 +104,9 @@ func TestWriteInputToTempFile(t *testing.T) {
 		t.Errorf("WriteInputToTempFile() path = %s, want absolute path", absPath)
 	}
 
-	CleanupTempFile(absPath)
+	if err := CleanupTempFile(absPath); err != nil {
+		t.Fatalf("CleanupTempFile() error = %v", err)
+	}
 }
 
 func TestCleanupTempFile(t *testing.T) {
@@ -113,7 +117,9 @@ func TestCleanupTempFile(t *testing.T) {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 
-		CleanupTempFile(tmpFile)
+		if err := CleanupTempFile(tmpFile); err != nil {
+			t.Fatalf("CleanupTempFile() error = %v", err)
+		}
 
 		if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
 			t.Error("CleanupTempFile() failed to remove existing file")
@@ -122,12 +128,48 @@ func TestCleanupTempFile(t *testing.T) {
 
 	t.Run("cleanup non-existent file does not panic", func(t *testing.T) {
 
-		CleanupTempFile("/nonexistent/path/file.txt")
+		if err := CleanupTempFile("/nonexistent/path/file.txt"); err != nil {
+			t.Fatalf("CleanupTempFile() error = %v", err)
+		}
 	})
 
 	t.Run("cleanup empty path does nothing", func(t *testing.T) {
 
-		CleanupTempFile("")
+		if err := CleanupTempFile(""); err != nil {
+			t.Fatalf("CleanupTempFile() error = %v", err)
+		}
+	})
+
+	t.Run("cleanup failure returns error without stderr", func(t *testing.T) {
+		cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+		if err := os.Mkdir(cleanupPath, 0700); err != nil {
+			t.Fatalf("create cleanup directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+			t.Fatalf("create cleanup child: %v", err)
+		}
+		stderrPath := filepath.Join(t.TempDir(), "stderr")
+		stderr, err := os.Create(stderrPath)
+		if err != nil {
+			t.Fatalf("create stderr capture: %v", err)
+		}
+		originalStderr := os.Stderr
+		os.Stderr = stderr
+		cleanupErr := CleanupTempFile(cleanupPath)
+		os.Stderr = originalStderr
+		if err := stderr.Close(); err != nil {
+			t.Fatalf("close stderr capture: %v", err)
+		}
+		if cleanupErr == nil || !strings.Contains(cleanupErr.Error(), "failed to clean up temp file") {
+			t.Fatalf("CleanupTempFile() error = %v", cleanupErr)
+		}
+		captured, err := os.ReadFile(stderrPath)
+		if err != nil {
+			t.Fatalf("read stderr capture: %v", err)
+		}
+		if len(captured) != 0 {
+			t.Fatalf("CleanupTempFile() wrote stderr: %q", captured)
+		}
 	})
 }
 

--- a/internal/agent/workdir.go
+++ b/internal/agent/workdir.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func NewIsolatedWorkDir() (string, func(), error) {
+	dir, err := os.MkdirTemp("", "acr-postprocess-")
+	if err != nil {
+		return "", nil, err
+	}
+	cmd := exec.Command("git", "init", "--quiet", "--template=", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(dir)
+		message := strings.TrimSpace(string(out))
+		if message != "" {
+			return "", nil, fmt.Errorf("initialize isolated agent workspace (%s): %w", message, err)
+		}
+		return "", nil, fmt.Errorf("initialize isolated agent workspace: %w", err)
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}

--- a/internal/agent/workdir_test.go
+++ b/internal/agent/workdir_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestNewIsolatedWorkDirCreatesAndCleansDirectory(t *testing.T) {
+	dir, cleanup, err := NewIsolatedWorkDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup is nil")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("work path %q is not a directory", dir)
+	}
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(out)) != "true" {
+		t.Fatalf("git worktree status = %q", out)
+	}
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("work directory remains after cleanup: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,24 @@ func LoadWithWarnings() (*LoadResult, error) {
 	}
 
 	configPath := filepath.Join(repoRoot, ConfigFileName)
-	return LoadFromPathWithWarnings(configPath)
+	data, err := git.ReadFileWithinRepository(repoRoot, ConfigFileName)
+	if os.IsNotExist(err) {
+		result := newRepositoryFileSystemLoadResult(repoRoot, configPath, nil, false)
+		result.Config = &Config{}
+		return result, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	result, err := loadDataWithWarnings(data)
+	fileSystemResult := newRepositoryFileSystemLoadResult(repoRoot, configPath, data, true)
+	if result != nil {
+		result.ConfigDir = fileSystemResult.ConfigDir
+		result.Source = fileSystemResult.Source
+		result.readConfigRelative = fileSystemResult.readConfigRelative
+	}
+	return result, err
 }
 
 func LoadFromDirWithWarnings(dir string) (*LoadResult, error) {
@@ -133,6 +150,15 @@ func LoadFromPathWithWarnings(path string) (*LoadResult, error) {
 		result.readConfigRelative = fileSystemResult.readConfigRelative
 	}
 	return result, err
+}
+
+func newRepositoryFileSystemLoadResult(repositoryRoot, path string, data []byte, configPresent bool) *LoadResult {
+	result := newFileSystemLoadResult(path, data, configPresent)
+	result.ConfigDir = repositoryRoot
+	result.readConfigRelative = func(_ context.Context, relativePath string) ([]byte, error) {
+		return git.ReadFileWithinRepository(repositoryRoot, relativePath)
+	}
+	return result
 }
 
 func (c *Config) validatePatterns() error {
@@ -479,6 +505,8 @@ type EnvState struct {
 	PRFeedbackEnabledSet bool
 	PRFeedbackAgent      string
 	PRFeedbackAgentSet   bool
+	WatchPollInterval    time.Duration
+	WatchPollIntervalSet bool
 }
 
 func LoadEnvState() (EnvState, []string) {
@@ -626,6 +654,17 @@ func LoadEnvState() (EnvState, []string) {
 		state.PRFeedbackAgent = v
 		state.PRFeedbackAgentSet = true
 	}
+	if v := os.Getenv("ACR_WATCH_POLL_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			state.WatchPollInterval = d
+			state.WatchPollIntervalSet = true
+		} else if secs, err := strconv.Atoi(v); err == nil {
+			state.WatchPollInterval = time.Duration(secs) * time.Second
+			state.WatchPollIntervalSet = true
+		} else {
+			warnings = append(warnings, fmt.Sprintf("ACR_WATCH_POLL_INTERVAL=%q is not a valid duration or integer, ignoring", v))
+		}
+	}
 
 	return state, warnings
 }
@@ -746,6 +785,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	}
 	if envState.PRFeedbackAgentSet {
 		result.PRFeedbackAgent = envState.PRFeedbackAgent
+	}
+	if envState.WatchPollIntervalSet {
+		result.WatchPollInterval = envState.WatchPollInterval
 	}
 
 	if flagState.ReviewersSet {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -106,43 +107,32 @@ func LoadFromDirWithWarnings(dir string) (*LoadResult, error) {
 }
 
 type LoadResult struct {
-	Config    *Config
-	ConfigDir string
-	Warnings  []string
+	Config             *Config
+	ConfigDir          string
+	Warnings           []string
+	Source             SourceIdentity
+	readConfigRelative func(context.Context, string) ([]byte, error)
 }
 
 func LoadFromPathWithWarnings(path string) (*LoadResult, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
-		return &LoadResult{Config: &Config{}}, nil
+		result := newFileSystemLoadResult(path, nil, false)
+		result.Config = &Config{}
+		return result, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	warnings := checkUnknownKeys(data)
-
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("invalid %s: %w", ConfigFileName, err)
+	result, err := loadDataWithWarnings(data)
+	fileSystemResult := newFileSystemLoadResult(path, data, true)
+	if result != nil {
+		result.ConfigDir = fileSystemResult.ConfigDir
+		result.Source = fileSystemResult.Source
+		result.readConfigRelative = fileSystemResult.readConfigRelative
 	}
-
-	if err := cfg.validatePatterns(); err != nil {
-		return nil, err
-	}
-
-	if cfg.ReviewerAgent != nil {
-		warnings = append(warnings, `"reviewer_agent" is deprecated, use "reviewer_agents" list instead`)
-		if len(cfg.ReviewerAgents) > 0 {
-			warnings = append(warnings, `both "reviewer_agent" and "reviewer_agents" are set; "reviewer_agents" takes precedence`)
-		}
-	}
-
-	if err := cfg.Validate(); err != nil {
-		return &LoadResult{Config: &cfg, ConfigDir: filepath.Dir(path), Warnings: warnings}, fmt.Errorf("%s: %w", ConfigFileName, err)
-	}
-
-	return &LoadResult{Config: &cfg, ConfigDir: filepath.Dir(path), Warnings: warnings}, nil
+	return result, err
 }
 
 func (c *Config) validatePatterns() error {
@@ -823,6 +813,24 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 }
 
 func ResolveGuidance(cfg *Config, envState EnvState, flagState FlagState, flagValues ResolvedConfig, configDir string) (string, error) {
+	readConfigRelative := func(_ context.Context, relativePath string) ([]byte, error) {
+		guidancePath := relativePath
+		if !filepath.IsAbs(guidancePath) && configDir != "" {
+			guidancePath = filepath.Join(configDir, guidancePath)
+		}
+		return os.ReadFile(guidancePath)
+	}
+	return resolveGuidance(context.Background(), cfg, envState, flagState, flagValues, readConfigRelative)
+}
+
+func ResolveGuidanceFromLoadResult(ctx context.Context, result *LoadResult, envState EnvState, flagState FlagState, flagValues ResolvedConfig) (string, error) {
+	if result == nil {
+		return resolveGuidance(ctx, nil, envState, flagState, flagValues, nil)
+	}
+	return resolveGuidance(ctx, result.Config, envState, flagState, flagValues, result.readConfigRelative)
+}
+
+func resolveGuidance(ctx context.Context, cfg *Config, envState EnvState, flagState FlagState, flagValues ResolvedConfig, readConfigRelative func(context.Context, string) ([]byte, error)) (string, error) {
 	if flagState.GuidanceSet && flagValues.Guidance != "" {
 		return flagValues.Guidance, nil
 	}
@@ -844,11 +852,10 @@ func ResolveGuidance(cfg *Config, envState EnvState, flagState FlagState, flagVa
 		return string(content), nil
 	}
 	if cfg != nil && cfg.GuidanceFile != nil && *cfg.GuidanceFile != "" {
-		guidancePath := *cfg.GuidanceFile
-		if !filepath.IsAbs(guidancePath) && configDir != "" {
-			guidancePath = filepath.Join(configDir, guidancePath)
+		if readConfigRelative == nil {
+			return "", fmt.Errorf("failed to read guidance file %q: no trusted configuration input source", *cfg.GuidanceFile)
 		}
-		content, err := os.ReadFile(guidancePath)
+		content, err := readConfigRelative(ctx, *cfg.GuidanceFile)
 		if err != nil {
 			return "", fmt.Errorf("failed to read guidance file %q: %w", *cfg.GuidanceFile, err)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1187,7 +1187,7 @@ func clearACREnv(t *testing.T) {
 		"ACR_RETRIES", "ACR_FETCH", "ACR_REVIEWER_AGENT", "ACR_SUMMARIZER_AGENT",
 		"ACR_SUMMARIZER_TIMEOUT", "ACR_FP_FILTER_TIMEOUT",
 		"ACR_GUIDANCE", "ACR_GUIDANCE_FILE", "ACR_FP_FILTER", "ACR_FP_THRESHOLD",
-		"ACR_PR_FEEDBACK", "ACR_PR_FEEDBACK_AGENT",
+		"ACR_PR_FEEDBACK", "ACR_PR_FEEDBACK_AGENT", "ACR_WATCH_POLL_INTERVAL",
 	} {
 		t.Setenv(key, os.Getenv(key))
 		os.Unsetenv(key)
@@ -1318,9 +1318,34 @@ func TestLoadEnvState_NoWarningsForValidValues(t *testing.T) {
 	t.Setenv("ACR_SUMMARIZER_TIMEOUT", "6m")
 	t.Setenv("ACR_FP_FILTER_TIMEOUT", "7m")
 	t.Setenv("ACR_FETCH", "true")
+	t.Setenv("ACR_WATCH_POLL_INTERVAL", "45s")
 	_, warnings := LoadEnvState()
 	if len(warnings) != 0 {
 		t.Errorf("expected no warnings for valid values, got %v", warnings)
+	}
+}
+
+func TestLoadEnvState_WatchPollInterval(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_WATCH_POLL_INTERVAL", "45s")
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	if !state.WatchPollIntervalSet || state.WatchPollInterval != 45*time.Second {
+		t.Fatalf("watch poll interval = %s, set = %t", state.WatchPollInterval, state.WatchPollIntervalSet)
+	}
+}
+
+func TestLoadEnvState_MalformedWatchPollInterval(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_WATCH_POLL_INTERVAL", "soon")
+	state, warnings := LoadEnvState()
+	if state.WatchPollIntervalSet {
+		t.Fatal("WatchPollIntervalSet is true")
+	}
+	if !hasWarningContaining(warnings, "ACR_WATCH_POLL_INTERVAL") {
+		t.Fatalf("warnings = %v", warnings)
 	}
 }
 
@@ -1597,7 +1622,12 @@ func TestResolve_WatchConfigAndFlagPrecedence(t *testing.T) {
 		t.Errorf("WatchMaxReviews = %d, want 3 from config", resolved.WatchMaxReviews)
 	}
 
-	resolved = Resolve(cfg, EnvState{},
+	resolved = Resolve(cfg, EnvState{WatchPollInterval: time.Minute, WatchPollIntervalSet: true}, FlagState{}, ResolvedConfig{})
+	if resolved.WatchPollInterval != time.Minute {
+		t.Errorf("WatchPollInterval = %s, want 1m from environment", resolved.WatchPollInterval)
+	}
+
+	resolved = Resolve(cfg, EnvState{WatchPollInterval: time.Minute, WatchPollIntervalSet: true},
 		FlagState{WatchPollIntervalSet: true, WatchMaxReviewsSet: true},
 		ResolvedConfig{WatchPollInterval: 2 * time.Minute, WatchMaxReviews: 5})
 	if resolved.WatchPollInterval != 2*time.Minute {

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -127,7 +127,7 @@ func ResolveTrustedSource(ctx context.Context, request TrustedSourceRequest) (So
 }
 
 func resolveRemoteBranchSource(ctx context.Context, repositoryRoot, remote, branch string) (Source, error) {
-	if err := gitpkg.FetchBaseRef(ctx, repositoryRoot, remote, branch); err != nil {
+	if err := gitpkg.FetchRemoteTrackingBranch(ctx, repositoryRoot, remote, branch); err != nil {
 		return nil, fmt.Errorf("failed to refresh trusted review configuration: %w", err)
 	}
 	ref := "refs/remotes/" + remote + "/" + branch

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -1,0 +1,246 @@
+package config
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	gitpkg "github.com/richhaase/agentic-code-reviewer/internal/git"
+)
+
+type Source interface {
+	LoadWithWarnings(context.Context) (*LoadResult, error)
+}
+
+const (
+	SourceKindDisabled           = "disabled"
+	SourceKindDefaults           = "defaults"
+	SourceKindRepositoryRevision = "repository-revision"
+	SourceKindFilesystem         = "filesystem"
+)
+
+type CanonicalPolicy string
+
+const (
+	CanonicalRemoteDefault CanonicalPolicy = "remote-default"
+	CanonicalNamedBranch   CanonicalPolicy = "named-branch"
+)
+
+type TrustedSourceRequest struct {
+	RepositoryRoot string
+	Remote         string
+	Branch         string
+	Policy         CanonicalPolicy
+	Disabled       bool
+}
+
+type SourceIdentity struct {
+	Kind          string
+	Locator       string
+	Ref           string
+	Revision      string
+	ConfigPresent bool
+	ConfigDigest  string
+}
+
+type RepositoryRevisionSource struct {
+	RepositoryRoot string
+	Ref            string
+	Revision       string
+}
+
+type DefaultsSource struct {
+	Reason string
+}
+
+type DisabledSource struct {
+	Locator string
+}
+
+func (s DisabledSource) LoadWithWarnings(_ context.Context) (*LoadResult, error) {
+	return &LoadResult{
+		Config: &Config{},
+		Source: SourceIdentity{
+			Kind:    SourceKindDisabled,
+			Locator: s.Locator,
+		},
+	}, nil
+}
+
+func (s DefaultsSource) LoadWithWarnings(_ context.Context) (*LoadResult, error) {
+	return &LoadResult{
+		Config: &Config{},
+		Source: SourceIdentity{
+			Kind:    SourceKindDefaults,
+			Locator: s.Reason,
+		},
+	}, nil
+}
+
+func ResolveTrustedSource(ctx context.Context, request TrustedSourceRequest) (Source, error) {
+	if request.Disabled {
+		return DisabledSource{Locator: "--no-config"}, nil
+	}
+	if request.RepositoryRoot == "" {
+		return nil, fmt.Errorf("trusted configuration repository root must not be empty")
+	}
+
+	switch request.Policy {
+	case CanonicalRemoteDefault:
+		if request.Remote == "" {
+			return nil, fmt.Errorf("remote-default canonical policy requires a remote")
+		}
+		branch, err := gitpkg.RemoteDefaultBranch(ctx, request.RepositoryRoot, request.Remote)
+		if err != nil {
+			return nil, fmt.Errorf("failed to select trusted review configuration: %w", err)
+		}
+		return resolveRemoteBranchSource(ctx, request.RepositoryRoot, request.Remote, branch)
+	case CanonicalNamedBranch:
+		if request.Branch == "" {
+			return nil, fmt.Errorf("named-branch canonical policy requires a branch")
+		}
+		if request.Remote != "" {
+			return resolveRemoteBranchSource(ctx, request.RepositoryRoot, request.Remote, request.Branch)
+		}
+		ref := "refs/heads/" + request.Branch
+		exists, err := gitpkg.RefExists(ctx, request.RepositoryRoot, ref)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect local canonical review configuration: %w", err)
+		}
+		if !exists {
+			return DefaultsSource{Reason: "canonical branch " + request.Branch + " is unavailable"}, nil
+		}
+		source, err := NewRepositoryRevisionSource(ctx, request.RepositoryRoot, ref)
+		if err != nil {
+			return nil, fmt.Errorf("failed to snapshot local canonical review configuration: %w", err)
+		}
+		return source, nil
+	default:
+		return nil, fmt.Errorf("unsupported canonical policy %q", request.Policy)
+	}
+}
+
+func resolveRemoteBranchSource(ctx context.Context, repositoryRoot, remote, branch string) (Source, error) {
+	if err := gitpkg.FetchBaseRef(repositoryRoot, remote, branch); err != nil {
+		return nil, fmt.Errorf("failed to refresh trusted review configuration: %w", err)
+	}
+	ref := gitpkg.QualifyBaseRef(remote, branch)
+	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to snapshot trusted review configuration: %w", err)
+	}
+	return source, nil
+}
+
+func NewRepositoryRevisionSource(ctx context.Context, repositoryRoot, ref string) (RepositoryRevisionSource, error) {
+	revision, err := gitpkg.ResolveCommit(ctx, repositoryRoot, ref)
+	if err != nil {
+		return RepositoryRevisionSource{}, err
+	}
+	return RepositoryRevisionSource{
+		RepositoryRoot: repositoryRoot,
+		Ref:            ref,
+		Revision:       revision,
+	}, nil
+}
+
+func (s RepositoryRevisionSource) LoadWithWarnings(ctx context.Context) (*LoadResult, error) {
+	data, err := gitpkg.ReadFileAtCommit(ctx, s.RepositoryRoot, s.Revision, ConfigFileName)
+	if errors.Is(err, gitpkg.ErrPathNotFoundAtRevision) {
+		return &LoadResult{
+			Config: &Config{},
+			Source: SourceIdentity{
+				Kind:     SourceKindRepositoryRevision,
+				Locator:  s.RepositoryRoot,
+				Ref:      s.Ref,
+				Revision: s.Revision,
+			},
+			readConfigRelative: s.readConfigRelative,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to load trusted configuration: %w", err)
+	}
+
+	result, err := loadDataWithWarnings(data)
+	if result != nil {
+		result.Source = SourceIdentity{
+			Kind:          SourceKindRepositoryRevision,
+			Locator:       s.RepositoryRoot,
+			Ref:           s.Ref,
+			Revision:      s.Revision,
+			ConfigPresent: true,
+			ConfigDigest:  digest(data),
+		}
+		result.readConfigRelative = s.readConfigRelative
+	}
+	return result, err
+}
+
+func (s RepositoryRevisionSource) readConfigRelative(ctx context.Context, relativePath string) ([]byte, error) {
+	data, err := gitpkg.ReadFileAtCommit(ctx, s.RepositoryRoot, s.Revision, relativePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read trusted configuration input %q from %s: %w", relativePath, s.Revision, err)
+	}
+	return data, nil
+}
+
+func loadDataWithWarnings(data []byte) (*LoadResult, error) {
+	warnings := checkUnknownKeys(data)
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", ConfigFileName, err)
+	}
+
+	if err := cfg.validatePatterns(); err != nil {
+		return nil, err
+	}
+
+	if cfg.ReviewerAgent != nil {
+		warnings = append(warnings, `"reviewer_agent" is deprecated, use "reviewer_agents" list instead`)
+		if len(cfg.ReviewerAgents) > 0 {
+			warnings = append(warnings, `both "reviewer_agent" and "reviewer_agents" are set; "reviewer_agents" takes precedence`)
+		}
+	}
+
+	result := &LoadResult{Config: &cfg, Warnings: warnings}
+	if err := cfg.Validate(); err != nil {
+		return result, fmt.Errorf("%s: %w", ConfigFileName, err)
+	}
+	return result, nil
+}
+
+func newFileSystemLoadResult(path string, data []byte, configPresent bool) *LoadResult {
+	configDir := filepath.Dir(path)
+	identity := SourceIdentity{
+		Kind:          SourceKindFilesystem,
+		Locator:       path,
+		ConfigPresent: configPresent,
+	}
+	if configPresent {
+		identity.ConfigDigest = digest(data)
+	}
+	return &LoadResult{
+		ConfigDir: configDir,
+		Source:    identity,
+		readConfigRelative: func(_ context.Context, relativePath string) ([]byte, error) {
+			resolvedPath := relativePath
+			if !filepath.IsAbs(resolvedPath) {
+				resolvedPath = filepath.Join(configDir, resolvedPath)
+			}
+			return os.ReadFile(resolvedPath)
+		},
+	}
+}
+
+func digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -127,7 +127,7 @@ func ResolveTrustedSource(ctx context.Context, request TrustedSourceRequest) (So
 }
 
 func resolveRemoteBranchSource(ctx context.Context, repositoryRoot, remote, branch string) (Source, error) {
-	if err := gitpkg.FetchBaseRef(repositoryRoot, remote, branch); err != nil {
+	if err := gitpkg.FetchBaseRef(ctx, repositoryRoot, remote, branch); err != nil {
 		return nil, fmt.Errorf("failed to refresh trusted review configuration: %w", err)
 	}
 	ref := gitpkg.QualifyBaseRef(remote, branch)

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -130,7 +130,7 @@ func resolveRemoteBranchSource(ctx context.Context, repositoryRoot, remote, bran
 	if err := gitpkg.FetchBaseRef(ctx, repositoryRoot, remote, branch); err != nil {
 		return nil, fmt.Errorf("failed to refresh trusted review configuration: %w", err)
 	}
-	ref := gitpkg.QualifyBaseRef(remote, branch)
+	ref := "refs/remotes/" + remote + "/" + branch
 	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to snapshot trusted review configuration: %w", err)

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -183,6 +183,15 @@ func (s RepositoryRevisionSource) LoadWithWarnings(ctx context.Context) (*LoadRe
 			ConfigDigest:  digest(data),
 		}
 		result.readConfigRelative = s.readConfigRelative
+		if result.Config != nil && result.Config.GuidanceFile != nil && *result.Config.GuidanceFile != "" {
+			if pathErr := gitpkg.ValidateRepositoryPath(*result.Config.GuidanceFile); pathErr != nil {
+				pathErr = fmt.Errorf("invalid trusted guidance_file: %w", pathErr)
+				if err != nil {
+					return result, errors.Join(err, pathErr)
+				}
+				return result, pathErr
+			}
+		}
 	}
 	return result, err
 }

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -127,15 +127,19 @@ func ResolveTrustedSource(ctx context.Context, request TrustedSourceRequest) (So
 }
 
 func resolveRemoteBranchSource(ctx context.Context, repositoryRoot, remote, branch string) (Source, error) {
-	if err := gitpkg.FetchRemoteTrackingBranch(ctx, repositoryRoot, remote, branch); err != nil {
+	ref := trustedSnapshotRef(remote, branch)
+	if err := gitpkg.FetchRemoteBranchToRef(ctx, repositoryRoot, remote, branch, ref); err != nil {
 		return nil, fmt.Errorf("failed to refresh trusted review configuration: %w", err)
 	}
-	ref := "refs/remotes/" + remote + "/" + branch
 	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to snapshot trusted review configuration: %w", err)
 	}
 	return source, nil
+}
+
+func trustedSnapshotRef(remote, branch string) string {
+	return "refs/acr/trusted-config/" + remote + "/" + branch
 }
 
 func NewRepositoryRevisionSource(ctx context.Context, repositoryRoot, ref string) (RepositoryRevisionSource, error) {

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -143,13 +143,16 @@ func TestRepositoryRevisionSourceFailsClosedForMissingTrustedGuidance(t *testing
 func TestRepositoryRevisionSourceResolvesTrustedSymlinksWithinRevision(t *testing.T) {
 	ctx := context.Background()
 	repositoryRoot := newConfigSourceRepository(t, "", map[string]string{
-		"config/trusted.yaml":     "reviewers: 9\nguidance_file: guidance/review.md\n",
-		"guidance/trusted-review": "trusted guidance",
+		"config/v1/trusted.yaml": "reviewers: 9\nguidance_file: guidance/current/review.md\n",
+		"guidance/v1/review.md":  "trusted guidance",
 	})
-	if err := os.Symlink("config/trusted.yaml", filepath.Join(repositoryRoot, ConfigFileName)); err != nil {
+	if err := os.Symlink("v1", filepath.Join(repositoryRoot, "config", "current")); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink("trusted-review", filepath.Join(repositoryRoot, "guidance", "review.md")); err != nil {
+	if err := os.Symlink("v1", filepath.Join(repositoryRoot, "guidance", "current")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("config/current/trusted.yaml", filepath.Join(repositoryRoot, ConfigFileName)); err != nil {
 		t.Fatal(err)
 	}
 	runConfigGit(t, repositoryRoot, "add", ".")

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -215,7 +216,7 @@ func TestResolveTrustedSourceUsesExplicitRepositoryOutsideCurrentDirectory(t *te
 	}
 }
 
-func TestResolveTrustedSourceUsesFullyQualifiedRemoteTrackingRef(t *testing.T) {
+func TestResolveTrustedSourceUsesIsolatedSnapshotRef(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	seedRoot := filepath.Join(root, "seed")
@@ -257,7 +258,7 @@ func TestResolveTrustedSourceUsesFullyQualifiedRemoteTrackingRef(t *testing.T) {
 	if resolved.Reviewers != 12 {
 		t.Fatalf("Reviewers = %d", resolved.Reviewers)
 	}
-	if result.Source.Ref != "refs/remotes/origin/main" {
+	if result.Source.Ref != "refs/acr/trusted-config/origin/main" {
 		t.Fatalf("source ref = %q", result.Source.Ref)
 	}
 }
@@ -281,6 +282,7 @@ func TestResolveTrustedSourceRefreshesBranchMatchingRemotePrefix(t *testing.T) {
 	runConfigGit(t, root, "clone", "--bare", seedRoot, remoteRoot)
 	runConfigGit(t, root, "clone", remoteRoot, repositoryRoot)
 	runConfigGit(t, repositoryRoot, "remote", "rename", "origin", "release")
+	trackingRevision := configGitOutput(t, repositoryRoot, "rev-parse", "refs/remotes/release/release/2.x")
 	runConfigGit(t, seedRoot, "remote", "add", "origin", remoteRoot)
 	writeConfigSourceFile(t, seedRoot, ConfigFileName, "reviewers: 13\n")
 	runConfigGit(t, seedRoot, "add", ConfigFileName)
@@ -304,8 +306,14 @@ func TestResolveTrustedSourceRefreshesBranchMatchingRemotePrefix(t *testing.T) {
 	if resolved.Reviewers != 13 {
 		t.Fatalf("Reviewers = %d", resolved.Reviewers)
 	}
-	if result.Source.Ref != "refs/remotes/release/release/2.x" {
+	if result.Source.Ref != "refs/acr/trusted-config/release/release/2.x" {
 		t.Fatalf("source ref = %q", result.Source.Ref)
+	}
+	if got := configGitOutput(t, repositoryRoot, "rev-parse", "refs/remotes/release/release/2.x"); got != trackingRevision {
+		t.Fatalf("remote-tracking ref moved from %s to %s", trackingRevision, got)
+	}
+	if got, want := result.Source.Revision, configGitOutput(t, seedRoot, "rev-parse", "HEAD"); got != want {
+		t.Fatalf("snapshot revision = %s, want %s", got, want)
 	}
 }
 
@@ -367,6 +375,17 @@ func runConfigGit(t *testing.T, repositoryRoot string, args ...string) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
+}
+
+func configGitOutput(t *testing.T, repositoryRoot string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repositoryRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func stringPointer(value string) *string {

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -176,6 +176,53 @@ func TestResolveTrustedSourceUsesExplicitRepositoryOutsideCurrentDirectory(t *te
 	}
 }
 
+func TestResolveTrustedSourceUsesFullyQualifiedRemoteTrackingRef(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	seedRoot := filepath.Join(root, "seed")
+	remoteRoot := filepath.Join(root, "origin.git")
+	repositoryRoot := filepath.Join(root, "working")
+	if err := os.MkdirAll(seedRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runConfigGit(t, seedRoot, "init", "-b", "main")
+	runConfigGit(t, seedRoot, "config", "user.email", "test@example.com")
+	runConfigGit(t, seedRoot, "config", "user.name", "Test User")
+	writeConfigSourceFile(t, seedRoot, ConfigFileName, "reviewers: 12\n")
+	runConfigGit(t, seedRoot, "add", ".")
+	runConfigGit(t, seedRoot, "commit", "-m", "trusted")
+	runConfigGit(t, root, "clone", "--bare", seedRoot, remoteRoot)
+	runConfigGit(t, root, "clone", remoteRoot, repositoryRoot)
+	runConfigGit(t, repositoryRoot, "config", "user.email", "test@example.com")
+	runConfigGit(t, repositoryRoot, "config", "user.name", "Test User")
+	runConfigGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writeConfigSourceFile(t, repositoryRoot, ConfigFileName, "reviewers: 1\n")
+	runConfigGit(t, repositoryRoot, "add", ".")
+	runConfigGit(t, repositoryRoot, "commit", "-m", "incoming")
+	runConfigGit(t, repositoryRoot, "tag", "origin/main")
+
+	source, err := ResolveTrustedSource(ctx, TrustedSourceRequest{
+		RepositoryRoot: repositoryRoot,
+		Remote:         "origin",
+		Branch:         "main",
+		Policy:         CanonicalNamedBranch,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(result.Config, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.Reviewers != 12 {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+	if result.Source.Ref != "refs/remotes/origin/main" {
+		t.Fatalf("source ref = %q", result.Source.Ref)
+	}
+}
+
 func TestResolveTrustedSourceDisabledIdentity(t *testing.T) {
 	ctx := context.Background()
 	source, err := ResolveTrustedSource(ctx, TrustedSourceRequest{

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -223,6 +223,53 @@ func TestResolveTrustedSourceUsesFullyQualifiedRemoteTrackingRef(t *testing.T) {
 	}
 }
 
+func TestResolveTrustedSourceRefreshesBranchMatchingRemotePrefix(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	seedRoot := filepath.Join(root, "seed")
+	remoteRoot := filepath.Join(root, "release.git")
+	repositoryRoot := filepath.Join(root, "working")
+	if err := os.MkdirAll(seedRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runConfigGit(t, seedRoot, "init", "-b", "main")
+	runConfigGit(t, seedRoot, "config", "user.email", "test@example.com")
+	runConfigGit(t, seedRoot, "config", "user.name", "Test User")
+	writeConfigSourceFile(t, seedRoot, ConfigFileName, "reviewers: 12\n")
+	runConfigGit(t, seedRoot, "add", ".")
+	runConfigGit(t, seedRoot, "commit", "-m", "initial")
+	runConfigGit(t, seedRoot, "checkout", "-b", "release/2.x")
+	runConfigGit(t, root, "clone", "--bare", seedRoot, remoteRoot)
+	runConfigGit(t, root, "clone", remoteRoot, repositoryRoot)
+	runConfigGit(t, repositoryRoot, "remote", "rename", "origin", "release")
+	runConfigGit(t, seedRoot, "remote", "add", "origin", remoteRoot)
+	writeConfigSourceFile(t, seedRoot, ConfigFileName, "reviewers: 13\n")
+	runConfigGit(t, seedRoot, "add", ConfigFileName)
+	runConfigGit(t, seedRoot, "commit", "-m", "updated")
+	runConfigGit(t, seedRoot, "push", "origin", "release/2.x")
+
+	source, err := ResolveTrustedSource(ctx, TrustedSourceRequest{
+		RepositoryRoot: repositoryRoot,
+		Remote:         "release",
+		Branch:         "release/2.x",
+		Policy:         CanonicalNamedBranch,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(result.Config, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.Reviewers != 13 {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+	if result.Source.Ref != "refs/remotes/release/release/2.x" {
+		t.Fatalf("source ref = %q", result.Source.Ref)
+	}
+}
+
 func TestResolveTrustedSourceDisabledIdentity(t *testing.T) {
 	ctx := context.Background()
 	source, err := ResolveTrustedSource(ctx, TrustedSourceRequest{

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestRepositoryRevisionSourceIgnoresTargetConfiguration(t *testing.T) {
+	trustedConfig := "reviewers: 7\nguidance_file: guidance/trusted.md\nfilters:\n  exclude_patterns:\n    - trusted-pattern\n"
+	tests := []struct {
+		name         string
+		targetConfig *string
+		targetFiles  map[string]string
+	}{
+		{
+			name:         "conflicting",
+			targetConfig: stringPointer("reviewers: 1\nguidance_file: guidance/target.md\n"),
+			targetFiles:  map[string]string{"guidance/target.md": "target guidance"},
+		},
+		{
+			name:         "broken",
+			targetConfig: stringPointer("reviewers: [broken\n"),
+		},
+		{
+			name: "missing",
+		},
+		{
+			name:         "redirecting",
+			targetConfig: stringPointer("reviewers: 1\nguidance_file: ../target-guidance.md\n"),
+			targetFiles:  map[string]string{"target-guidance.md": "target guidance"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			repositoryRoot := newConfigSourceRepository(t, trustedConfig, map[string]string{
+				"guidance/trusted.md": "trusted guidance",
+			})
+			runConfigGit(t, repositoryRoot, "checkout", "-b", "incoming")
+			if tt.targetConfig == nil {
+				if err := os.Remove(filepath.Join(repositoryRoot, ConfigFileName)); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				writeConfigSourceFile(t, repositoryRoot, ConfigFileName, *tt.targetConfig)
+			}
+			for path, content := range tt.targetFiles {
+				writeConfigSourceFile(t, repositoryRoot, path, content)
+			}
+
+			source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := source.LoadWithWarnings(ctx)
+			if err != nil {
+				t.Fatalf("LoadWithWarnings() error = %v", err)
+			}
+
+			resolved := Resolve(result.Config, EnvState{}, FlagState{}, ResolvedConfig{})
+			if resolved.Reviewers != 7 {
+				t.Fatalf("Reviewers = %d", resolved.Reviewers)
+			}
+			if patterns := Merge(result.Config, nil); len(patterns) != 1 || patterns[0] != "trusted-pattern" {
+				t.Fatalf("patterns = %v", patterns)
+			}
+
+			guidance, err := ResolveGuidanceFromLoadResult(ctx, result, EnvState{}, FlagState{}, ResolvedConfig{})
+			if err != nil {
+				t.Fatalf("ResolveGuidanceFromLoadResult() error = %v", err)
+			}
+			if guidance != "trusted guidance" {
+				t.Fatalf("guidance = %q", guidance)
+			}
+			if result.Source.Ref != "main" || result.Source.Revision != source.Revision || !result.Source.ConfigPresent || result.Source.ConfigDigest == "" {
+				t.Fatalf("source identity = %+v", result.Source)
+			}
+		})
+	}
+}
+
+func TestRepositoryRevisionSourceUsesDefaultsWhenTrustedConfigIsAbsent(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newConfigSourceRepository(t, "", nil)
+	runConfigGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writeConfigSourceFile(t, repositoryRoot, ConfigFileName, "reviewers: 1\n")
+
+	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(result.Config, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.Reviewers != Defaults.Reviewers {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+	if result.Source.ConfigPresent {
+		t.Fatalf("source identity = %+v", result.Source)
+	}
+}
+
+func TestRepositoryRevisionSourceFailsClosedForInvalidTrustedConfig(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newConfigSourceRepository(t, "reviewers: [broken\n", nil)
+	runConfigGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writeConfigSourceFile(t, repositoryRoot, ConfigFileName, "reviewers: 1\n")
+
+	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.LoadWithWarnings(ctx); err == nil {
+		t.Fatal("LoadWithWarnings succeeded")
+	}
+}
+
+func TestRepositoryRevisionSourceFailsClosedForMissingTrustedGuidance(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newConfigSourceRepository(t, "guidance_file: guidance/review.md\n", nil)
+	runConfigGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writeConfigSourceFile(t, repositoryRoot, "guidance/review.md", "target guidance")
+
+	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveGuidanceFromLoadResult(ctx, result, EnvState{}, FlagState{}, ResolvedConfig{}); err == nil {
+		t.Fatal("ResolveGuidanceFromLoadResult succeeded")
+	}
+}
+
+func TestResolveTrustedSourceUsesExplicitRepositoryOutsideCurrentDirectory(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newConfigSourceRepository(t, "reviewers: 11\n", nil)
+	runConfigGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writeConfigSourceFile(t, repositoryRoot, ConfigFileName, "reviewers: 1\n")
+
+	originalDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalDirectory)
+
+	source, err := ResolveTrustedSource(ctx, TrustedSourceRequest{
+		RepositoryRoot: repositoryRoot,
+		Branch:         "main",
+		Policy:         CanonicalNamedBranch,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(result.Config, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.Reviewers != 11 {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+	if result.Source.Locator != repositoryRoot {
+		t.Fatalf("source = %+v", result.Source)
+	}
+}
+
+func TestResolveTrustedSourceDisabledIdentity(t *testing.T) {
+	ctx := context.Background()
+	source, err := ResolveTrustedSource(ctx, TrustedSourceRequest{
+		RepositoryRoot: "/does/not/exist",
+		Disabled:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source.Kind != SourceKindDisabled || result.Source.Locator != "--no-config" {
+		t.Fatalf("source = %+v", result.Source)
+	}
+	resolved := Resolve(result.Config, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.Reviewers != Defaults.Reviewers {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+}
+
+func newConfigSourceRepository(t *testing.T, trustedConfig string, trustedFiles map[string]string) string {
+	t.Helper()
+	repositoryRoot := t.TempDir()
+	runConfigGit(t, repositoryRoot, "init", "-b", "main")
+	runConfigGit(t, repositoryRoot, "config", "user.email", "test@example.com")
+	runConfigGit(t, repositoryRoot, "config", "user.name", "Test User")
+	writeConfigSourceFile(t, repositoryRoot, "tracked.txt", "tracked")
+	if trustedConfig != "" {
+		writeConfigSourceFile(t, repositoryRoot, ConfigFileName, trustedConfig)
+	}
+	for path, content := range trustedFiles {
+		writeConfigSourceFile(t, repositoryRoot, path, content)
+	}
+	runConfigGit(t, repositoryRoot, "add", ".")
+	runConfigGit(t, repositoryRoot, "commit", "-m", "trusted")
+	return repositoryRoot
+}
+
+func writeConfigSourceFile(t *testing.T, repositoryRoot, relativePath, content string) {
+	t.Helper()
+	filePath := filepath.Join(repositoryRoot, relativePath)
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runConfigGit(t *testing.T, repositoryRoot string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repositoryRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -141,6 +141,22 @@ func TestRepositoryRevisionSourceFailsClosedForMissingTrustedGuidance(t *testing
 	}
 }
 
+func TestRepositoryRevisionSourceRejectsInvalidGuidancePathBeforePrecedence(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newConfigSourceRepository(t, "guidance: trusted inline\nguidance_file: ../outside.md\n", nil)
+	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err == nil || !strings.Contains(err.Error(), "invalid trusted guidance_file") {
+		t.Fatalf("LoadWithWarnings() error = %v", err)
+	}
+	if result == nil || result.Config == nil {
+		t.Fatalf("failed load lost diagnostics: %#v", result)
+	}
+}
+
 func TestRepositoryRevisionSourceResolvesTrustedSymlinksWithinRevision(t *testing.T) {
 	ctx := context.Background()
 	repositoryRoot := newConfigSourceRepository(t, "", map[string]string{

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -180,6 +180,24 @@ func TestRepositoryRevisionSourceResolvesTrustedSymlinksWithinRevision(t *testin
 	}
 }
 
+func TestRepositoryRevisionSourceFailsClosedForDanglingTrustedConfigSymlink(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newConfigSourceRepository(t, "", nil)
+	if err := os.Symlink("missing-config.yaml", filepath.Join(repositoryRoot, ConfigFileName)); err != nil {
+		t.Fatal(err)
+	}
+	runConfigGit(t, repositoryRoot, "add", ConfigFileName)
+	runConfigGit(t, repositoryRoot, "commit", "-m", "dangling trusted config")
+
+	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.LoadWithWarnings(ctx); err == nil || !strings.Contains(err.Error(), "resolves to missing path") {
+		t.Fatalf("LoadWithWarnings() error = %v", err)
+	}
+}
+
 func TestResolveTrustedSourceUsesExplicitRepositoryOutsideCurrentDirectory(t *testing.T) {
 	ctx := context.Background()
 	repositoryRoot := newConfigSourceRepository(t, "reviewers: 11\n", nil)

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -140,6 +140,42 @@ func TestRepositoryRevisionSourceFailsClosedForMissingTrustedGuidance(t *testing
 	}
 }
 
+func TestRepositoryRevisionSourceResolvesTrustedSymlinksWithinRevision(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newConfigSourceRepository(t, "", map[string]string{
+		"config/trusted.yaml":     "reviewers: 9\nguidance_file: guidance/review.md\n",
+		"guidance/trusted-review": "trusted guidance",
+	})
+	if err := os.Symlink("config/trusted.yaml", filepath.Join(repositoryRoot, ConfigFileName)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("trusted-review", filepath.Join(repositoryRoot, "guidance", "review.md")); err != nil {
+		t.Fatal(err)
+	}
+	runConfigGit(t, repositoryRoot, "add", ".")
+	runConfigGit(t, repositoryRoot, "commit", "-m", "trusted symlinks")
+
+	source, err := NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := Resolve(result.Config, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.Reviewers != 9 {
+		t.Fatalf("Reviewers = %d", resolved.Reviewers)
+	}
+	guidance, err := ResolveGuidanceFromLoadResult(ctx, result, EnvState{}, FlagState{}, ResolvedConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if guidance != "trusted guidance" {
+		t.Fatalf("guidance = %q", guidance)
+	}
+}
+
 func TestResolveTrustedSourceUsesExplicitRepositoryOutsideCurrentDirectory(t *testing.T) {
 	ctx := context.Background()
 	repositoryRoot := newConfigSourceRepository(t, "reviewers: 11\n", nil)

--- a/internal/domain/result.go
+++ b/internal/domain/result.go
@@ -2,15 +2,43 @@ package domain
 
 import "time"
 
+type ReviewerFailureKind string
+
+const (
+	ReviewerFailureExecution   ReviewerFailureKind = "execution"
+	ReviewerFailureExit        ReviewerFailureKind = "exit"
+	ReviewerFailureTimeout     ReviewerFailureKind = "timeout"
+	ReviewerFailureAuth        ReviewerFailureKind = "authentication"
+	ReviewerFailureInterrupted ReviewerFailureKind = "interrupted"
+	ReviewerFailureParser      ReviewerFailureKind = "parser"
+)
+
+type ReviewerFailure struct {
+	Kind    ReviewerFailureKind
+	Message string
+}
+
+type ReviewerWarningKind string
+
+const ReviewerWarningCleanup ReviewerWarningKind = "cleanup"
+
+type ReviewerWarning struct {
+	Kind    ReviewerWarningKind
+	Message string
+}
+
 type ReviewerResult struct {
 	ReviewerID  int
 	AgentName   string
 	Findings    []Finding
 	ExitCode    int
+	Attempts    int
 	ParseErrors int
 	TimedOut    bool
 	AuthFailed  bool
 	Duration    time.Duration
+	Failure     *ReviewerFailure
+	Warnings    []ReviewerWarning
 }
 
 type ReviewStats struct {

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -344,6 +344,7 @@ type FalsePositiveFilterOutcome struct {
 	SkipReason string
 	EvalErrors int
 	Duration   time.Duration
+	Warnings   []string
 	Removed    []ReviewFinding
 }
 

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -19,7 +19,7 @@ type PullRequestKey struct {
 	Number     int
 }
 
-var pullRequestHostPattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?$`)
+var pullRequestHostPattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$`)
 
 var pullRequestPathComponentPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -320,6 +320,7 @@ type SummarizerOutcome struct {
 	Stderr           string
 	DiagnosticOutput string
 	Duration         time.Duration
+	Warnings         []string
 }
 
 type ReviewFindingKind string

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -1,0 +1,379 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+type PullRequestKey struct {
+	Host       string
+	Owner      string
+	Repository string
+	Number     int
+}
+
+func (k PullRequestKey) Validate() error {
+	var invalid []string
+	if strings.TrimSpace(k.Host) == "" {
+		invalid = append(invalid, "host is required")
+	}
+	if strings.TrimSpace(k.Owner) == "" {
+		invalid = append(invalid, "owner is required")
+	}
+	if strings.TrimSpace(k.Repository) == "" {
+		invalid = append(invalid, "repository is required")
+	}
+	if k.Number < 1 {
+		invalid = append(invalid, "pull request number must be positive")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid pull request key: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func (k PullRequestKey) String() string {
+	return fmt.Sprintf("%s/%s/%s#%d", k.Host, k.Owner, k.Repository, k.Number)
+}
+
+type RevisionEvidence struct {
+	RequestedBaseRef string
+	ResolvedBaseRef  string
+	HeadObjectID     string
+	BaseObjectID     string
+}
+
+type ReviewTarget struct {
+	RepositoryRoot string
+	WorktreeRoot   string
+	Revision       RevisionEvidence
+	PullRequest    *PullRequestKey
+}
+
+func (t ReviewTarget) Validate() error {
+	var invalid []string
+	if !filepath.IsAbs(t.RepositoryRoot) {
+		invalid = append(invalid, "repository root must be absolute")
+	}
+	if !filepath.IsAbs(t.WorktreeRoot) {
+		invalid = append(invalid, "worktree root must be absolute")
+	}
+	if strings.TrimSpace(t.Revision.RequestedBaseRef) == "" {
+		invalid = append(invalid, "requested base ref is required")
+	}
+	if strings.TrimSpace(t.Revision.ResolvedBaseRef) == "" {
+		invalid = append(invalid, "resolved base ref is required")
+	}
+	if t.PullRequest != nil {
+		if err := t.PullRequest.Validate(); err != nil {
+			invalid = append(invalid, err.Error())
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid review target: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func (t ReviewTarget) Clone() ReviewTarget {
+	clone := t
+	if t.PullRequest != nil {
+		key := *t.PullRequest
+		clone.PullRequest = &key
+	}
+	return clone
+}
+
+type ReviewTrigger string
+
+const (
+	ReviewTriggerManual ReviewTrigger = "manual"
+	ReviewTriggerWatch  ReviewTrigger = "watch"
+	ReviewTriggerDesk   ReviewTrigger = "desk"
+)
+
+func (t ReviewTrigger) Validate() error {
+	switch t {
+	case ReviewTriggerManual, ReviewTriggerWatch, ReviewTriggerDesk:
+		return nil
+	default:
+		return fmt.Errorf("invalid review trigger %q", t)
+	}
+}
+
+type ReviewStatus string
+
+const (
+	ReviewStatusCompleted   ReviewStatus = "completed"
+	ReviewStatusFailed      ReviewStatus = "failed"
+	ReviewStatusInterrupted ReviewStatus = "interrupted"
+)
+
+type ReviewConclusion string
+
+const (
+	ReviewConclusionNone      ReviewConclusion = ""
+	ReviewConclusionNoChanges ReviewConclusion = "no_changes"
+	ReviewConclusionClean     ReviewConclusion = "clean"
+	ReviewConclusionFindings  ReviewConclusion = "findings"
+)
+
+type ReviewPhase string
+
+const (
+	ReviewPhaseInitialization      ReviewPhase = "initialization"
+	ReviewPhaseRevisions           ReviewPhase = "revisions"
+	ReviewPhaseDiff                ReviewPhase = "diff"
+	ReviewPhaseReviewers           ReviewPhase = "reviewers"
+	ReviewPhaseFeedback            ReviewPhase = "feedback"
+	ReviewPhaseSummarization       ReviewPhase = "summarization"
+	ReviewPhaseFalsePositiveFilter ReviewPhase = "false_positive_filter"
+	ReviewPhaseExcludeFilter       ReviewPhase = "exclude_filter"
+	ReviewPhaseComplete            ReviewPhase = "complete"
+)
+
+type ReviewEngine struct {
+	Name    string
+	Version string
+}
+
+func (e ReviewEngine) Validate() error {
+	if strings.TrimSpace(e.Name) == "" {
+		return fmt.Errorf("review engine name is required")
+	}
+	if strings.TrimSpace(e.Version) == "" {
+		return fmt.Errorf("review engine version is required")
+	}
+	return nil
+}
+
+type ConfigurationSourceIdentity struct {
+	Kind          string
+	Locator       string
+	Ref           string
+	Revision      string
+	ConfigPresent bool
+	ConfigDigest  string
+}
+
+func (s ConfigurationSourceIdentity) Validate() error {
+	if strings.TrimSpace(s.Kind) == "" {
+		return fmt.Errorf("configuration source kind is required")
+	}
+	if s.ConfigPresent && strings.TrimSpace(s.ConfigDigest) == "" {
+		return fmt.Errorf("configuration source digest is required when configuration is present")
+	}
+	if !s.ConfigPresent && s.ConfigDigest != "" {
+		return fmt.Errorf("configuration source digest requires a present configuration")
+	}
+	return nil
+}
+
+type ReviewConfigurationValues struct {
+	Reviewers         int
+	Concurrency       int
+	Timeout           time.Duration
+	Retries           int
+	ReviewerAgents    []string
+	ReviewerModel     string
+	SummarizerAgent   string
+	SummarizerModel   string
+	SummarizerTimeout time.Duration
+	FPFilterTimeout   time.Duration
+	Guidance          string
+	UseRefFile        bool
+	FPFilterEnabled   bool
+	FPThreshold       int
+	PRFeedbackEnabled bool
+	PRFeedbackAgent   string
+	ExcludePatterns   []string
+}
+
+type ReviewConfiguration struct {
+	values      ReviewConfigurationValues
+	fingerprint string
+}
+
+func NewReviewConfiguration(values ReviewConfigurationValues) (ReviewConfiguration, error) {
+	values.ReviewerAgents = cloneStrings(values.ReviewerAgents)
+	values.ExcludePatterns = cloneStrings(values.ExcludePatterns)
+
+	if err := validateReviewConfiguration(values); err != nil {
+		return ReviewConfiguration{}, err
+	}
+
+	payload, err := json.Marshal(values)
+	if err != nil {
+		return ReviewConfiguration{}, fmt.Errorf("fingerprint review configuration: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+
+	return ReviewConfiguration{
+		values:      values,
+		fingerprint: "sha256:" + hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+func (c ReviewConfiguration) Values() ReviewConfigurationValues {
+	values := c.values
+	values.ReviewerAgents = slices.Clone(c.values.ReviewerAgents)
+	values.ExcludePatterns = slices.Clone(c.values.ExcludePatterns)
+	return values
+}
+
+func (c ReviewConfiguration) Fingerprint() string {
+	return c.fingerprint
+}
+
+func (c ReviewConfiguration) Validate() error {
+	if err := validateReviewConfiguration(c.values); err != nil {
+		return err
+	}
+	if c.fingerprint == "" {
+		return fmt.Errorf("review configuration fingerprint is required")
+	}
+	return nil
+}
+
+func validateReviewConfiguration(values ReviewConfigurationValues) error {
+	var invalid []string
+	if values.Reviewers < 1 {
+		invalid = append(invalid, "reviewers must be positive")
+	}
+	if values.Concurrency < 1 {
+		invalid = append(invalid, "concurrency must be positive")
+	} else if values.Concurrency > values.Reviewers {
+		invalid = append(invalid, "concurrency cannot exceed reviewers")
+	}
+	if values.Timeout <= 0 {
+		invalid = append(invalid, "reviewer timeout must be positive")
+	}
+	if values.Retries < 0 {
+		invalid = append(invalid, "retries cannot be negative")
+	}
+	if len(values.ReviewerAgents) == 0 {
+		invalid = append(invalid, "at least one reviewer agent is required")
+	}
+	for i, name := range values.ReviewerAgents {
+		if strings.TrimSpace(name) == "" {
+			invalid = append(invalid, fmt.Sprintf("reviewer agent %d is empty", i+1))
+		}
+	}
+	if strings.TrimSpace(values.SummarizerAgent) == "" {
+		invalid = append(invalid, "summarizer agent is required")
+	}
+	if values.SummarizerTimeout <= 0 {
+		invalid = append(invalid, "summarizer timeout must be positive")
+	}
+	if values.FPFilterTimeout <= 0 {
+		invalid = append(invalid, "false-positive filter timeout must be positive")
+	}
+	if values.FPThreshold < 1 || values.FPThreshold > 100 {
+		invalid = append(invalid, "false-positive threshold must be between 1 and 100")
+	}
+	for _, pattern := range values.ExcludePatterns {
+		if _, err := regexp.Compile(pattern); err != nil {
+			invalid = append(invalid, fmt.Sprintf("invalid exclude pattern %q: %v", pattern, err))
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid review configuration: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return slices.Clone(values)
+}
+
+type ReviewFailure struct {
+	Phase   ReviewPhase
+	Message string
+}
+
+type SummarizerOutcome struct {
+	ExitCode         int
+	Stderr           string
+	DiagnosticOutput string
+	Duration         time.Duration
+}
+
+type ReviewFindingKind string
+
+const (
+	ReviewFindingActionable    ReviewFindingKind = "actionable"
+	ReviewFindingInformational ReviewFindingKind = "informational"
+)
+
+type ReviewFinding struct {
+	ID          string
+	Kind        ReviewFindingKind
+	Group       FindingGroup
+	Disposition Disposition
+}
+
+type FalsePositiveFilterOutcome struct {
+	Enabled    bool
+	Applied    bool
+	Skipped    bool
+	SkipReason string
+	EvalErrors int
+	Duration   time.Duration
+	Removed    []ReviewFinding
+}
+
+type ExcludeFilterOutcome struct {
+	Patterns []string
+	Removed  []ReviewFinding
+}
+
+type ReviewRun struct {
+	ID                       string
+	Target                   ReviewTarget
+	Trigger                  ReviewTrigger
+	Engine                   ReviewEngine
+	StartedAt                time.Time
+	CompletedAt              time.Time
+	Configuration            ReviewConfiguration
+	ConfigurationSource      ConfigurationSourceIdentity
+	ConfigurationFingerprint string
+	Status                   ReviewStatus
+	Conclusion               ReviewConclusion
+	Failure                  *ReviewFailure
+	ReviewerResults          []ReviewerResult
+	Stats                    ReviewStats
+	Summarizer               SummarizerOutcome
+	RawFindings              []Finding
+	AggregatedFindings       []AggregatedFinding
+	PreFilterSummary         GroupedFindings
+	FindingRecords           []ReviewFinding
+	Findings                 []ReviewFinding
+	Info                     []ReviewFinding
+	FalsePositiveFilter      FalsePositiveFilterOutcome
+	ExcludeFilter            ExcludeFilterOutcome
+	Dispositions             map[int]Disposition
+}
+
+func (r ReviewRun) FinalGroupedFindings() GroupedFindings {
+	grouped := GroupedFindings{
+		Findings: make([]FindingGroup, 0, len(r.Findings)),
+		Info:     make([]FindingGroup, 0, len(r.Info)),
+	}
+	for _, finding := range r.Findings {
+		grouped.Findings = append(grouped.Findings, finding.Group)
+	}
+	for _, finding := range r.Info {
+		grouped.Info = append(grouped.Info, finding.Group)
+	}
+	return grouped
+}

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -19,16 +19,26 @@ type PullRequestKey struct {
 	Number     int
 }
 
+var pullRequestHostPattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?$`)
+
+var pullRequestPathComponentPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
 func (k PullRequestKey) Validate() error {
 	var invalid []string
 	if strings.TrimSpace(k.Host) == "" {
 		invalid = append(invalid, "host is required")
+	} else if strings.TrimSpace(k.Host) != k.Host || !pullRequestHostPattern.MatchString(k.Host) {
+		invalid = append(invalid, "host contains invalid characters")
 	}
 	if strings.TrimSpace(k.Owner) == "" {
 		invalid = append(invalid, "owner is required")
+	} else if !validPullRequestPathComponent(k.Owner) {
+		invalid = append(invalid, "owner contains invalid characters")
 	}
 	if strings.TrimSpace(k.Repository) == "" {
 		invalid = append(invalid, "repository is required")
+	} else if !validPullRequestPathComponent(k.Repository) {
+		invalid = append(invalid, "repository contains invalid characters")
 	}
 	if k.Number < 1 {
 		invalid = append(invalid, "pull request number must be positive")
@@ -37,6 +47,10 @@ func (k PullRequestKey) Validate() error {
 		return fmt.Errorf("invalid pull request key: %s", strings.Join(invalid, "; "))
 	}
 	return nil
+}
+
+func validPullRequestPathComponent(value string) bool {
+	return strings.TrimSpace(value) == value && value != "." && value != ".." && pullRequestPathComponentPattern.MatchString(value)
 }
 
 func (k PullRequestKey) String() string {

--- a/internal/domain/review_test.go
+++ b/internal/domain/review_test.go
@@ -28,12 +28,17 @@ func validReviewConfigurationValues() ReviewConfigurationValues {
 }
 
 func TestPullRequestKeyValidate(t *testing.T) {
-	valid := PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
-	if err := valid.Validate(); err != nil {
-		t.Fatalf("valid key rejected: %v", err)
+	valid := []PullRequestKey{
+		{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42},
+		{Host: "github.example.com:8443", Owner: "owner-name", Repository: ".github", Number: 1},
 	}
-	if valid.String() != "github.com/owner/repo#42" {
-		t.Fatalf("unexpected key string %q", valid.String())
+	for _, key := range valid {
+		if err := key.Validate(); err != nil {
+			t.Fatalf("valid key rejected: %v", err)
+		}
+	}
+	if valid[0].String() != "github.com/owner/repo#42" {
+		t.Fatalf("unexpected key string %q", valid[0].String())
 	}
 
 	invalid := PullRequestKey{}
@@ -44,6 +49,23 @@ func TestPullRequestKeyValidate(t *testing.T) {
 	for _, part := range []string{"host", "owner", "repository", "number"} {
 		if !strings.Contains(err.Error(), part) {
 			t.Errorf("validation error %q does not mention %q", err, part)
+		}
+	}
+}
+
+func TestPullRequestKeyRejectsUnsafeComponents(t *testing.T) {
+	tests := []PullRequestKey{
+		{Host: "https://github.com", Owner: "owner", Repository: "repo", Number: 1},
+		{Host: "github.com/other", Owner: "owner", Repository: "repo", Number: 1},
+		{Host: "github.com", Owner: "..", Repository: "repo", Number: 1},
+		{Host: "github.com", Owner: "owner/replacement", Repository: "repo", Number: 1},
+		{Host: "github.com", Owner: "owner", Repository: "..", Number: 1},
+		{Host: "github.com", Owner: "owner", Repository: "repo/name", Number: 1},
+		{Host: "github.com", Owner: "owner", Repository: "%2F", Number: 1},
+	}
+	for _, key := range tests {
+		if err := key.Validate(); err == nil {
+			t.Errorf("unsafe key accepted: %#v", key)
 		}
 	}
 }

--- a/internal/domain/review_test.go
+++ b/internal/domain/review_test.go
@@ -1,0 +1,200 @@
+package domain
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func validReviewConfigurationValues() ReviewConfigurationValues {
+	return ReviewConfigurationValues{
+		Reviewers:         3,
+		Concurrency:       2,
+		Timeout:           time.Minute,
+		Retries:           1,
+		ReviewerAgents:    []string{"codex", "claude"},
+		ReviewerModel:     "review-model",
+		SummarizerAgent:   "codex",
+		SummarizerModel:   "summary-model",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		Guidance:          "focus on correctness",
+		FPFilterEnabled:   true,
+		FPThreshold:       75,
+		PRFeedbackEnabled: true,
+		ExcludePatterns:   []string{"generated/"},
+	}
+}
+
+func TestPullRequestKeyValidate(t *testing.T) {
+	valid := PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid key rejected: %v", err)
+	}
+	if valid.String() != "github.com/owner/repo#42" {
+		t.Fatalf("unexpected key string %q", valid.String())
+	}
+
+	invalid := PullRequestKey{}
+	err := invalid.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	for _, part := range []string{"host", "owner", "repository", "number"} {
+		if !strings.Contains(err.Error(), part) {
+			t.Errorf("validation error %q does not mention %q", err, part)
+		}
+	}
+}
+
+func TestReviewTargetAllowsLocalReviewWithoutPullRequest(t *testing.T) {
+	root := t.TempDir()
+	target := ReviewTarget{
+		RepositoryRoot: root,
+		WorktreeRoot:   filepath.Join(root, "worktree"),
+		Revision: RevisionEvidence{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "origin/main",
+		},
+	}
+
+	if err := target.Validate(); err != nil {
+		t.Fatalf("local target rejected: %v", err)
+	}
+}
+
+func TestReviewConfigurationIsImmutableAndFingerprintIsDeterministic(t *testing.T) {
+	values := validReviewConfigurationValues()
+	first, err := NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create first configuration: %v", err)
+	}
+	second, err := NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create second configuration: %v", err)
+	}
+	if first.Fingerprint() != second.Fingerprint() {
+		t.Fatalf("fingerprints differ: %q != %q", first.Fingerprint(), second.Fingerprint())
+	}
+
+	values.ReviewerAgents[0] = "changed"
+	values.ExcludePatterns[0] = "changed"
+	got := first.Values()
+	if got.ReviewerAgents[0] != "codex" {
+		t.Fatalf("reviewer agents changed through input alias: %v", got.ReviewerAgents)
+	}
+	if got.ExcludePatterns[0] != "generated/" {
+		t.Fatalf("exclude patterns changed through input alias: %v", got.ExcludePatterns)
+	}
+
+	got.ReviewerAgents[0] = "changed-again"
+	if first.Values().ReviewerAgents[0] != "codex" {
+		t.Fatal("configuration values exposed mutable reviewer agents")
+	}
+}
+
+func TestReviewConfigurationFingerprintChangesWithSemanticInput(t *testing.T) {
+	firstValues := validReviewConfigurationValues()
+	secondValues := validReviewConfigurationValues()
+	secondValues.FPThreshold = 90
+
+	first, err := NewReviewConfiguration(firstValues)
+	if err != nil {
+		t.Fatalf("create first configuration: %v", err)
+	}
+	second, err := NewReviewConfiguration(secondValues)
+	if err != nil {
+		t.Fatalf("create second configuration: %v", err)
+	}
+	if first.Fingerprint() == second.Fingerprint() {
+		t.Fatal("semantic configuration change did not alter fingerprint")
+	}
+}
+
+func TestReviewConfigurationRejectsInvalidInputs(t *testing.T) {
+	values := validReviewConfigurationValues()
+	values.Reviewers = 0
+	values.ExcludePatterns = []string{"["}
+
+	_, err := NewReviewConfiguration(values)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "reviewers") || !strings.Contains(err.Error(), "exclude") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestReviewConfigurationRequiresResolvedConcurrency(t *testing.T) {
+	tests := []struct {
+		name        string
+		concurrency int
+	}{
+		{name: "zero", concurrency: 0},
+		{name: "greater than reviewers", concurrency: 4},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values := validReviewConfigurationValues()
+			values.Concurrency = test.concurrency
+			_, err := NewReviewConfiguration(values)
+			if err == nil || !strings.Contains(err.Error(), "concurrency") {
+				t.Fatalf("expected concurrency validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestConfigurationSourceIdentityValidation(t *testing.T) {
+	valid := []ConfigurationSourceIdentity{
+		{Kind: "test", Locator: "fixture", ConfigPresent: true, ConfigDigest: "digest"},
+		{Kind: "repository-revision", Locator: "/repo", Ref: "main", Revision: "object"},
+		{Kind: "disabled", Locator: "--no-config"},
+		{Kind: "defaults", Locator: "configuration absent"},
+	}
+	for _, source := range valid {
+		if err := source.Validate(); err != nil {
+			t.Errorf("valid source %#v rejected: %v", source, err)
+		}
+	}
+
+	invalid := []ConfigurationSourceIdentity{
+		{},
+		{Kind: "test", ConfigPresent: true},
+		{Kind: "test", ConfigDigest: "digest"},
+	}
+	for _, source := range invalid {
+		if err := source.Validate(); err == nil {
+			t.Errorf("invalid source %#v accepted", source)
+		}
+	}
+}
+
+func TestReviewRunBuildsPresentationNeutralFinalGroups(t *testing.T) {
+	run := ReviewRun{
+		Findings: []ReviewFinding{{
+			ID:   "finding-001",
+			Kind: ReviewFindingActionable,
+			Group: FindingGroup{
+				Title: "Bug",
+			},
+		}},
+		Info: []ReviewFinding{{
+			ID:   "info-001",
+			Kind: ReviewFindingInformational,
+			Group: FindingGroup{
+				Title: "Note",
+			},
+		}},
+	}
+
+	grouped := run.FinalGroupedFindings()
+	if len(grouped.Findings) != 1 || grouped.Findings[0].Title != "Bug" {
+		t.Fatalf("unexpected actionable groups: %#v", grouped.Findings)
+	}
+	if len(grouped.Info) != 1 || grouped.Info[0].Title != "Note" {
+		t.Fatalf("unexpected informational groups: %#v", grouped.Info)
+	}
+}

--- a/internal/domain/review_test.go
+++ b/internal/domain/review_test.go
@@ -30,7 +30,7 @@ func validReviewConfigurationValues() ReviewConfigurationValues {
 func TestPullRequestKeyValidate(t *testing.T) {
 	valid := []PullRequestKey{
 		{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42},
-		{Host: "github.example.com:8443", Owner: "owner-name", Repository: ".github", Number: 1},
+		{Host: "github.example.com", Owner: "owner-name", Repository: ".github", Number: 1},
 	}
 	for _, key := range valid {
 		if err := key.Validate(); err != nil {
@@ -56,6 +56,7 @@ func TestPullRequestKeyValidate(t *testing.T) {
 func TestPullRequestKeyRejectsUnsafeComponents(t *testing.T) {
 	tests := []PullRequestKey{
 		{Host: "https://github.com", Owner: "owner", Repository: "repo", Number: 1},
+		{Host: "github.example.com:8443", Owner: "owner", Repository: "repo", Number: 1},
 		{Host: "github.com/other", Owner: "owner", Repository: "repo", Number: 1},
 		{Host: "github.com", Owner: "..", Repository: "repo", Number: 1},
 		{Host: "github.com", Owner: "owner/replacement", Repository: "repo", Number: 1},

--- a/internal/feedback/fetch.go
+++ b/internal/feedback/fetch.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strconv"
 	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 type PRContext struct {
@@ -33,19 +36,34 @@ func (p *PRContext) HasContent() bool {
 }
 
 func FetchPRContext(ctx context.Context, prNumber string) (*PRContext, error) {
+	return FetchPRContextFromDir(ctx, prNumber, "")
+}
+
+func FetchPRContextFromDir(ctx context.Context, prNumber, workDir string) (*PRContext, error) {
+	return fetchPRContext(ctx, prNumber, workDir, nil)
+}
+
+func FetchPRContextForPullRequest(ctx context.Context, key domain.PullRequestKey, workDir string) (*PRContext, error) {
+	if err := key.Validate(); err != nil {
+		return nil, err
+	}
+	return fetchPRContext(ctx, strconv.Itoa(key.Number), workDir, &key)
+}
+
+func fetchPRContext(ctx context.Context, prNumber, workDir string, key *domain.PullRequestKey) (*PRContext, error) {
 	if prNumber == "" {
 		return nil, errors.New("PR number is required")
 	}
 
 	result := &PRContext{Number: prNumber}
 
-	desc, err := fetchPRDescription(ctx, prNumber)
+	desc, err := fetchPRDescription(ctx, prNumber, workDir, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch PR description: %w", err)
 	}
 	result.Description = desc
 
-	comments, err := fetchPRComments(ctx, prNumber)
+	comments, err := fetchPRComments(ctx, prNumber, workDir, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch PR comments: %w", err)
 	}
@@ -54,8 +72,13 @@ func FetchPRContext(ctx context.Context, prNumber string) (*PRContext, error) {
 	return result, nil
 }
 
-func fetchPRDescription(ctx context.Context, prNumber string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "body", "--jq", ".body")
+func fetchPRDescription(ctx context.Context, prNumber, workDir string, key *domain.PullRequestKey) (string, error) {
+	args := []string{"pr", "view", prNumber, "--json", "body", "--jq", ".body"}
+	if key != nil {
+		args = append(args, "--repo", repositorySelector(*key))
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = workDir
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -70,11 +93,12 @@ type prCommentResponse struct {
 	Body string `json:"body"`
 }
 
-func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
+func fetchPRComments(ctx context.Context, prNumber, workDir string, key *domain.PullRequestKey) ([]Comment, error) {
 	var comments []Comment
 
-	endpoint := "repos/{owner}/{repo}/pulls/" + prNumber + "/comments"
-	cmd := exec.CommandContext(ctx, "gh", "api", "--paginate", "--jq", ".[]", endpoint)
+	endpoint := pullRequestEndpoint(key, "pulls/"+prNumber+"/comments")
+	cmd := exec.CommandContext(ctx, "gh", apiArgs(key, endpoint)...)
+	cmd.Dir = workDir
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch review comments: %w", err)
@@ -94,8 +118,9 @@ func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
 		}
 	}
 
-	endpoint = "repos/{owner}/{repo}/issues/" + prNumber + "/comments"
-	cmd = exec.CommandContext(ctx, "gh", "api", "--paginate", "--jq", ".[]", endpoint)
+	endpoint = pullRequestEndpoint(key, "issues/"+prNumber+"/comments")
+	cmd = exec.CommandContext(ctx, "gh", apiArgs(key, endpoint)...)
+	cmd.Dir = workDir
 	out, err = cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch issue comments: %w", err)
@@ -115,8 +140,9 @@ func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
 		}
 	}
 
-	endpoint = "repos/{owner}/{repo}/pulls/" + prNumber + "/reviews"
-	cmd = exec.CommandContext(ctx, "gh", "api", "--paginate", "--jq", ".[]", endpoint)
+	endpoint = pullRequestEndpoint(key, "pulls/"+prNumber+"/reviews")
+	cmd = exec.CommandContext(ctx, "gh", apiArgs(key, endpoint)...)
+	cmd.Dir = workDir
 	out, err = cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch review summaries: %w", err)
@@ -137,6 +163,25 @@ func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
 	}
 
 	return comments, nil
+}
+
+func repositorySelector(key domain.PullRequestKey) string {
+	return key.Host + "/" + key.Owner + "/" + key.Repository
+}
+
+func pullRequestEndpoint(key *domain.PullRequestKey, suffix string) string {
+	if key == nil {
+		return "repos/{owner}/{repo}/" + suffix
+	}
+	return "repos/" + key.Owner + "/" + key.Repository + "/" + suffix
+}
+
+func apiArgs(key *domain.PullRequestKey, endpoint string) []string {
+	args := []string{"api"}
+	if key != nil {
+		args = append(args, "--hostname", key.Host)
+	}
+	return append(args, "--paginate", "--jq", ".[]", endpoint)
 }
 
 func parseNDJSON(data []byte) ([]prCommentResponse, error) {

--- a/internal/feedback/fetch_test.go
+++ b/internal/feedback/fetch_test.go
@@ -3,8 +3,11 @@ package feedback
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 func TestFetchPRContext_NoPRNumber(t *testing.T) {
@@ -12,6 +15,27 @@ func TestFetchPRContext_NoPRNumber(t *testing.T) {
 	_, err := FetchPRContext(ctx, "")
 	if err == nil {
 		t.Error("expected error for empty PR number")
+	}
+}
+
+func TestPullRequestScopeUsesGlobalKey(t *testing.T) {
+	key := domain.PullRequestKey{Host: "github.example.com", Owner: "owner", Repository: "repo", Number: 42}
+	if repositorySelector(key) != "github.example.com/owner/repo" {
+		t.Fatalf("unexpected repository selector %q", repositorySelector(key))
+	}
+	endpoint := pullRequestEndpoint(&key, "pulls/42/comments")
+	if endpoint != "repos/owner/repo/pulls/42/comments" {
+		t.Fatalf("unexpected endpoint %q", endpoint)
+	}
+	wantArgs := []string{"api", "--hostname", "github.example.com", "--paginate", "--jq", ".[]", endpoint}
+	if got := apiArgs(&key, endpoint); !slices.Equal(got, wantArgs) {
+		t.Fatalf("API args = %v, want %v", got, wantArgs)
+	}
+}
+
+func TestFetchPRContextForPullRequestRejectsInvalidKey(t *testing.T) {
+	if _, err := FetchPRContextForPullRequest(context.Background(), domain.PullRequestKey{}, ""); err == nil {
+		t.Fatal("expected invalid pull request key error")
 	}
 }
 

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -33,23 +33,31 @@ func (s *Summarizer) Summarize(ctx context.Context, prNumber string) (string, er
 }
 
 func (s *Summarizer) SummarizeFromDir(ctx context.Context, prNumber, workDir string) (string, error) {
+	return s.SummarizeFromDirs(ctx, prNumber, workDir, workDir)
+}
+
+func (s *Summarizer) SummarizeFromDirs(ctx context.Context, prNumber, repositoryDir, agentDir string) (string, error) {
 	if prNumber == "" {
 		return "", fmt.Errorf("PR number is required")
 	}
 
-	prCtx, err := FetchPRContextFromDir(ctx, prNumber, workDir)
+	prCtx, err := FetchPRContextFromDir(ctx, prNumber, repositoryDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
-	return s.summarizeContext(ctx, prCtx, workDir)
+	return s.summarizeContext(ctx, prCtx, agentDir)
 }
 
 func (s *Summarizer) SummarizePullRequest(ctx context.Context, key domain.PullRequestKey, workDir string) (string, error) {
-	prCtx, err := FetchPRContextForPullRequest(ctx, key, workDir)
+	return s.SummarizePullRequestFromDirs(ctx, key, workDir, workDir)
+}
+
+func (s *Summarizer) SummarizePullRequestFromDirs(ctx context.Context, key domain.PullRequestKey, repositoryDir, agentDir string) (string, error) {
+	prCtx, err := FetchPRContextForPullRequest(ctx, key, repositoryDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
-	return s.summarizeContext(ctx, prCtx, workDir)
+	return s.summarizeContext(ctx, prCtx, agentDir)
 }
 
 func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext, workDir string) (string, error) {
@@ -97,9 +105,8 @@ func (s *Summarizer) handleCloseError(err error) error {
 	}
 	if s.verbose && s.logger != nil {
 		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
-		return nil
 	}
-	return fmt.Errorf("feedback cleanup failed: %w", err)
+	return nil
 }
 
 func (s *Summarizer) buildInput(prCtx *PRContext) string {

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -71,9 +71,7 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 		return "", fmt.Errorf("agent execution failed: %w", err)
 	}
 	defer func() {
-		if err := execResult.Close(); err != nil && s.verbose {
-			s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
-		}
+		s.logCloseError(execResult.Close())
 	}()
 
 	output, err := io.ReadAll(execResult)
@@ -93,6 +91,12 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 	}
 
 	return summary, nil
+}
+
+func (s *Summarizer) logCloseError(err error) {
+	if err != nil && s.verbose && s.logger != nil {
+		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
+	}
 }
 
 func (s *Summarizer) buildInput(prCtx *PRContext) string {

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -106,7 +106,7 @@ func (s *Summarizer) handleCloseError(err error) error {
 	if s.verbose && s.logger != nil {
 		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
 	}
-	return nil
+	return fmt.Errorf("feedback cleanup failed: %w", err)
 }
 
 func (s *Summarizer) buildInput(prCtx *PRContext) string {

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -40,7 +41,7 @@ func (s *Summarizer) SummarizeFromDir(ctx context.Context, prNumber, workDir str
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
-	return s.summarizeContext(ctx, prCtx)
+	return s.summarizeContext(ctx, prCtx, workDir)
 }
 
 func (s *Summarizer) SummarizePullRequest(ctx context.Context, key domain.PullRequestKey, workDir string) (string, error) {
@@ -48,10 +49,10 @@ func (s *Summarizer) SummarizePullRequest(ctx context.Context, key domain.PullRe
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
-	return s.summarizeContext(ctx, prCtx)
+	return s.summarizeContext(ctx, prCtx, workDir)
 }
 
-func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (string, error) {
+func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext, workDir string) (string, error) {
 	if !prCtx.HasContent() {
 		return "", nil
 	}
@@ -63,23 +64,20 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 		return "", fmt.Errorf("failed to create agent: %w", err)
 	}
 
-	execResult, err := ag.ExecuteSummary(ctx, summarizePrompt, []byte(input))
+	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: summarizePrompt, Input: []byte(input), WorkDir: workDir})
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
 		return "", fmt.Errorf("agent execution failed: %w", err)
 	}
-	defer func() {
-		s.logCloseError(execResult.Close())
-	}()
-
 	output, err := io.ReadAll(execResult)
+	closeErr := execResult.Close()
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", ctx.Err()
+			return "", errors.Join(ctx.Err(), closeErr)
 		}
-		return "", fmt.Errorf("failed to read agent output: %w", err)
+		return "", errors.Join(fmt.Errorf("failed to read agent output: %w", err), closeErr)
 	}
 
 	summary := strings.TrimSpace(string(output))
@@ -87,16 +85,21 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 	summary = agent.StripMarkdownCodeFence(summary)
 
 	if strings.Contains(strings.ToLower(summary), "no prior feedback") {
-		return "", nil
+		summary = ""
 	}
 
-	return summary, nil
+	return summary, s.handleCloseError(closeErr)
 }
 
-func (s *Summarizer) logCloseError(err error) {
-	if err != nil && s.verbose && s.logger != nil {
-		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
+func (s *Summarizer) handleCloseError(err error) error {
+	if err == nil {
+		return nil
 	}
+	if s.verbose && s.logger != nil {
+		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
+		return nil
+	}
+	return fmt.Errorf("feedback cleanup failed: %w", err)
 }
 
 func (s *Summarizer) buildInput(prCtx *PRContext) string {

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
 
@@ -27,15 +28,30 @@ func NewSummarizer(agentName, model string, verbose bool, logger *terminal.Logge
 }
 
 func (s *Summarizer) Summarize(ctx context.Context, prNumber string) (string, error) {
+	return s.SummarizeFromDir(ctx, prNumber, "")
+}
+
+func (s *Summarizer) SummarizeFromDir(ctx context.Context, prNumber, workDir string) (string, error) {
 	if prNumber == "" {
 		return "", fmt.Errorf("PR number is required")
 	}
 
-	prCtx, err := FetchPRContext(ctx, prNumber)
+	prCtx, err := FetchPRContextFromDir(ctx, prNumber, workDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
+	return s.summarizeContext(ctx, prCtx)
+}
 
+func (s *Summarizer) SummarizePullRequest(ctx context.Context, key domain.PullRequestKey, workDir string) (string, error) {
+	prCtx, err := FetchPRContextForPullRequest(ctx, key, workDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch PR context: %w", err)
+	}
+	return s.summarizeContext(ctx, prCtx)
+}
+
+func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (string, error) {
 	if !prCtx.HasContent() {
 		return "", nil
 	}

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -26,7 +26,9 @@ func TestNewSummarizer(t *testing.T) {
 
 func TestSummarizerCloseErrorWithNilLoggerDoesNotPanic(t *testing.T) {
 	s := NewSummarizer("codex", "", true, nil)
-	s.logCloseError(errors.New("cleanup failed"))
+	if err := s.handleCloseError(errors.New("cleanup failed")); err == nil {
+		t.Fatal("handleCloseError succeeded")
+	}
 }
 
 func TestBuildInput_DescriptionOnly(t *testing.T) {

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -26,8 +26,15 @@ func TestNewSummarizer(t *testing.T) {
 
 func TestSummarizerCloseErrorWithNilLoggerDoesNotPanic(t *testing.T) {
 	s := NewSummarizer("codex", "", true, nil)
-	if err := s.handleCloseError(errors.New("cleanup failed")); err == nil {
-		t.Fatal("handleCloseError succeeded")
+	if err := s.handleCloseError(errors.New("cleanup failed")); err != nil {
+		t.Fatalf("handleCloseError returned %v", err)
+	}
+}
+
+func TestSummarizerCloseErrorIsNonFatalWhenNotVerbose(t *testing.T) {
+	s := NewSummarizer("codex", "", false, nil)
+	if err := s.handleCloseError(errors.New("cleanup failed")); err != nil {
+		t.Fatalf("handleCloseError returned %v", err)
 	}
 }
 

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -24,16 +24,25 @@ func TestNewSummarizer(t *testing.T) {
 	}
 }
 
-func TestSummarizerCloseErrorWithNilLoggerDoesNotPanic(t *testing.T) {
+func TestSummarizerCloseErrorWithNilLoggerIsReported(t *testing.T) {
 	s := NewSummarizer("codex", "", true, nil)
-	if err := s.handleCloseError(errors.New("cleanup failed")); err != nil {
+	err := s.handleCloseError(errors.New("cleanup failed"))
+	if err == nil || !strings.Contains(err.Error(), "feedback cleanup failed") {
 		t.Fatalf("handleCloseError returned %v", err)
 	}
 }
 
-func TestSummarizerCloseErrorIsNonFatalWhenNotVerbose(t *testing.T) {
+func TestSummarizerCloseErrorIsReportedWhenNotVerbose(t *testing.T) {
 	s := NewSummarizer("codex", "", false, nil)
-	if err := s.handleCloseError(errors.New("cleanup failed")); err != nil {
+	err := s.handleCloseError(errors.New("cleanup failed"))
+	if err == nil || !strings.Contains(err.Error(), "cleanup failed") {
+		t.Fatalf("handleCloseError returned %v", err)
+	}
+}
+
+func TestSummarizerSuccessfulCloseReturnsNil(t *testing.T) {
+	s := NewSummarizer("codex", "", false, nil)
+	if err := s.handleCloseError(nil); err != nil {
 		t.Fatalf("handleCloseError returned %v", err)
 	}
 }

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -21,6 +22,11 @@ func TestNewSummarizer(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewSummarizer returned nil")
 	}
+}
+
+func TestSummarizerCloseErrorWithNilLoggerDoesNotPanic(t *testing.T) {
+	s := NewSummarizer("codex", "", true, nil)
+	s.logCloseError(errors.New("cleanup failed"))
 }
 
 func TestBuildInput_DescriptionOnly(t *testing.T) {

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -3,6 +3,7 @@ package fpfilter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
@@ -28,6 +29,7 @@ type Result struct {
 	EvalErrors   int
 	Skipped      bool
 	SkipReason   string
+	Warnings     []string
 }
 
 type Filter struct {
@@ -35,11 +37,12 @@ type Filter struct {
 	model     string
 	agent     agent.Agent
 	threshold int
+	workDir   string
 	verbose   bool
 	logger    *terminal.Logger
 }
 
-func New(agentName, model string, threshold int, verbose bool, logger *terminal.Logger) *Filter {
+func New(agentName, model string, threshold int, workDir string, verbose bool, logger *terminal.Logger) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
@@ -47,19 +50,26 @@ func New(agentName, model string, threshold int, verbose bool, logger *terminal.
 		agentName: agentName,
 		model:     model,
 		threshold: threshold,
+		workDir:   workDir,
 		logger:    logger,
 		verbose:   verbose,
 	}
 }
 
-func NewWithAgent(ag agent.Agent, threshold int) *Filter {
+func NewWithAgent(ag agent.Agent, threshold int, workDir string) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
 	return &Filter{
 		agent:     ag,
 		threshold: threshold,
+		workDir:   workDir,
 	}
+}
+
+func withWarnings(result *Result, warnings []string) *Result {
+	result.Warnings = append([]string(nil), warnings...)
+	return result
 }
 
 func skippedResult(grouped domain.GroupedFindings, start time.Time, reason string) *Result {
@@ -148,7 +158,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 	}
 
 	prompt := buildPromptWithFeedback(fpEvaluationPrompt, priorFeedback)
-	execResult, err := ag.ExecuteSummary(ctx, prompt, payload)
+	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: prompt, Input: payload, WorkDir: f.workDir})
 	if err != nil {
 		if ctx.Err() != nil {
 			return skippedResult(grouped, start, "context canceled")
@@ -156,35 +166,36 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		return skippedResult(grouped, start, "LLM execution failed: "+err.Error())
 	}
 
-	defer func() {
-		if err := execResult.Close(); err != nil && f.verbose && f.logger != nil {
-			f.logger.Logf(terminal.StyleDim, "fp-filter close error (non-fatal): %v", err)
-		}
-	}()
-
 	output, err := io.ReadAll(execResult)
+	var warnings []string
+	if closeErr := execResult.Close(); closeErr != nil {
+		warnings = append(warnings, fmt.Sprintf("false-positive filter cleanup failed: %v", closeErr))
+		if f.verbose && f.logger != nil {
+			f.logger.Logf(terminal.StyleDim, "fp-filter close error (non-fatal): %v", closeErr)
+		}
+	}
 	if err != nil {
 		if ctx.Err() != nil {
-			return skippedResult(grouped, start, "context canceled")
+			return withWarnings(skippedResult(grouped, start, "context canceled"), warnings)
 		}
-		return skippedResult(grouped, start, "response read failed: "+err.Error())
+		return withWarnings(skippedResult(grouped, start, "response read failed: "+err.Error()), warnings)
 	}
 
 	parser, err := agent.NewSummaryParser(ag.Name())
 	if err != nil {
-		return skippedResult(grouped, start, "parser creation failed: "+err.Error())
+		return withWarnings(skippedResult(grouped, start, "parser creation failed: "+err.Error()), warnings)
 	}
 
 	responseText, err := parser.ExtractText(output)
 	if err != nil {
-		return skippedResult(grouped, start, "response extraction failed: "+err.Error())
+		return withWarnings(skippedResult(grouped, start, "response extraction failed: "+err.Error()), warnings)
 	}
 
 	var response evaluationResponse
 	if err := json.Unmarshal([]byte(responseText), &response); err != nil {
 		r := skippedResult(grouped, start, "response parse failed: "+err.Error())
 		r.EvalErrors = len(grouped.Findings)
-		return r
+		return withWarnings(r, warnings)
 	}
 
 	evalMap := make(map[int]findingEvaluation)
@@ -218,7 +229,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		}
 	}
 
-	return &Result{
+	return withWarnings(&Result{
 		Grouped: domain.GroupedFindings{
 			Findings: kept,
 			Info:     grouped.Info,
@@ -227,5 +238,5 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		RemovedCount: len(removed),
 		Duration:     time.Since(start),
 		EvalErrors:   evalErrors,
-	}
+	}, warnings)
 }

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -32,6 +32,7 @@ type Result struct {
 type Filter struct {
 	agentName string
 	model     string
+	agent     agent.Agent
 	threshold int
 	verbose   bool
 	logger    *terminal.Logger
@@ -47,6 +48,16 @@ func New(agentName, model string, threshold int, verbose bool, logger *terminal.
 		threshold: threshold,
 		logger:    logger,
 		verbose:   verbose,
+	}
+}
+
+func NewWithAgent(ag agent.Agent, threshold int) *Filter {
+	if threshold < 1 || threshold > 100 {
+		threshold = DefaultThreshold
+	}
+	return &Filter{
+		agent:     ag,
+		threshold: threshold,
 	}
 }
 
@@ -108,9 +119,13 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		}
 	}
 
-	ag, err := agent.NewAgentWithModel(f.agentName, f.model)
-	if err != nil {
-		return skippedResult(grouped, start, "agent creation failed: "+err.Error())
+	ag := f.agent
+	if ag == nil {
+		var err error
+		ag, err = agent.NewAgentWithModel(f.agentName, f.model)
+		if err != nil {
+			return skippedResult(grouped, start, "agent creation failed: "+err.Error())
+		}
 	}
 
 	req := evaluationRequest{
@@ -141,7 +156,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 	}
 
 	defer func() {
-		if err := execResult.Close(); err != nil && f.verbose {
+		if err := execResult.Close(); err != nil && f.verbose && f.logger != nil {
 			f.logger.Logf(terminal.StyleDim, "fp-filter close error (non-fatal): %v", err)
 		}
 	}()
@@ -154,7 +169,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		return skippedResult(grouped, start, "response read failed: "+err.Error())
 	}
 
-	parser, err := agent.NewSummaryParser(f.agentName)
+	parser, err := agent.NewSummaryParser(ag.Name())
 	if err != nil {
 		return skippedResult(grouped, start, "parser creation failed: "+err.Error())
 	}

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -14,6 +14,7 @@ import (
 const DefaultThreshold = 75
 
 type EvaluatedFinding struct {
+	Index     int
 	Finding   domain.FindingGroup
 	FPScore   int
 	Reasoning string
@@ -207,6 +208,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 
 		if adjusted >= f.threshold {
 			removed = append(removed, EvaluatedFinding{
+				Index:     i,
 				Finding:   finding,
 				FPScore:   adjusted,
 				Reasoning: eval.Reasoning,

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFilter_New(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	if f == nil {
 		t.Fatal("New returned nil")
 	}
@@ -183,7 +183,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := New("codex", "", tt.threshold, false, logger)
+			f := New("codex", "", tt.threshold, "", false, logger)
 			if f.threshold != tt.expectedThreshold {
 				t.Errorf("threshold = %d, want %d", f.threshold, tt.expectedThreshold)
 			}
@@ -192,7 +192,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 }
 
 func TestApply_EmptyFindings(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -217,7 +217,7 @@ func TestApply_EmptyFindings(t *testing.T) {
 }
 
 func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -231,7 +231,7 @@ func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
 }
 
 func TestApply_EmptyFindingsPreservesInfo(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 		Info: []domain.FindingGroup{

--- a/internal/git/revision.go
+++ b/internal/git/revision.go
@@ -1,0 +1,156 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+var ErrPathNotFoundAtRevision = errors.New("path not found at revision")
+
+func RemoteExists(ctx context.Context, repoRoot, remote string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "remote")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to list git remotes: %w", err)
+	}
+	for _, name := range strings.Fields(string(out)) {
+		if name == remote {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func RefExists(ctx context.Context, repoRoot, ref string) (bool, error) {
+	if strings.TrimSpace(ref) == "" || strings.HasPrefix(ref, "-") {
+		return false, fmt.Errorf("ref %q is invalid", ref)
+	}
+	cmd := exec.CommandContext(ctx, "git", "show-ref", "--verify", "--quiet", ref)
+	cmd.Dir = repoRoot
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, fmt.Errorf("failed to inspect ref %q: %w", ref, err)
+}
+
+func RemoteDefaultBranch(ctx context.Context, repoRoot, remote string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", remote, "HEAD")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(out))
+		if message != "" {
+			return "", fmt.Errorf("failed to resolve the default branch for remote %q (%s): %w", remote, message, err)
+		}
+		return "", fmt.Errorf("failed to resolve the default branch for remote %q: %w", remote, err)
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 3 || fields[0] != "ref:" || fields[2] != "HEAD" {
+			continue
+		}
+		const prefix = "refs/heads/"
+		if strings.HasPrefix(fields[1], prefix) {
+			return strings.TrimPrefix(fields[1], prefix), nil
+		}
+	}
+
+	return "", fmt.Errorf("remote %q did not advertise a default branch", remote)
+}
+
+func ResolveCommit(ctx context.Context, repoRoot, ref string) (string, error) {
+	if strings.TrimSpace(ref) == "" || strings.HasPrefix(ref, "-") {
+		return "", fmt.Errorf("trusted ref %q is invalid", ref)
+	}
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", ref+"^{commit}")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(out))
+		if message != "" {
+			return "", fmt.Errorf("failed to resolve trusted ref %q (%s): %w", ref, message, err)
+		}
+		return "", fmt.Errorf("failed to resolve trusted ref %q: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func ReadFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath string) ([]byte, error) {
+	if !isObjectID(commit) {
+		return nil, fmt.Errorf("commit %q must be an immutable object ID", commit)
+	}
+	cleanPath, err := cleanRepositoryPath(repositoryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	object := commit + ":" + cleanPath
+	check := exec.CommandContext(ctx, "git", "ls-tree", "-z", commit, "--", cleanPath)
+	check.Dir = repoRoot
+	entry, err := check.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("failed to inspect %s at %s: %w", cleanPath, commit, err)
+	}
+	if len(entry) == 0 {
+		return nil, fmt.Errorf("%w: %s at %s", ErrPathNotFoundAtRevision, cleanPath, commit)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", object)
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s at %s: %w", cleanPath, commit, err)
+	}
+	return out, nil
+}
+
+func isObjectID(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, character := range value {
+		if character >= '0' && character <= '9' {
+			continue
+		}
+		if character >= 'a' && character <= 'f' {
+			continue
+		}
+		if character >= 'A' && character <= 'F' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func cleanRepositoryPath(repositoryPath string) (string, error) {
+	if repositoryPath == "" {
+		return "", fmt.Errorf("repository path must not be empty")
+	}
+	if strings.HasPrefix(repositoryPath, "/") {
+		return "", fmt.Errorf("repository path %q must be relative", repositoryPath)
+	}
+
+	cleanPath := path.Clean(strings.ReplaceAll(repositoryPath, "\\", "/"))
+	if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+		return "", fmt.Errorf("repository path %q escapes the repository", repositoryPath)
+	}
+	return cleanPath, nil
+}

--- a/internal/git/revision.go
+++ b/internal/git/revision.go
@@ -12,18 +12,26 @@ import (
 var ErrPathNotFoundAtRevision = errors.New("path not found at revision")
 
 func RemoteExists(ctx context.Context, repoRoot, remote string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "remote")
-	cmd.Dir = repoRoot
-	out, err := cmd.Output()
+	remotes, err := Remotes(ctx, repoRoot)
 	if err != nil {
-		return false, fmt.Errorf("failed to list git remotes: %w", err)
+		return false, err
 	}
-	for _, name := range strings.Fields(string(out)) {
+	for _, name := range remotes {
 		if name == remote {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+func Remotes(ctx context.Context, repoRoot string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "remote")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list git remotes: %w", err)
+	}
+	return strings.Fields(string(out)), nil
 }
 
 func RefExists(ctx context.Context, repoRoot, ref string) (bool, error) {
@@ -76,11 +84,16 @@ func ResolveCommit(ctx context.Context, repoRoot, ref string) (string, error) {
 	if strings.TrimSpace(ref) == "" || strings.HasPrefix(ref, "-") {
 		return "", fmt.Errorf("trusted ref %q is invalid", ref)
 	}
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", ref+"^{commit}")
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
 	cmd.Dir = repoRoot
-	out, err := cmd.CombinedOutput()
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		message := strings.TrimSpace(string(out))
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		message := strings.TrimSpace(stderr.String())
 		if message != "" {
 			return "", fmt.Errorf("failed to resolve trusted ref %q (%s): %w", ref, message, err)
 		}

--- a/internal/git/revision.go
+++ b/internal/git/revision.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -119,6 +121,75 @@ func ReadFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath stri
 func ValidateRepositoryPath(repositoryPath string) error {
 	_, err := cleanRepositoryPath(repositoryPath)
 	return err
+}
+
+func ReadFileWithinRepository(repositoryRoot, repositoryPath string) ([]byte, error) {
+	cleanPath, err := cleanRepositoryPath(repositoryPath)
+	if err != nil {
+		return nil, err
+	}
+	root, err := filepath.Abs(repositoryRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repository root %q: %w", repositoryRoot, err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repository root %q: %w", repositoryRoot, err)
+	}
+	return readFileWithinRepository(root, cleanPath, 0, make(map[string]struct{}))
+}
+
+func readFileWithinRepository(repositoryRoot, repositoryPath string, depth int, visited map[string]struct{}) ([]byte, error) {
+	if depth > maxRepositorySymlinkDepth {
+		return nil, fmt.Errorf("repository path %q exceeds the symlink resolution limit", repositoryPath)
+	}
+	if _, exists := visited[repositoryPath]; exists {
+		return nil, fmt.Errorf("repository path %q contains a symlink cycle", repositoryPath)
+	}
+	visited[repositoryPath] = struct{}{}
+
+	components := strings.Split(repositoryPath, "/")
+	for index := range components {
+		candidate := path.Join(components[:index+1]...)
+		candidatePath := filepath.Join(repositoryRoot, filepath.FromSlash(candidate))
+		info, err := os.Lstat(candidatePath)
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(candidatePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read repository symlink %q: %w", candidate, err)
+			}
+			if target == "" {
+				return nil, fmt.Errorf("repository symlink %q has an empty target", candidate)
+			}
+			normalizedTarget := strings.ReplaceAll(target, "\\", "/")
+			if isAbsoluteRepositoryPath(normalizedTarget) {
+				return nil, fmt.Errorf("repository symlink %q has an absolute target %q", candidate, target)
+			}
+			resolvedPath := path.Join(path.Dir(candidate), normalizedTarget)
+			if index+1 < len(components) {
+				resolvedPath = path.Join(resolvedPath, path.Join(components[index+1:]...))
+			}
+			resolvedPath, err = cleanRepositoryPath(resolvedPath)
+			if err != nil {
+				return nil, fmt.Errorf("repository symlink %q is invalid: %w", candidate, err)
+			}
+			return readFileWithinRepository(repositoryRoot, resolvedPath, depth+1, visited)
+		}
+		if index+1 < len(components) {
+			if !info.IsDir() {
+				return nil, fmt.Errorf("repository path %q is not a directory", candidate)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("repository path %q is not a regular file or symlink", repositoryPath)
+		}
+		return os.ReadFile(candidatePath)
+	}
+	return nil, fmt.Errorf("repository path %q is invalid", repositoryPath)
 }
 
 func readFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath string, depth int, visited map[string]struct{}) ([]byte, error) {

--- a/internal/git/revision.go
+++ b/internal/git/revision.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -10,6 +11,8 @@ import (
 )
 
 var ErrPathNotFoundAtRevision = errors.New("path not found at revision")
+
+const maxRepositorySymlinkDepth = 32
 
 func RemoteExists(ctx context.Context, repoRoot, remote string) (bool, error) {
 	remotes, err := Remotes(ctx, repoRoot)
@@ -110,28 +113,82 @@ func ReadFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath stri
 	if err != nil {
 		return nil, err
 	}
+	return readFileAtCommit(ctx, repoRoot, commit, cleanPath, 0, make(map[string]struct{}))
+}
 
-	object := commit + ":" + cleanPath
-	check := exec.CommandContext(ctx, "git", "ls-tree", "-z", commit, "--", cleanPath)
+func readFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath string, depth int, visited map[string]struct{}) ([]byte, error) {
+	if depth > maxRepositorySymlinkDepth {
+		return nil, fmt.Errorf("repository path %q exceeds the symlink resolution limit", repositoryPath)
+	}
+	if _, exists := visited[repositoryPath]; exists {
+		return nil, fmt.Errorf("repository path %q contains a symlink cycle", repositoryPath)
+	}
+	visited[repositoryPath] = struct{}{}
+
+	check := exec.CommandContext(ctx, "git", "ls-tree", "-z", commit, "--", repositoryPath)
 	check.Dir = repoRoot
 	entry, err := check.Output()
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		return nil, fmt.Errorf("failed to inspect %s at %s: %w", cleanPath, commit, err)
+		return nil, fmt.Errorf("failed to inspect %s at %s: %w", repositoryPath, commit, err)
 	}
 	if len(entry) == 0 {
-		return nil, fmt.Errorf("%w: %s at %s", ErrPathNotFoundAtRevision, cleanPath, commit)
+		return nil, fmt.Errorf("%w: %s at %s", ErrPathNotFoundAtRevision, repositoryPath, commit)
 	}
 
+	mode, err := treeEntryMode(entry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect %s at %s: %w", repositoryPath, commit, err)
+	}
+	if mode != "100644" && mode != "100755" && mode != "120000" {
+		return nil, fmt.Errorf("repository path %q at %s is not a regular file or symlink", repositoryPath, commit)
+	}
+
+	object := commit + ":" + repositoryPath
 	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", object)
 	cmd.Dir = repoRoot
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %s at %s: %w", cleanPath, commit, err)
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("failed to read %s at %s: %w", repositoryPath, commit, err)
 	}
-	return out, nil
+	if mode != "120000" {
+		return out, nil
+	}
+
+	target := string(out)
+	if target == "" {
+		return nil, fmt.Errorf("repository symlink %q at %s has an empty target", repositoryPath, commit)
+	}
+	normalizedTarget := strings.ReplaceAll(target, "\\", "/")
+	if isAbsoluteRepositoryPath(normalizedTarget) {
+		return nil, fmt.Errorf("repository symlink %q at %s has an absolute target %q", repositoryPath, commit, target)
+	}
+	resolvedTarget, err := cleanRepositoryPath(path.Join(path.Dir(repositoryPath), normalizedTarget))
+	if err != nil {
+		return nil, fmt.Errorf("repository symlink %q at %s is invalid: %w", repositoryPath, commit, err)
+	}
+	return readFileAtCommit(ctx, repoRoot, commit, resolvedTarget, depth+1, visited)
+}
+
+func treeEntryMode(entry []byte) (string, error) {
+	if len(entry) == 0 || entry[len(entry)-1] != 0 || bytes.Count(entry, []byte{0}) != 1 {
+		return "", fmt.Errorf("unexpected git ls-tree output")
+	}
+	record := entry[:len(entry)-1]
+	metadata, _, found := bytes.Cut(record, []byte{'\t'})
+	if !found {
+		return "", fmt.Errorf("unexpected git ls-tree output")
+	}
+	fields := bytes.Fields(metadata)
+	if len(fields) != 3 || string(fields[1]) != "blob" {
+		return "", fmt.Errorf("unexpected git ls-tree entry")
+	}
+	return string(fields[0]), nil
 }
 
 func isObjectID(value string) bool {
@@ -157,13 +214,26 @@ func cleanRepositoryPath(repositoryPath string) (string, error) {
 	if repositoryPath == "" {
 		return "", fmt.Errorf("repository path must not be empty")
 	}
-	if strings.HasPrefix(repositoryPath, "/") {
+	normalizedPath := strings.ReplaceAll(repositoryPath, "\\", "/")
+	if isAbsoluteRepositoryPath(normalizedPath) {
 		return "", fmt.Errorf("repository path %q must be relative", repositoryPath)
 	}
 
-	cleanPath := path.Clean(strings.ReplaceAll(repositoryPath, "\\", "/"))
+	cleanPath := path.Clean(normalizedPath)
 	if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
 		return "", fmt.Errorf("repository path %q escapes the repository", repositoryPath)
 	}
 	return cleanPath, nil
+}
+
+func isAbsoluteRepositoryPath(repositoryPath string) bool {
+	return strings.HasPrefix(repositoryPath, "/") || hasWindowsVolumePrefix(repositoryPath)
+}
+
+func hasWindowsVolumePrefix(repositoryPath string) bool {
+	if len(repositoryPath) < 2 || repositoryPath[1] != ':' {
+		return false
+	}
+	letter := repositoryPath[0]
+	return letter >= 'a' && letter <= 'z' || letter >= 'A' && letter <= 'Z'
 }

--- a/internal/git/revision.go
+++ b/internal/git/revision.go
@@ -116,6 +116,11 @@ func ReadFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath stri
 	return readFileAtCommit(ctx, repoRoot, commit, cleanPath, 0, make(map[string]struct{}))
 }
 
+func ValidateRepositoryPath(repositoryPath string) error {
+	_, err := cleanRepositoryPath(repositoryPath)
+	return err
+}
+
 func readFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath string, depth int, visited map[string]struct{}) ([]byte, error) {
 	if depth > maxRepositorySymlinkDepth {
 		return nil, fmt.Errorf("repository path %q exceeds the symlink resolution limit", repositoryPath)

--- a/internal/git/revision.go
+++ b/internal/git/revision.go
@@ -125,6 +125,55 @@ func readFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath stri
 	}
 	visited[repositoryPath] = struct{}{}
 
+	components := strings.Split(repositoryPath, "/")
+	for index := range components {
+		candidate := path.Join(components[:index+1]...)
+		entry, err := treeEntryAtCommit(ctx, repoRoot, commit, candidate)
+		if err != nil {
+			return nil, err
+		}
+		mode, err := treeEntryMode(entry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect %s at %s: %w", candidate, commit, err)
+		}
+		if mode == "120000" {
+			targetBytes, err := readBlobAtCommit(ctx, repoRoot, commit, candidate)
+			if err != nil {
+				return nil, err
+			}
+			target := string(targetBytes)
+			if target == "" {
+				return nil, fmt.Errorf("repository symlink %q at %s has an empty target", candidate, commit)
+			}
+			normalizedTarget := strings.ReplaceAll(target, "\\", "/")
+			if isAbsoluteRepositoryPath(normalizedTarget) {
+				return nil, fmt.Errorf("repository symlink %q at %s has an absolute target %q", candidate, commit, target)
+			}
+			resolvedPath := path.Join(path.Dir(candidate), normalizedTarget)
+			if index+1 < len(components) {
+				resolvedPath = path.Join(resolvedPath, path.Join(components[index+1:]...))
+			}
+			resolvedPath, err = cleanRepositoryPath(resolvedPath)
+			if err != nil {
+				return nil, fmt.Errorf("repository symlink %q at %s is invalid: %w", candidate, commit, err)
+			}
+			return readFileAtCommit(ctx, repoRoot, commit, resolvedPath, depth+1, visited)
+		}
+		if index+1 < len(components) {
+			if mode != "040000" {
+				return nil, fmt.Errorf("repository path %q at %s is not a directory", candidate, commit)
+			}
+			continue
+		}
+		if mode != "100644" && mode != "100755" {
+			return nil, fmt.Errorf("repository path %q at %s is not a regular file or symlink", repositoryPath, commit)
+		}
+		return readBlobAtCommit(ctx, repoRoot, commit, repositoryPath)
+	}
+	return nil, fmt.Errorf("%w: %s at %s", ErrPathNotFoundAtRevision, repositoryPath, commit)
+}
+
+func treeEntryAtCommit(ctx context.Context, repoRoot, commit, repositoryPath string) ([]byte, error) {
 	check := exec.CommandContext(ctx, "git", "ls-tree", "-z", commit, "--", repositoryPath)
 	check.Dir = repoRoot
 	entry, err := check.Output()
@@ -137,15 +186,10 @@ func readFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath stri
 	if len(entry) == 0 {
 		return nil, fmt.Errorf("%w: %s at %s", ErrPathNotFoundAtRevision, repositoryPath, commit)
 	}
+	return entry, nil
+}
 
-	mode, err := treeEntryMode(entry)
-	if err != nil {
-		return nil, fmt.Errorf("failed to inspect %s at %s: %w", repositoryPath, commit, err)
-	}
-	if mode != "100644" && mode != "100755" && mode != "120000" {
-		return nil, fmt.Errorf("repository path %q at %s is not a regular file or symlink", repositoryPath, commit)
-	}
-
+func readBlobAtCommit(ctx context.Context, repoRoot, commit, repositoryPath string) ([]byte, error) {
 	object := commit + ":" + repositoryPath
 	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", object)
 	cmd.Dir = repoRoot
@@ -156,23 +200,7 @@ func readFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath stri
 		}
 		return nil, fmt.Errorf("failed to read %s at %s: %w", repositoryPath, commit, err)
 	}
-	if mode != "120000" {
-		return out, nil
-	}
-
-	target := string(out)
-	if target == "" {
-		return nil, fmt.Errorf("repository symlink %q at %s has an empty target", repositoryPath, commit)
-	}
-	normalizedTarget := strings.ReplaceAll(target, "\\", "/")
-	if isAbsoluteRepositoryPath(normalizedTarget) {
-		return nil, fmt.Errorf("repository symlink %q at %s has an absolute target %q", repositoryPath, commit, target)
-	}
-	resolvedTarget, err := cleanRepositoryPath(path.Join(path.Dir(repositoryPath), normalizedTarget))
-	if err != nil {
-		return nil, fmt.Errorf("repository symlink %q at %s is invalid: %w", repositoryPath, commit, err)
-	}
-	return readFileAtCommit(ctx, repoRoot, commit, resolvedTarget, depth+1, visited)
+	return out, nil
 }
 
 func treeEntryMode(entry []byte) (string, error) {
@@ -185,7 +213,7 @@ func treeEntryMode(entry []byte) (string, error) {
 		return "", fmt.Errorf("unexpected git ls-tree output")
 	}
 	fields := bytes.Fields(metadata)
-	if len(fields) != 3 || string(fields[1]) != "blob" {
+	if len(fields) != 3 {
 		return "", fmt.Errorf("unexpected git ls-tree entry")
 	}
 	return string(fields[0]), nil

--- a/internal/git/revision.go
+++ b/internal/git/revision.go
@@ -233,7 +233,11 @@ func readFileAtCommit(ctx context.Context, repoRoot, commit, repositoryPath stri
 			if err != nil {
 				return nil, fmt.Errorf("repository symlink %q at %s is invalid: %w", candidate, commit, err)
 			}
-			return readFileAtCommit(ctx, repoRoot, commit, resolvedPath, depth+1, visited)
+			data, err := readFileAtCommit(ctx, repoRoot, commit, resolvedPath, depth+1, visited)
+			if errors.Is(err, ErrPathNotFoundAtRevision) {
+				return nil, fmt.Errorf("repository symlink %q at %s resolves to missing path %q", candidate, commit, resolvedPath)
+			}
+			return data, err
 		}
 		if index+1 < len(components) {
 			if mode != "040000" {

--- a/internal/git/revision_test.go
+++ b/internal/git/revision_test.go
@@ -1,0 +1,95 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveCommitRejectsUnsafeRefs(t *testing.T) {
+	repositoryRoot := setupTestRepo(t)
+	for _, ref := range []string{"", "   ", "--help"} {
+		if _, err := ResolveCommit(context.Background(), repositoryRoot, ref); err == nil {
+			t.Errorf("ResolveCommit(%q) succeeded", ref)
+		}
+	}
+}
+
+func TestReadFileAtCommitUsesImmutableObjectID(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := filepath.Join(repositoryRoot, "test.txt")
+	if err := os.WriteFile(filePath, []byte("changed content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "test content" {
+		t.Fatalf("ReadFileAtCommit() = %q", content)
+	}
+}
+
+func TestReadFileAtCommitRejectsMutableRefAndEscapingPath(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	if _, err := ReadFileAtCommit(ctx, repositoryRoot, "HEAD", "test.txt"); err == nil {
+		t.Fatal("ReadFileAtCommit accepted a mutable ref")
+	}
+
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "../test.txt"); err == nil {
+		t.Fatal("ReadFileAtCommit accepted an escaping path")
+	}
+	if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "missing.txt"); !errors.Is(err, ErrPathNotFoundAtRevision) {
+		t.Fatalf("ReadFileAtCommit missing error = %v", err)
+	}
+}
+
+func TestReadFileAtCommitDoesNotTreatRepositoryFailureAsMissingPath(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ReadFileAtCommit(ctx, filepath.Join(repositoryRoot, "missing-repository"), commit, "test.txt")
+	if err == nil {
+		t.Fatal("ReadFileAtCommit succeeded")
+	}
+	if errors.Is(err, ErrPathNotFoundAtRevision) {
+		t.Fatalf("ReadFileAtCommit error = %v", err)
+	}
+}
+
+func TestRemoteDefaultBranch(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	bareRoot := filepath.Join(t.TempDir(), "origin.git")
+	cmd := exec.Command("git", "clone", "--bare", repositoryRoot, bareRoot)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare failed: %v\n%s", err, out)
+	}
+
+	branch, err := RemoteDefaultBranch(ctx, repositoryRoot, bareRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if branch == "" {
+		t.Fatal("RemoteDefaultBranch returned an empty branch")
+	}
+}

--- a/internal/git/revision_test.go
+++ b/internal/git/revision_test.go
@@ -122,9 +122,46 @@ func TestReadFileAtCommitFollowsSymlinkWithinRevision(t *testing.T) {
 	}
 }
 
+func TestReadFileAtCommitFollowsIntermediateSymlinkWithinRevision(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	versionRoot := filepath.Join(repositoryRoot, "config", "v1")
+	if err := os.MkdirAll(versionRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(versionRoot, "acr.yaml"), []byte("reviewers: 8"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("v1", filepath.Join(repositoryRoot, "config", "current")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("config/current/acr.yaml", filepath.Join(repositoryRoot, ".acr.yaml")); err != nil {
+		t.Fatal(err)
+	}
+	commitRevisionFiles(t, repositoryRoot)
+
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, repositoryPath := range []string{"config/current/acr.yaml", ".acr.yaml"} {
+		content, err := ReadFileAtCommit(ctx, repositoryRoot, commit, repositoryPath)
+		if err != nil {
+			t.Fatalf("ReadFileAtCommit(%q) error = %v", repositoryPath, err)
+		}
+		if string(content) != "reviewers: 8" {
+			t.Fatalf("ReadFileAtCommit(%q) = %q", repositoryPath, content)
+		}
+	}
+}
+
 func TestReadFileAtCommitRejectsEscapingAndCyclicSymlinks(t *testing.T) {
 	ctx := context.Background()
 	repositoryRoot := setupTestRepo(t)
+	configRoot := filepath.Join(repositoryRoot, "config")
+	if err := os.MkdirAll(configRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Symlink("../outside.md", filepath.Join(repositoryRoot, "escaping.md")); err != nil {
 		t.Fatal(err)
 	}
@@ -132,6 +169,15 @@ func TestReadFileAtCommitRejectsEscapingAndCyclicSymlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.Symlink("cycle-a.md", filepath.Join(repositoryRoot, "cycle-b.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../outside", filepath.Join(configRoot, "escaping")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("cycle-b", filepath.Join(configRoot, "cycle-a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("cycle-a", filepath.Join(configRoot, "cycle-b")); err != nil {
 		t.Fatal(err)
 	}
 	commitRevisionFiles(t, repositoryRoot)
@@ -145,6 +191,12 @@ func TestReadFileAtCommitRejectsEscapingAndCyclicSymlinks(t *testing.T) {
 	}
 	if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "cycle-a.md"); err == nil || !strings.Contains(err.Error(), "symlink cycle") {
 		t.Fatalf("cyclic symlink error = %v", err)
+	}
+	if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "config/escaping/acr.yaml"); err == nil || !strings.Contains(err.Error(), "escapes the repository") {
+		t.Fatalf("intermediate escaping symlink error = %v", err)
+	}
+	if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "config/cycle-a/acr.yaml"); err == nil || !strings.Contains(err.Error(), "symlink cycle") {
+		t.Fatalf("intermediate cyclic symlink error = %v", err)
 	}
 }
 

--- a/internal/git/revision_test.go
+++ b/internal/git/revision_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -92,6 +93,83 @@ func TestReadFileAtCommitDoesNotTreatRepositoryFailureAsMissingPath(t *testing.T
 	}
 	if errors.Is(err, ErrPathNotFoundAtRevision) {
 		t.Fatalf("ReadFileAtCommit error = %v", err)
+	}
+}
+
+func TestReadFileAtCommitFollowsSymlinkWithinRevision(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	guidancePath := filepath.Join(repositoryRoot, "guidance.md")
+	linkPath := filepath.Join(repositoryRoot, "review-guidance.md")
+	if err := os.WriteFile(guidancePath, []byte("trusted guidance"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("guidance.md", linkPath); err != nil {
+		t.Fatal(err)
+	}
+	commitRevisionFiles(t, repositoryRoot)
+
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "review-guidance.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "trusted guidance" {
+		t.Fatalf("ReadFileAtCommit() = %q", content)
+	}
+}
+
+func TestReadFileAtCommitRejectsEscapingAndCyclicSymlinks(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	if err := os.Symlink("../outside.md", filepath.Join(repositoryRoot, "escaping.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("cycle-b.md", filepath.Join(repositoryRoot, "cycle-a.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("cycle-a.md", filepath.Join(repositoryRoot, "cycle-b.md")); err != nil {
+		t.Fatal(err)
+	}
+	commitRevisionFiles(t, repositoryRoot)
+
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "escaping.md"); err == nil || !strings.Contains(err.Error(), "escapes the repository") {
+		t.Fatalf("escaping symlink error = %v", err)
+	}
+	if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, "cycle-a.md"); err == nil || !strings.Contains(err.Error(), "symlink cycle") {
+		t.Fatalf("cyclic symlink error = %v", err)
+	}
+}
+
+func TestReadFileAtCommitRejectsCrossPlatformAbsolutePaths(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, repositoryPath := range []string{"/tmp/guidance.md", `C:\guidance.md`, `d:/guidance.md`} {
+		if _, err := ReadFileAtCommit(ctx, repositoryRoot, commit, repositoryPath); err == nil || !strings.Contains(err.Error(), "must be relative") {
+			t.Errorf("ReadFileAtCommit(%q) error = %v", repositoryPath, err)
+		}
+	}
+}
+
+func commitRevisionFiles(t *testing.T, repositoryRoot string) {
+	t.Helper()
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "revision files"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repositoryRoot
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
 	}
 }
 

--- a/internal/git/revision_test.go
+++ b/internal/git/revision_test.go
@@ -122,6 +122,31 @@ func TestReadFileAtCommitFollowsSymlinkWithinRevision(t *testing.T) {
 	}
 }
 
+func TestReadFileAtCommitDistinguishesDanglingSymlinkFromMissingPath(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := setupTestRepo(t)
+	linkPath := filepath.Join(repositoryRoot, "review-guidance.md")
+	if err := os.Symlink("missing-guidance.md", linkPath); err != nil {
+		t.Fatal(err)
+	}
+	commitRevisionFiles(t, repositoryRoot)
+
+	commit, err := ResolveCommit(ctx, repositoryRoot, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ReadFileAtCommit(ctx, repositoryRoot, commit, "review-guidance.md")
+	if err == nil {
+		t.Fatal("ReadFileAtCommit succeeded")
+	}
+	if errors.Is(err, ErrPathNotFoundAtRevision) {
+		t.Fatalf("dangling symlink reported as missing path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "resolves to missing path") {
+		t.Fatalf("dangling symlink error = %v", err)
+	}
+}
+
 func TestReadFileAtCommitFollowsIntermediateSymlinkWithinRevision(t *testing.T) {
 	ctx := context.Background()
 	repositoryRoot := setupTestRepo(t)

--- a/internal/git/revision_test.go
+++ b/internal/git/revision_test.go
@@ -18,6 +18,25 @@ func TestResolveCommitRejectsUnsafeRefs(t *testing.T) {
 	}
 }
 
+func TestResolveCommitIgnoresSuccessfulStderr(t *testing.T) {
+	repositoryRoot := setupTestRepo(t)
+	for _, args := range [][]string{{"branch", "ambiguous"}, {"tag", "ambiguous"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repositoryRoot
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	revision, err := ResolveCommit(context.Background(), repositoryRoot, "ambiguous")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isObjectID(revision) {
+		t.Fatalf("ResolveCommit() = %q", revision)
+	}
+}
+
 func TestReadFileAtCommitUsesImmutableObjectID(t *testing.T) {
 	ctx := context.Background()
 	repositoryRoot := setupTestRepo(t)

--- a/internal/git/revision_test.go
+++ b/internal/git/revision_test.go
@@ -214,6 +214,54 @@ func TestReadFileAtCommitRejectsCrossPlatformAbsolutePaths(t *testing.T) {
 	}
 }
 
+func TestReadFileWithinRepositoryResolvesBoundedSymlinks(t *testing.T) {
+	repositoryRoot := setupTestRepo(t)
+	if err := os.MkdirAll(filepath.Join(repositoryRoot, "config", "v1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryRoot, "config", "v1", "guidance.md"), []byte("bounded"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("v1", filepath.Join(repositoryRoot, "config", "current")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("config/current/guidance.md", filepath.Join(repositoryRoot, "guidance.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ReadFileWithinRepository(repositoryRoot, "guidance.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "bounded" {
+		t.Fatalf("data = %q", data)
+	}
+}
+
+func TestReadFileWithinRepositoryRejectsEscapingSymlinks(t *testing.T) {
+	root := t.TempDir()
+	repositoryRoot := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	outsidePath := filepath.Join(root, "outside.md")
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../outside.md", filepath.Join(repositoryRoot, "relative.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(repositoryRoot, "absolute.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, repositoryPath := range []string{"relative.md", "absolute.md"} {
+		if _, err := ReadFileWithinRepository(repositoryRoot, repositoryPath); err == nil {
+			t.Fatalf("ReadFileWithinRepository(%q) succeeded", repositoryPath)
+		}
+	}
+}
+
 func commitRevisionFiles(t *testing.T, repositoryRoot string) {
 	t.Helper()
 	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "revision files"}} {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -51,17 +51,60 @@ func GetHeadSHA(dir string) (string, error) {
 }
 
 func GetCommonDir() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
-	out, err := cmd.Output()
+	dir, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("failed to get git common dir: %w", err)
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
+	return GetCommonDirAt(context.Background(), dir)
+}
+
+func GetCommonDirAt(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail != "" {
+			return "", fmt.Errorf("failed to get git common dir for %s (%s): %w", dir, detail, err)
+		}
+		return "", fmt.Errorf("failed to get git common dir for %s: %w", dir, err)
 	}
 	path := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(dir, path)
+	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve common dir path: %w", err)
+		return "", fmt.Errorf("failed to resolve common dir path for %s: %w", dir, err)
 	}
-	return abs, nil
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate common dir path for %s: %w", dir, err)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func ValidateWorktreeRepository(ctx context.Context, repositoryRoot, worktreeRoot string) error {
+	repositoryCommonDir, err := GetCommonDirAt(ctx, repositoryRoot)
+	if err != nil {
+		return fmt.Errorf("resolve repository root: %w", err)
+	}
+	worktreeCommonDir, err := GetCommonDirAt(ctx, worktreeRoot)
+	if err != nil {
+		return fmt.Errorf("resolve worktree root: %w", err)
+	}
+	repositoryInfo, err := os.Stat(repositoryCommonDir)
+	if err != nil {
+		return fmt.Errorf("stat repository common dir: %w", err)
+	}
+	worktreeInfo, err := os.Stat(worktreeCommonDir)
+	if err != nil {
+		return fmt.Errorf("stat worktree common dir: %w", err)
+	}
+	if !os.SameFile(repositoryInfo, worktreeInfo) {
+		return fmt.Errorf("repository root %q and worktree root %q belong to different repositories", repositoryRoot, worktreeRoot)
+	}
+	return nil
 }
 
 func ensureWorktreesExcluded(commonDir string) error {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -61,9 +62,11 @@ func GetCommonDir() (string, error) {
 func GetCommonDirAt(ctx context.Context, dir string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
 	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		detail := strings.TrimSpace(string(out))
+		detail := strings.TrimSpace(stderr.String())
 		if detail != "" {
 			return "", fmt.Errorf("failed to get git common dir for %s (%s): %w", dir, detail, err)
 		}
@@ -273,10 +276,16 @@ var gitVersionPattern = regexp.MustCompile(`^git version ([0-9]+)\.([0-9]+)`)
 func requireIsolatedFetchGitVersion(ctx context.Context, repoRoot string) error {
 	cmd := exec.CommandContext(ctx, "git", "version")
 	cmd.Dir = repoRoot
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+		detail := strings.TrimSpace(stderr.String())
+		if detail != "" {
+			return fmt.Errorf("failed to determine git version (%s): %w", detail, err)
 		}
 		return fmt.Errorf("failed to determine git version: %w", err)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -204,6 +206,9 @@ func FetchRemoteBranchToRef(ctx context.Context, repoRoot, remote, branch, desti
 	if !strings.HasPrefix(destinationRef, "refs/") {
 		return fmt.Errorf("destination ref %q must be fully qualified", destinationRef)
 	}
+	if err := requireIsolatedFetchGitVersion(ctx, repoRoot); err != nil {
+		return err
+	}
 	refSpec := fmt.Sprintf("+refs/heads/%s:%s", branch, destinationRef)
 	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--no-write-fetch-head", "--refmap=", remote, refSpec)
 	cmd.Dir = repoRoot
@@ -218,6 +223,48 @@ func FetchRemoteBranchToRef(ctx context.Context, repoRoot, remote, branch, desti
 		return fmt.Errorf("failed to fetch branch %q: %w", branch, err)
 	}
 	return nil
+}
+
+var gitVersionPattern = regexp.MustCompile(`^git version ([0-9]+)\.([0-9]+)`)
+
+func requireIsolatedFetchGitVersion(ctx context.Context, repoRoot string) error {
+	cmd := exec.CommandContext(ctx, "git", "version")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("failed to determine git version: %w", err)
+	}
+	major, minor, err := parseGitVersion(string(out))
+	if err != nil {
+		return err
+	}
+	if !gitVersionSupportsIsolatedFetch(major, minor) {
+		return fmt.Errorf("git 2.29 or newer is required for isolated trusted-configuration fetches; found %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func gitVersionSupportsIsolatedFetch(major, minor int) bool {
+	return major > 2 || major == 2 && minor >= 29
+}
+
+func parseGitVersion(output string) (int, int, error) {
+	matches := gitVersionPattern.FindStringSubmatch(strings.TrimSpace(output))
+	if len(matches) != 3 {
+		return 0, 0, fmt.Errorf("unrecognized git version output %q", strings.TrimSpace(output))
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid git major version %q: %w", matches[1], err)
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid git minor version %q: %w", matches[2], err)
+	}
+	return major, minor, nil
 }
 
 func QualifyBaseRef(remote, baseRef string) string {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -193,19 +193,22 @@ func FetchBaseRef(ctx context.Context, repoRoot, remote, baseRef string) error {
 	if strings.HasPrefix(baseRef, remote+"/") {
 		return nil
 	}
+	return FetchRemoteTrackingBranch(ctx, repoRoot, remote, baseRef)
+}
 
-	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", baseRef, remote, baseRef)
+func FetchRemoteTrackingBranch(ctx context.Context, repoRoot, remote, branch string) error {
+	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
 	cmd := exec.CommandContext(ctx, "git", "fetch", remote, refSpec)
 	cmd.Dir = repoRoot
 	if out, err := cmd.CombinedOutput(); err != nil {
 		if ctx.Err() != nil {
-			return fmt.Errorf("failed to fetch base ref '%s': %w", baseRef, ctx.Err())
+			return fmt.Errorf("failed to fetch base ref '%s': %w", branch, ctx.Err())
 		}
 		output := strings.TrimSpace(string(out))
 		if output != "" {
-			return fmt.Errorf("failed to fetch base ref '%s' (%s): %w", baseRef, output, err)
+			return fmt.Errorf("failed to fetch base ref '%s' (%s): %w", branch, output, err)
 		}
-		return fmt.Errorf("failed to fetch base ref '%s': %w", baseRef, err)
+		return fmt.Errorf("failed to fetch base ref '%s': %w", branch, err)
 	}
 	return nil
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -197,18 +197,25 @@ func FetchBaseRef(ctx context.Context, repoRoot, remote, baseRef string) error {
 }
 
 func FetchRemoteTrackingBranch(ctx context.Context, repoRoot, remote, branch string) error {
-	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
-	cmd := exec.CommandContext(ctx, "git", "fetch", remote, refSpec)
+	return FetchRemoteBranchToRef(ctx, repoRoot, remote, branch, "refs/remotes/"+remote+"/"+branch)
+}
+
+func FetchRemoteBranchToRef(ctx context.Context, repoRoot, remote, branch, destinationRef string) error {
+	if !strings.HasPrefix(destinationRef, "refs/") {
+		return fmt.Errorf("destination ref %q must be fully qualified", destinationRef)
+	}
+	refSpec := fmt.Sprintf("+refs/heads/%s:%s", branch, destinationRef)
+	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "--no-write-fetch-head", "--refmap=", remote, refSpec)
 	cmd.Dir = repoRoot
 	if out, err := cmd.CombinedOutput(); err != nil {
 		if ctx.Err() != nil {
-			return fmt.Errorf("failed to fetch base ref '%s': %w", branch, ctx.Err())
+			return fmt.Errorf("failed to fetch branch %q: %w", branch, ctx.Err())
 		}
 		output := strings.TrimSpace(string(out))
 		if output != "" {
-			return fmt.Errorf("failed to fetch base ref '%s' (%s): %w", branch, output, err)
+			return fmt.Errorf("failed to fetch branch %q (%s): %w", branch, output, err)
 		}
-		return fmt.Errorf("failed to fetch base ref '%s': %w", branch, err)
+		return fmt.Errorf("failed to fetch branch %q: %w", branch, err)
 	}
 	return nil
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -187,16 +188,19 @@ func CreateWorktree(branch string) (*Worktree, error) {
 	}, nil
 }
 
-func FetchBaseRef(repoRoot, remote, baseRef string) error {
+func FetchBaseRef(ctx context.Context, repoRoot, remote, baseRef string) error {
 
 	if strings.HasPrefix(baseRef, remote+"/") {
 		return nil
 	}
 
-	refSpec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", baseRef, remote, baseRef)
-	cmd := exec.Command("git", "fetch", remote, refSpec)
+	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", baseRef, remote, baseRef)
+	cmd := exec.CommandContext(ctx, "git", "fetch", remote, refSpec)
 	cmd.Dir = repoRoot
 	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("failed to fetch base ref '%s': %w", baseRef, ctx.Err())
+		}
 		output := strings.TrimSpace(string(out))
 		if output != "" {
 			return fmt.Errorf("failed to fetch base ref '%s' (%s): %w", baseRef, output, err)

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -256,6 +256,23 @@ func TestGetCommonDir_InGitRepo(t *testing.T) {
 	}
 }
 
+func TestGetCommonDirAtIgnoresSuccessfulCommandStderr(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	t.Setenv("GIT_TRACE", "1")
+
+	commonDir, err := GetCommonDirAt(context.Background(), repoDir)
+	if err != nil {
+		t.Fatalf("GetCommonDirAt failed: %v", err)
+	}
+	expected, err := filepath.EvalSymlinks(filepath.Join(repoDir, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commonDir != expected {
+		t.Fatalf("common dir = %q, want %q", commonDir, expected)
+	}
+}
+
 func TestValidateWorktreeRepository(t *testing.T) {
 	repoDir := setupTestRepo(t)
 	linkedDir := filepath.Join(t.TempDir(), "linked")
@@ -518,6 +535,14 @@ func TestGitVersionSupportsIsolatedFetch(t *testing.T) {
 		if got := gitVersionSupportsIsolatedFetch(test.major, test.minor); got != test.want {
 			t.Fatalf("gitVersionSupportsIsolatedFetch(%d, %d) = %t", test.major, test.minor, got)
 		}
+	}
+}
+
+func TestRequireIsolatedFetchGitVersionIgnoresSuccessfulCommandStderr(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	t.Setenv("GIT_TRACE", "1")
+	if err := requireIsolatedFetchGitVersion(context.Background(), repoDir); err != nil {
+		t.Fatalf("requireIsolatedFetchGitVersion failed: %v", err)
 	}
 }
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -370,7 +372,7 @@ func TestFetchBaseRef_CommandFormat(t *testing.T) {
 	}
 	defer os.Chdir(origDir)
 
-	err = FetchBaseRef(repoDir, "origin", "main")
+	err = FetchBaseRef(context.Background(), repoDir, "origin", "main")
 
 	if err == nil {
 		t.Error("expected error when fetching from non-existent remote")
@@ -394,7 +396,7 @@ func TestFetchBaseRef_UsesRemoteParameter(t *testing.T) {
 	}
 	defer os.Chdir(origDir)
 
-	err = FetchBaseRef(repoDir, "upstream", "develop")
+	err = FetchBaseRef(context.Background(), repoDir, "upstream", "develop")
 
 	if err == nil {
 		t.Error("expected error when fetching from non-existent remote")
@@ -403,6 +405,66 @@ func TestFetchBaseRef_UsesRemoteParameter(t *testing.T) {
 	if !strings.Contains(err.Error(), "develop") {
 		t.Errorf("expected error to mention 'develop', got: %v", err)
 	}
+}
+
+func TestFetchBaseRefHonorsCancellation(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := FetchBaseRef(ctx, repoDir, "origin", "main")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("FetchBaseRef() error = %v", err)
+	}
+}
+
+func TestFetchBaseRefAcceptsForcedRemoteUpdate(t *testing.T) {
+	seedRoot := setupTestRepo(t)
+	runWorktreeGit(t, seedRoot, "branch", "-M", "main")
+	initialRevision := strings.TrimSpace(runWorktreeGit(t, seedRoot, "rev-parse", "HEAD"))
+	remoteRoot := filepath.Join(t.TempDir(), "origin.git")
+	workingRoot := filepath.Join(t.TempDir(), "working")
+	runWorktreeGit(t, t.TempDir(), "clone", "--bare", seedRoot, remoteRoot)
+	runWorktreeGit(t, t.TempDir(), "clone", remoteRoot, workingRoot)
+	runWorktreeGit(t, seedRoot, "remote", "add", "origin", remoteRoot)
+
+	if err := os.WriteFile(filepath.Join(seedRoot, "test.txt"), []byte("second"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runWorktreeGit(t, seedRoot, "add", "test.txt")
+	runWorktreeGit(t, seedRoot, "commit", "-m", "second")
+	runWorktreeGit(t, seedRoot, "push", "origin", "main")
+	if err := FetchBaseRef(context.Background(), workingRoot, "origin", "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	runWorktreeGit(t, seedRoot, "reset", "--hard", initialRevision)
+	if err := os.WriteFile(filepath.Join(seedRoot, "test.txt"), []byte("replacement"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runWorktreeGit(t, seedRoot, "add", "test.txt")
+	runWorktreeGit(t, seedRoot, "commit", "-m", "replacement")
+	runWorktreeGit(t, seedRoot, "push", "--force", "origin", "main")
+
+	if err := FetchBaseRef(context.Background(), workingRoot, "origin", "main"); err != nil {
+		t.Fatal(err)
+	}
+	want := strings.TrimSpace(runWorktreeGit(t, seedRoot, "rev-parse", "HEAD"))
+	got := strings.TrimSpace(runWorktreeGit(t, workingRoot, "rev-parse", "refs/remotes/origin/main"))
+	if got != want {
+		t.Fatalf("remote-tracking revision = %s, want %s", got, want)
+	}
+}
+
+func runWorktreeGit(t *testing.T, directory string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = directory
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
 }
 
 func TestQualifyBaseRef_AddsRemote(t *testing.T) {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -456,6 +456,47 @@ func TestFetchBaseRefAcceptsForcedRemoteUpdate(t *testing.T) {
 	}
 }
 
+func TestParseGitVersion(t *testing.T) {
+	tests := []struct {
+		output string
+		major  int
+		minor  int
+	}{
+		{"git version 2.29.0", 2, 29},
+		{"git version 2.39.3 (Apple Git-145)", 2, 39},
+		{"git version 3.1.0.windows.1", 3, 1},
+	}
+	for _, test := range tests {
+		major, minor, err := parseGitVersion(test.output)
+		if err != nil {
+			t.Fatalf("parseGitVersion(%q): %v", test.output, err)
+		}
+		if major != test.major || minor != test.minor {
+			t.Fatalf("parseGitVersion(%q) = %d.%d, want %d.%d", test.output, major, minor, test.major, test.minor)
+		}
+	}
+	if _, _, err := parseGitVersion("git version unknown"); err == nil {
+		t.Fatal("parseGitVersion accepted invalid output")
+	}
+}
+
+func TestGitVersionSupportsIsolatedFetch(t *testing.T) {
+	for _, test := range []struct {
+		major int
+		minor int
+		want  bool
+	}{
+		{1, 99, false},
+		{2, 28, false},
+		{2, 29, true},
+		{3, 0, true},
+	} {
+		if got := gitVersionSupportsIsolatedFetch(test.major, test.minor); got != test.want {
+			t.Fatalf("gitVersionSupportsIsolatedFetch(%d, %d) = %t", test.major, test.minor, got)
+		}
+	}
+}
+
 func runWorktreeGit(t *testing.T, directory string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -256,6 +256,30 @@ func TestGetCommonDir_InGitRepo(t *testing.T) {
 	}
 }
 
+func TestValidateWorktreeRepository(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	linkedDir := filepath.Join(t.TempDir(), "linked")
+	cmd := exec.Command("git", "worktree", "add", "--detach", linkedDir)
+	cmd.Dir = repoDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create linked worktree: %v\n%s", err, output)
+	}
+	t.Cleanup(func() {
+		remove := exec.Command("git", "worktree", "remove", "--force", linkedDir)
+		remove.Dir = repoDir
+		_ = remove.Run()
+	})
+
+	if err := ValidateWorktreeRepository(context.Background(), repoDir, linkedDir); err != nil {
+		t.Fatalf("linked worktree rejected: %v", err)
+	}
+
+	otherDir := setupTestRepo(t)
+	if err := ValidateWorktreeRepository(context.Background(), repoDir, otherDir); err == nil {
+		t.Fatal("unrelated repository accepted as worktree")
+	}
+}
+
 func TestEnsureWorktreesExcluded(t *testing.T) {
 	repoDir := setupTestRepo(t)
 	commonDir := filepath.Join(repoDir, ".git")

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -80,11 +80,19 @@ func ValidatePR(ctx context.Context, prNumber string) error {
 }
 
 func GetRepoRemote(ctx context.Context) string {
-
-	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "url,sshUrl")
-	out, err := cmd.Output()
+	remote, err := FindRepoRemote(ctx, "")
 	if err != nil {
 		return "origin"
+	}
+	return remote
+}
+
+func FindRepoRemote(ctx context.Context, repositoryRoot string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "url,sshUrl")
+	cmd.Dir = repositoryRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to identify repository through gh: %w", err)
 	}
 
 	var repoInfo struct {
@@ -92,13 +100,14 @@ func GetRepoRemote(ctx context.Context) string {
 		SSHUrl string `json:"sshUrl"`
 	}
 	if err := json.Unmarshal(out, &repoInfo); err != nil {
-		return "origin"
+		return "", fmt.Errorf("failed to parse repository identity: %w", err)
 	}
 
 	remoteCmd := exec.CommandContext(ctx, "git", "remote", "-v")
+	remoteCmd.Dir = repositoryRoot
 	remoteOut, err := remoteCmd.Output()
 	if err != nil {
-		return "origin"
+		return "", fmt.Errorf("failed to list repository remotes: %w", err)
 	}
 
 	lines := strings.Split(string(remoteOut), "\n")
@@ -111,11 +120,11 @@ func GetRepoRemote(ctx context.Context) string {
 		remoteURL := fields[1]
 
 		if urlMatches(remoteURL, repoInfo.URL) || urlMatches(remoteURL, repoInfo.SSHUrl) {
-			return remoteName
+			return remoteName, nil
 		}
 	}
 
-	return "origin"
+	return "", fmt.Errorf("no configured remote matches the GitHub repository")
 }
 
 func urlMatches(url1, url2 string) bool {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -81,14 +81,6 @@ func ValidatePR(ctx context.Context, prNumber string) error {
 	return nil
 }
 
-func GetRepoRemote(ctx context.Context) string {
-	remote, err := FindRepoRemote(ctx, "")
-	if err != nil {
-		return "origin"
-	}
-	return remote
-}
-
 func FindRepoRemote(ctx context.Context, repositoryRoot string) (string, error) {
 	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "url,sshUrl")
 	cmd.Dir = repositoryRoot

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -112,7 +112,10 @@ func FindRepoRemote(ctx context.Context, repositoryRoot string) (string, error) 
 		return "", fmt.Errorf("failed to list repository remotes: %w", err)
 	}
 
-	remote := matchingFetchRemote(remoteOut, repoInfo.URL, repoInfo.SSHUrl)
+	remote, err := matchingFetchRemote(remoteOut, repoInfo.URL, repoInfo.SSHUrl)
+	if err != nil {
+		return "", err
+	}
 	if remote != "" {
 		return remote, nil
 	}
@@ -120,8 +123,10 @@ func FindRepoRemote(ctx context.Context, repositoryRoot string) (string, error) 
 	return "", fmt.Errorf("no configured remote matches the GitHub repository")
 }
 
-func matchingFetchRemote(remoteOut []byte, repositoryURL, repositorySSHURL string) string {
+func matchingFetchRemote(remoteOut []byte, repositoryURL, repositorySSHURL string) (string, error) {
 	lines := strings.Split(string(remoteOut), "\n")
+	var matches []string
+	seen := make(map[string]struct{})
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) < 3 || fields[2] != "(fetch)" {
@@ -131,10 +136,19 @@ func matchingFetchRemote(remoteOut []byte, repositoryURL, repositorySSHURL strin
 		remoteURL := fields[1]
 
 		if urlMatches(remoteURL, repositoryURL) || urlMatches(remoteURL, repositorySSHURL) {
-			return remoteName
+			if _, ok := seen[remoteName]; !ok {
+				seen[remoteName] = struct{}{}
+				matches = append(matches, remoteName)
+			}
 		}
 	}
-	return ""
+	if len(matches) == 0 {
+		return "", nil
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return "", fmt.Errorf("multiple configured fetch remotes match the GitHub repository: %s", strings.Join(matches, ", "))
 }
 
 func urlMatches(url1, url2 string) bool {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -153,7 +153,8 @@ func normalizeRepositoryURL(raw string) (string, bool) {
 
 	parsed, err := url.Parse(raw)
 	if err == nil && parsed.Host != "" {
-		return normalizeRepositoryLocation(parsed.Host, parsed.Path), true
+		host := parsed.Hostname()
+		return normalizeRepositoryLocation(host, parsed.Path), host != ""
 	}
 
 	colon := strings.Index(raw, ":")

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -110,21 +110,29 @@ func FindRepoRemote(ctx context.Context, repositoryRoot string) (string, error) 
 		return "", fmt.Errorf("failed to list repository remotes: %w", err)
 	}
 
+	remote := matchingFetchRemote(remoteOut, repoInfo.URL, repoInfo.SSHUrl)
+	if remote != "" {
+		return remote, nil
+	}
+
+	return "", fmt.Errorf("no configured remote matches the GitHub repository")
+}
+
+func matchingFetchRemote(remoteOut []byte, repositoryURL, repositorySSHURL string) string {
 	lines := strings.Split(string(remoteOut), "\n")
 	for _, line := range lines {
 		fields := strings.Fields(line)
-		if len(fields) < 2 {
+		if len(fields) < 3 || fields[2] != "(fetch)" {
 			continue
 		}
 		remoteName := fields[0]
 		remoteURL := fields[1]
 
-		if urlMatches(remoteURL, repoInfo.URL) || urlMatches(remoteURL, repoInfo.SSHUrl) {
-			return remoteName, nil
+		if urlMatches(remoteURL, repositoryURL) || urlMatches(remoteURL, repositorySSHURL) {
+			return remoteName
 		}
 	}
-
-	return "", fmt.Errorf("no configured remote matches the GitHub repository")
+	return ""
 }
 
 func urlMatches(url1, url2 string) bool {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -137,27 +137,32 @@ func matchingFetchRemote(remoteOut []byte, repositoryURL, repositorySSHURL strin
 }
 
 func urlMatches(url1, url2 string) bool {
-	return normalizeRepositoryURL(url1) == normalizeRepositoryURL(url2)
+	if strings.TrimSpace(url1) == "" || strings.TrimSpace(url2) == "" {
+		return strings.TrimSpace(url1) == strings.TrimSpace(url2)
+	}
+	first, firstHasHost := normalizeRepositoryURL(url1)
+	second, secondHasHost := normalizeRepositoryURL(url2)
+	return firstHasHost && secondHasHost && first == second
 }
 
-func normalizeRepositoryURL(raw string) string {
+func normalizeRepositoryURL(raw string) (string, bool) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return ""
+		return "", false
 	}
 
 	parsed, err := url.Parse(raw)
 	if err == nil && parsed.Host != "" {
-		return normalizeRepositoryLocation(parsed.Host, parsed.Path)
+		return normalizeRepositoryLocation(parsed.Host, parsed.Path), true
 	}
 
 	colon := strings.Index(raw, ":")
 	slash := strings.Index(raw, "/")
 	if colon > 0 && (slash == -1 || colon < slash) {
-		return normalizeRepositoryLocation(raw[:colon], raw[colon+1:])
+		return normalizeRepositoryLocation(raw[:colon], raw[colon+1:]), true
 	}
 
-	return normalizeRepositoryLocation("", raw)
+	return normalizeRepositoryLocation("", raw), false
 }
 
 func normalizeRepositoryLocation(host, path string) string {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -154,6 +155,9 @@ func normalizeRepositoryURL(raw string) (string, bool) {
 	parsed, err := url.Parse(raw)
 	if err == nil && parsed.Host != "" {
 		host := parsed.Hostname()
+		if port := parsed.Port(); port != "" && !isDefaultRepositoryPort(parsed.Scheme, port) {
+			host = net.JoinHostPort(host, port)
+		}
 		return normalizeRepositoryLocation(host, parsed.Path), host != ""
 	}
 
@@ -164,6 +168,21 @@ func normalizeRepositoryURL(raw string) (string, bool) {
 	}
 
 	return normalizeRepositoryLocation("", raw), false
+}
+
+func isDefaultRepositoryPort(scheme, port string) bool {
+	switch strings.ToLower(scheme) {
+	case "ssh", "git+ssh", "ssh+git":
+		return port == "22"
+	case "http":
+		return port == "80"
+	case "https":
+		return port == "443"
+	case "git":
+		return port == "9418"
+	default:
+		return false
+	}
 }
 
 func normalizeRepositoryLocation(host, path string) string {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 )
@@ -136,27 +137,45 @@ func matchingFetchRemote(remoteOut []byte, repositoryURL, repositorySSHURL strin
 }
 
 func urlMatches(url1, url2 string) bool {
+	return normalizeRepositoryURL(url1) == normalizeRepositoryURL(url2)
+}
 
-	normalize := func(url string) string {
-		url = strings.TrimSuffix(url, ".git")
-		url = strings.TrimPrefix(url, "https://")
-		url = strings.TrimPrefix(url, "http://")
-
-		if strings.HasPrefix(url, "ssh://") {
-			url = strings.TrimPrefix(url, "ssh://")
-
-			if idx := strings.Index(url, "@"); idx != -1 {
-				url = url[idx+1:]
-			}
-		}
-
-		if strings.HasPrefix(url, "git@") {
-			url = strings.TrimPrefix(url, "git@")
-			url = strings.Replace(url, ":", "/", 1)
-		}
-		return strings.ToLower(url)
+func normalizeRepositoryURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
 	}
-	return normalize(url1) == normalize(url2)
+
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Host != "" {
+		return normalizeRepositoryLocation(parsed.Host, parsed.Path)
+	}
+
+	colon := strings.Index(raw, ":")
+	slash := strings.Index(raw, "/")
+	if colon > 0 && (slash == -1 || colon < slash) {
+		return normalizeRepositoryLocation(raw[:colon], raw[colon+1:])
+	}
+
+	return normalizeRepositoryLocation("", raw)
+}
+
+func normalizeRepositoryLocation(host, path string) string {
+	host = strings.TrimSpace(host)
+	if at := strings.LastIndex(host, "@"); at != -1 {
+		host = host[at+1:]
+	}
+	path = strings.Trim(strings.TrimSpace(path), "/")
+
+	location := path
+	if host != "" && path != "" {
+		location = host + "/" + path
+	} else if host != "" {
+		location = host
+	}
+
+	location = strings.ToLower(strings.TrimSuffix(location, "/"))
+	return strings.TrimSuffix(location, ".git")
 }
 
 func classifyGHError(err error) error {

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -442,6 +442,12 @@ func TestUrlMatches_AuthenticatedDifferentHost(t *testing.T) {
 	}
 }
 
+func TestUrlMatches_HostlessPathDoesNotMatchCanonicalRepository(t *testing.T) {
+	if urlMatches("github.com/owner/repo.git", "https://github.com/owner/repo") {
+		t.Fatal("hostless path matched canonical repository")
+	}
+}
+
 func TestUrlMatches_SSHURLFormat(t *testing.T) {
 
 	result := urlMatches("ssh://git@github.com/owner/repo.git", "https://github.com/owner/repo")
@@ -502,6 +508,18 @@ func TestMatchingFetchRemoteAcceptsCanonicalAuthenticatedAndSCPURLs(t *testing.T
 				t.Fatalf("remote = %q, want canonical", remote)
 			}
 		})
+	}
+}
+
+func TestMatchingFetchRemoteRejectsHostlessCanonicalLookalike(t *testing.T) {
+	remotes := []byte(strings.Join([]string{
+		"aaa-local\tgithub.com/org/canonical.git (fetch)",
+		"zzz-canonical\thttps://github.com/org/canonical.git (fetch)",
+	}, "\n"))
+
+	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+	if remote != "zzz-canonical" {
+		t.Fatalf("remote = %q, want zzz-canonical", remote)
 	}
 }
 

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -471,6 +471,34 @@ func TestUrlMatches_SSHURLWithExplicitPort(t *testing.T) {
 	}
 }
 
+func TestUrlMatches_DefaultPorts(t *testing.T) {
+	tests := []string{
+		"https://github.com:443/owner/repo.git",
+		"http://github.com:80/owner/repo.git",
+		"git://github.com:9418/owner/repo.git",
+	}
+	for _, remoteURL := range tests {
+		if !urlMatches(remoteURL, "https://github.com/owner/repo") {
+			t.Errorf("expected default-port canonical match for %q", remoteURL)
+		}
+	}
+}
+
+func TestUrlMatches_NonDefaultPortDoesNotMatchCanonicalRepository(t *testing.T) {
+	if urlMatches("ssh://git@github.com:2222/owner/repo.git", "https://github.com/owner/repo") {
+		t.Fatal("non-default port matched canonical repository")
+	}
+}
+
+func TestUrlMatches_RequiresSameNonDefaultPort(t *testing.T) {
+	if !urlMatches("ssh://git@github.com:2222/owner/repo.git", "ssh://github.com:2222/owner/repo") {
+		t.Fatal("matching non-default ports did not match")
+	}
+	if urlMatches("ssh://git@github.com:2222/owner/repo.git", "ssh://github.com:2200/owner/repo") {
+		t.Fatal("different non-default ports matched")
+	}
+}
+
 func TestUrlMatches_SSHURLVsSSHShorthand(t *testing.T) {
 	result := urlMatches("ssh://git@github.com/owner/repo.git", "git@github.com:owner/repo.git")
 	if !result {
@@ -522,6 +550,18 @@ func TestMatchingFetchRemoteRejectsHostlessCanonicalLookalike(t *testing.T) {
 	remotes := []byte(strings.Join([]string{
 		"aaa-local\tgithub.com/org/canonical.git (fetch)",
 		"zzz-canonical\thttps://github.com/org/canonical.git (fetch)",
+	}, "\n"))
+
+	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+	if remote != "zzz-canonical" {
+		t.Fatalf("remote = %q, want zzz-canonical", remote)
+	}
+}
+
+func TestMatchingFetchRemoteRejectsNonDefaultPortLookalike(t *testing.T) {
+	remotes := []byte(strings.Join([]string{
+		"aaa-other-service\tssh://git@github.com:2222/org/canonical.git (fetch)",
+		"zzz-canonical\tssh://git@github.com:22/org/canonical.git (fetch)",
 	}, "\n"))
 
 	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -412,6 +412,36 @@ func TestUrlMatches_SSHShorthandFormat(t *testing.T) {
 	}
 }
 
+func TestUrlMatches_GeneralSCPFormat(t *testing.T) {
+	tests := []string{
+		"github.com:owner/repo.git",
+		"deploy@github.com:owner/repo.git",
+	}
+	for _, remoteURL := range tests {
+		if !urlMatches(remoteURL, "https://github.com/owner/repo") {
+			t.Errorf("expected canonical match for %q", remoteURL)
+		}
+	}
+}
+
+func TestUrlMatches_AuthenticatedHTTPSFormat(t *testing.T) {
+	tests := []string{
+		"https://user@github.com/owner/repo.git",
+		"https://user:token@github.com/owner/repo.git",
+	}
+	for _, remoteURL := range tests {
+		if !urlMatches(remoteURL, "https://github.com/owner/repo") {
+			t.Errorf("expected canonical match for %q", remoteURL)
+		}
+	}
+}
+
+func TestUrlMatches_AuthenticatedDifferentHost(t *testing.T) {
+	if urlMatches("https://github.com@evil.example/owner/repo.git", "https://github.com/owner/repo") {
+		t.Fatal("authenticated URL on a different host matched canonical repository")
+	}
+}
+
 func TestUrlMatches_SSHURLFormat(t *testing.T) {
 
 	result := urlMatches("ssh://git@github.com/owner/repo.git", "https://github.com/owner/repo")
@@ -453,6 +483,25 @@ func TestMatchingFetchRemoteIgnoresCanonicalPushURLOnForkRemote(t *testing.T) {
 	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
 	if remote != "zzz-canonical" {
 		t.Fatalf("remote = %q, want zzz-canonical", remote)
+	}
+}
+
+func TestMatchingFetchRemoteAcceptsCanonicalAuthenticatedAndSCPURLs(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteURL string
+	}{
+		{name: "authenticated HTTPS", remoteURL: "https://user@github.com/org/canonical.git"},
+		{name: "SCP without user", remoteURL: "github.com:org/canonical.git"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remotes := []byte("canonical\t" + tt.remoteURL + " (fetch)\n")
+			remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+			if remote != "canonical" {
+				t.Fatalf("remote = %q, want canonical", remote)
+			}
+		})
 	}
 }
 

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -464,6 +464,13 @@ func TestUrlMatches_SSHURLFormatNoUser(t *testing.T) {
 	}
 }
 
+func TestUrlMatches_SSHURLWithExplicitPort(t *testing.T) {
+	result := urlMatches("ssh://git@github.com:22/owner/repo.git", "https://github.com/owner/repo")
+	if !result {
+		t.Error("expected true for SSH URL with explicit port vs HTTPS")
+	}
+}
+
 func TestUrlMatches_SSHURLVsSSHShorthand(t *testing.T) {
 	result := urlMatches("ssh://git@github.com/owner/repo.git", "git@github.com:owner/repo.git")
 	if !result {

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -442,6 +442,20 @@ func TestUrlMatches_DifferentRepos(t *testing.T) {
 	}
 }
 
+func TestMatchingFetchRemoteIgnoresCanonicalPushURLOnForkRemote(t *testing.T) {
+	remotes := []byte(strings.Join([]string{
+		"aaa-fork\thttps://github.com/user/fork.git (fetch)",
+		"aaa-fork\thttps://github.com/org/canonical.git (push)",
+		"zzz-canonical\thttps://github.com/org/canonical.git (fetch)",
+		"zzz-canonical\thttps://github.com/org/canonical.git (push)",
+	}, "\n"))
+
+	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+	if remote != "zzz-canonical" {
+		t.Fatalf("remote = %q, want zzz-canonical", remote)
+	}
+}
+
 func TestUrlMatches_CaseInsensitive(t *testing.T) {
 	result := urlMatches("https://github.com/OWNER/REPO", "https://github.com/owner/repo")
 	if !result {

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -513,6 +513,15 @@ func TestUrlMatches_DifferentRepos(t *testing.T) {
 	}
 }
 
+func matchingFetchRemoteForTest(t *testing.T, remotes []byte, repositoryURL, repositorySSHURL string) string {
+	t.Helper()
+	remote, err := matchingFetchRemote(remotes, repositoryURL, repositorySSHURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return remote
+}
+
 func TestMatchingFetchRemoteIgnoresCanonicalPushURLOnForkRemote(t *testing.T) {
 	remotes := []byte(strings.Join([]string{
 		"aaa-fork\thttps://github.com/user/fork.git (fetch)",
@@ -521,7 +530,7 @@ func TestMatchingFetchRemoteIgnoresCanonicalPushURLOnForkRemote(t *testing.T) {
 		"zzz-canonical\thttps://github.com/org/canonical.git (push)",
 	}, "\n"))
 
-	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+	remote := matchingFetchRemoteForTest(t, remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
 	if remote != "zzz-canonical" {
 		t.Fatalf("remote = %q, want zzz-canonical", remote)
 	}
@@ -538,7 +547,7 @@ func TestMatchingFetchRemoteAcceptsCanonicalAuthenticatedAndSCPURLs(t *testing.T
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			remotes := []byte("canonical\t" + tt.remoteURL + " (fetch)\n")
-			remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+			remote := matchingFetchRemoteForTest(t, remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
 			if remote != "canonical" {
 				t.Fatalf("remote = %q, want canonical", remote)
 			}
@@ -552,7 +561,7 @@ func TestMatchingFetchRemoteRejectsHostlessCanonicalLookalike(t *testing.T) {
 		"zzz-canonical\thttps://github.com/org/canonical.git (fetch)",
 	}, "\n"))
 
-	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+	remote := matchingFetchRemoteForTest(t, remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
 	if remote != "zzz-canonical" {
 		t.Fatalf("remote = %q, want zzz-canonical", remote)
 	}
@@ -564,9 +573,21 @@ func TestMatchingFetchRemoteRejectsNonDefaultPortLookalike(t *testing.T) {
 		"zzz-canonical\tssh://git@github.com:22/org/canonical.git (fetch)",
 	}, "\n"))
 
-	remote := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+	remote := matchingFetchRemoteForTest(t, remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
 	if remote != "zzz-canonical" {
 		t.Fatalf("remote = %q, want zzz-canonical", remote)
+	}
+}
+
+func TestMatchingFetchRemoteRejectsAmbiguousCanonicalRemotes(t *testing.T) {
+	remotes := []byte(strings.Join([]string{
+		"origin\tgit@github.com:org/canonical.git (fetch)",
+		"upstream\thttps://github.com/org/canonical.git (fetch)",
+	}, "\n"))
+
+	remote, err := matchingFetchRemote(remotes, "https://github.com/org/canonical", "git@github.com:org/canonical.git")
+	if err == nil || !strings.Contains(err.Error(), "multiple configured fetch remotes") {
+		t.Fatalf("remote = %q, error = %v", remote, err)
 	}
 }
 

--- a/internal/review/events.go
+++ b/internal/review/events.go
@@ -46,13 +46,14 @@ func (f EventSinkFunc) HandleReviewEvent(event Event) {
 }
 
 type eventEmitter struct {
-	mu       sync.Mutex
-	sink     EventSink
-	now      func() time.Time
-	runID    string
-	sequence uint64
-	closed   bool
-	open     []domain.ReviewPhase
+	mu               sync.Mutex
+	sink             EventSink
+	now              func() time.Time
+	runID            string
+	sequence         uint64
+	closed           bool
+	open             []domain.ReviewPhase
+	beforeCompletion func()
 }
 
 func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventEmitter {
@@ -60,7 +61,13 @@ func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventE
 }
 
 func (e *eventEmitter) emit(event Event) {
-	if e == nil || e.sink == nil {
+	if e == nil {
+		return
+	}
+	if event.Kind == EventRunCompleted {
+		e.runBeforeCompletion()
+	}
+	if e.sink == nil {
 		return
 	}
 	e.mu.Lock()
@@ -74,6 +81,25 @@ func (e *eventEmitter) emit(event Event) {
 		}
 	}
 	e.emitLocked(event)
+}
+
+func (e *eventEmitter) setBeforeCompletion(fn func()) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.beforeCompletion = fn
+	e.mu.Unlock()
+}
+
+func (e *eventEmitter) runBeforeCompletion() {
+	e.mu.Lock()
+	fn := e.beforeCompletion
+	e.beforeCompletion = nil
+	e.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 func (e *eventEmitter) emitLocked(event Event) {

--- a/internal/review/events.go
+++ b/internal/review/events.go
@@ -1,0 +1,84 @@
+package review
+
+import (
+	"sync"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type EventKind string
+
+const (
+	EventRunStarted        EventKind = "run_started"
+	EventPhaseStarted      EventKind = "phase_started"
+	EventPhaseCompleted    EventKind = "phase_completed"
+	EventWarning           EventKind = "warning"
+	EventReviewerStarted   EventKind = "reviewer_started"
+	EventReviewerOutput    EventKind = "reviewer_output"
+	EventReviewerRetrying  EventKind = "reviewer_retrying"
+	EventReviewerCompleted EventKind = "reviewer_completed"
+	EventRunCompleted      EventKind = "run_completed"
+)
+
+type Event struct {
+	Sequence       uint64
+	At             time.Time
+	RunID          string
+	Kind           EventKind
+	Phase          domain.ReviewPhase
+	Message        string
+	ReviewerID     int
+	AgentName      string
+	ReviewerResult domain.ReviewerResult
+	Status         domain.ReviewStatus
+	Conclusion     domain.ReviewConclusion
+}
+
+type EventSink interface {
+	HandleReviewEvent(Event)
+}
+
+type EventSinkFunc func(Event)
+
+func (f EventSinkFunc) HandleReviewEvent(event Event) {
+	f(event)
+}
+
+type eventEmitter struct {
+	mu       sync.Mutex
+	sink     EventSink
+	now      func() time.Time
+	runID    string
+	sequence uint64
+	closed   bool
+}
+
+func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventEmitter {
+	return &eventEmitter{sink: sink, now: now, runID: runID}
+}
+
+func (e *eventEmitter) emit(event Event) {
+	if e == nil || e.sink == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return
+	}
+	e.sequence++
+	event.Sequence = e.sequence
+	event.At = e.now()
+	event.RunID = e.runID
+	e.sink.HandleReviewEvent(event)
+}
+
+func (e *eventEmitter) close() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.closed = true
+	e.mu.Unlock()
+}

--- a/internal/review/events.go
+++ b/internal/review/events.go
@@ -52,6 +52,7 @@ type eventEmitter struct {
 	runID    string
 	sequence uint64
 	closed   bool
+	open     []domain.ReviewPhase
 }
 
 func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventEmitter {
@@ -67,11 +68,46 @@ func (e *eventEmitter) emit(event Event) {
 	if e.closed {
 		return
 	}
+	if event.Kind == EventRunCompleted {
+		for len(e.open) > 0 {
+			e.emitLocked(Event{Kind: EventPhaseCompleted, Phase: e.open[0]})
+		}
+	}
+	e.emitLocked(event)
+}
+
+func (e *eventEmitter) emitLocked(event Event) {
+	if event.Kind == EventPhaseStarted {
+		if !e.phaseOpen(event.Phase) {
+			e.open = append(e.open, event.Phase)
+		}
+	}
+	if event.Kind == EventPhaseCompleted {
+		e.closePhase(event.Phase)
+	}
 	e.sequence++
 	event.Sequence = e.sequence
 	event.At = e.now()
 	event.RunID = e.runID
 	e.sink.HandleReviewEvent(event)
+}
+
+func (e *eventEmitter) phaseOpen(phase domain.ReviewPhase) bool {
+	for _, candidate := range e.open {
+		if candidate == phase {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *eventEmitter) closePhase(phase domain.ReviewPhase) {
+	for i, candidate := range e.open {
+		if candidate == phase {
+			e.open = append(e.open[:i], e.open[i+1:]...)
+			return
+		}
+	}
 }
 
 func (e *eventEmitter) close() {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -122,6 +122,9 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if err := validateRequest(request); err != nil {
 		return nil, err
 	}
+	if err := git.ValidateWorktreeRepository(context.WithoutCancel(ctx), request.Target.RepositoryRoot, request.Target.WorktreeRoot); err != nil {
+		return nil, fmt.Errorf("invalid review request: %w", err)
+	}
 
 	startedAt := s.dependencies.now()
 	runID, err := s.dependencies.newRunID(startedAt)
@@ -259,6 +262,8 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseSummarization})
 	summaryCtx, summaryCancel := context.WithTimeout(ctx, values.SummarizerTimeout)
 	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings, postProcessDir)
+	summaryContextErr := summaryCtx.Err()
+	parentContextErr := ctx.Err()
 	summaryCancel()
 	if summaryResult != nil {
 		run.Stats.SummarizerDuration = summaryResult.Duration
@@ -279,6 +284,15 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 		initializeRunFindingRecords(run)
 	}
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseSummarization})
+	if parentContextErr != nil {
+		return s.interrupt(run, domain.ReviewPhaseSummarization, parentContextErr, emitter), nil
+	}
+	if errors.Is(summaryContextErr, context.DeadlineExceeded) {
+		message := boundedSummaryEvidence(fmt.Sprintf("summarizer timed out after %s", values.SummarizerTimeout))
+		run.Summarizer.ExitCode = -1
+		run.Summarizer.Stderr = message
+		return s.fail(run, domain.ReviewPhaseSummarization, errors.New(message), emitter), nil
+	}
 	if err != nil {
 		return s.finishFromError(run, domain.ReviewPhaseSummarization, err, ctx, emitter), nil
 	}

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -155,6 +155,11 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if err != nil {
 		return s.fail(run, domain.ReviewPhaseInitialization, err, emitter), nil
 	}
+	postProcessDir, cleanupPostProcessDir, err := agent.NewIsolatedWorkDir()
+	if err != nil {
+		return s.fail(run, domain.ReviewPhaseInitialization, fmt.Errorf("create isolated post-processing workspace: %w", err), emitter), nil
+	}
+	defer cleanupPostProcessDir()
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseInitialization})
 	if err := ctx.Err(); err != nil {
 		return s.interrupt(run, domain.ReviewPhaseInitialization, err, emitter), nil
@@ -253,7 +258,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 
 	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseSummarization})
 	summaryCtx, summaryCancel := context.WithTimeout(ctx, values.SummarizerTimeout)
-	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings, run.Target.WorktreeRoot)
+	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings, postProcessDir)
 	summaryCancel()
 	if summaryResult != nil {
 		run.Stats.SummarizerDuration = summaryResult.Duration
@@ -308,7 +313,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if values.FPFilterEnabled && len(finalGrouped.Findings) > 0 {
 		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
 		fpCtx, fpCancel := context.WithTimeout(ctx, values.FPFilterTimeout)
-		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold, run.Target.WorktreeRoot).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
+		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold, postProcessDir).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
 		fpCancel()
 		if fpResult != nil {
 			finalGrouped = cloneGroupedFindings(fpResult.Grouped)
@@ -611,8 +616,13 @@ func summarizePriorFeedback(ctx context.Context, target domain.ReviewTarget, age
 	if target.PullRequest == nil {
 		return "", nil
 	}
+	agentDir, cleanupAgentDir, err := agent.NewIsolatedWorkDir()
+	if err != nil {
+		return "", fmt.Errorf("create isolated feedback workspace: %w", err)
+	}
+	defer cleanupAgentDir()
 	summary := feedback.NewSummarizer(agentName, model, false, nil)
-	return summary.SummarizePullRequest(ctx, *target.PullRequest, target.WorktreeRoot)
+	return summary.SummarizePullRequestFromDirs(ctx, *target.PullRequest, target.WorktreeRoot, agentDir)
 }
 
 func defaultRunID(startedAt time.Time) (string, error) {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -254,6 +254,13 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if err := ctx.Err(); err != nil {
 		return s.interrupt(run, domain.ReviewPhaseReviewers, err, emitter), nil
 	}
+	confirmedRevision, err = s.dependencies.revisions(ctx, run.Target)
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseReviewers, err, ctx, emitter), nil
+	}
+	if err := validateResolvedRevision(run.Target.Revision, confirmedRevision); err != nil {
+		return s.fail(run, domain.ReviewPhaseReviewers, err, emitter), nil
+	}
 	if run.Stats.AllFailed() {
 		return s.fail(run, domain.ReviewPhaseReviewers, fmt.Errorf("all reviewers failed"), emitter), nil
 	}
@@ -318,9 +325,14 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 		return s.fail(run, domain.ReviewPhaseSummarization, errors.New(message), emitter), nil
 	}
 
-	priorFeedback, err := feedbackTask.receive(ctx, emitter)
-	if err != nil {
-		return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
+	var priorFeedback string
+	if len(run.PreFilterSummary.Findings) == 0 {
+		feedbackTask.cancelAndComplete(emitter)
+	} else {
+		priorFeedback, err = feedbackTask.receive(ctx, emitter)
+		if err != nil {
+			return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
+		}
 	}
 	if err := ctx.Err(); err != nil {
 		return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
@@ -537,6 +549,14 @@ func (t *priorFeedbackTask) stop() {
 	}
 	t.cancel()
 	<-t.done
+}
+
+func (t *priorFeedbackTask) cancelAndComplete(emitter *eventEmitter) {
+	if t == nil {
+		return
+	}
+	t.stop()
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback})
 }
 
 func (s *Service) emitReviewerWarnings(stats domain.ReviewStats, emitter *eventEmitter) {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -284,10 +284,11 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 		initializeRunFindingRecords(run)
 	}
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseSummarization})
+	summarySucceeded := err == nil && summaryResult != nil && summaryResult.ExitCode == 0
 	if parentContextErr != nil {
 		return s.interrupt(run, domain.ReviewPhaseSummarization, parentContextErr, emitter), nil
 	}
-	if errors.Is(summaryContextErr, context.DeadlineExceeded) {
+	if !summarySucceeded && errors.Is(summaryContextErr, context.DeadlineExceeded) {
 		message := boundedSummaryEvidence(fmt.Sprintf("summarizer timed out after %s", values.SummarizerTimeout))
 		run.Summarizer.ExitCode = -1
 		run.Summarizer.Stderr = message

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -1,0 +1,782 @@
+package review
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/feedback"
+	"github.com/richhaase/agentic-code-reviewer/internal/filter"
+	"github.com/richhaase/agentic-code-reviewer/internal/fpfilter"
+	"github.com/richhaase/agentic-code-reviewer/internal/git"
+	"github.com/richhaase/agentic-code-reviewer/internal/runner"
+	"github.com/richhaase/agentic-code-reviewer/internal/summarizer"
+)
+
+type Request struct {
+	Target              domain.ReviewTarget
+	Trigger             domain.ReviewTrigger
+	Engine              domain.ReviewEngine
+	Configuration       domain.ReviewConfiguration
+	ConfigurationSource domain.ConfigurationSourceIdentity
+	Events              EventSink
+}
+
+type AgentFactory func(string, string) (agent.Agent, error)
+
+type RevisionProvider func(context.Context, domain.ReviewTarget) (domain.RevisionEvidence, error)
+
+type DiffProvider func(context.Context, domain.ReviewTarget) (string, error)
+
+type PriorFeedbackProvider func(context.Context, domain.ReviewTarget, string, string) (string, error)
+
+type RunIDGenerator func(time.Time) (string, error)
+
+type Option func(*serviceDependencies)
+
+type serviceDependencies struct {
+	now           func() time.Time
+	newRunID      RunIDGenerator
+	newAgent      AgentFactory
+	revisions     RevisionProvider
+	diff          DiffProvider
+	priorFeedback PriorFeedbackProvider
+}
+
+type Service struct {
+	dependencies serviceDependencies
+}
+
+func NewService(options ...Option) (*Service, error) {
+	dependencies := serviceDependencies{
+		now:           time.Now,
+		newRunID:      defaultRunID,
+		newAgent:      agent.NewAgentWithModel,
+		revisions:     resolveRevisions,
+		diff:          loadDiff,
+		priorFeedback: summarizePriorFeedback,
+	}
+	for _, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("review service option cannot be nil")
+		}
+		option(&dependencies)
+	}
+	if dependencies.now == nil || dependencies.newRunID == nil || dependencies.newAgent == nil || dependencies.revisions == nil || dependencies.diff == nil || dependencies.priorFeedback == nil {
+		return nil, fmt.Errorf("review service dependencies must not be nil")
+	}
+	return &Service{dependencies: dependencies}, nil
+}
+
+func WithClock(now func() time.Time) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.now = now
+	}
+}
+
+func WithRunIDGenerator(generator RunIDGenerator) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.newRunID = generator
+	}
+}
+
+func WithAgentFactory(factory AgentFactory) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.newAgent = factory
+	}
+}
+
+func WithRevisionProvider(provider RevisionProvider) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.revisions = provider
+	}
+}
+
+func WithDiffProvider(provider DiffProvider) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.diff = provider
+	}
+}
+
+func WithPriorFeedbackProvider(provider PriorFeedbackProvider) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.priorFeedback = provider
+	}
+}
+
+func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("review service is required")
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("review context is required")
+	}
+	if err := validateRequest(request); err != nil {
+		return nil, err
+	}
+
+	startedAt := s.dependencies.now()
+	runID, err := s.dependencies.newRunID(startedAt)
+	if err != nil {
+		return nil, fmt.Errorf("create review run ID: %w", err)
+	}
+	if strings.TrimSpace(runID) == "" {
+		return nil, fmt.Errorf("create review run ID: empty ID")
+	}
+
+	run := &domain.ReviewRun{
+		ID:                       runID,
+		Target:                   request.Target.Clone(),
+		Trigger:                  request.Trigger,
+		Engine:                   request.Engine,
+		StartedAt:                startedAt,
+		Configuration:            request.Configuration,
+		ConfigurationSource:      request.ConfigurationSource,
+		ConfigurationFingerprint: request.Configuration.Fingerprint(),
+	}
+	emitter := newEventEmitter(request.Events, s.dependencies.now, runID)
+	emitter.emit(Event{Kind: EventRunStarted})
+
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseInitialization, err, emitter), nil
+	}
+
+	values := request.Configuration.Values()
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseInitialization})
+	reviewAgents, summarizerAgent, err := s.initializeAgents(values)
+	if err != nil {
+		return s.fail(run, domain.ReviewPhaseInitialization, err, emitter), nil
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseInitialization})
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseInitialization, err, emitter), nil
+	}
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseRevisions})
+	revision, err := s.dependencies.revisions(ctx, run.Target)
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseRevisions, err, ctx, emitter), nil
+	}
+	if err := validateResolvedRevision(run.Target.Revision, revision); err != nil {
+		return s.fail(run, domain.ReviewPhaseRevisions, err, emitter), nil
+	}
+	run.Target.Revision = revision
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseRevisions})
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseRevisions, err, emitter), nil
+	}
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseDiff})
+	diff, err := s.dependencies.diff(ctx, run.Target)
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseDiff, err, ctx, emitter), nil
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseDiff})
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseDiff, err, emitter), nil
+	}
+	if diff == "" {
+		return s.complete(run, domain.ReviewConclusionNoChanges, emitter), nil
+	}
+
+	feedbackTask := s.startPriorFeedback(ctx, run.Target, values, emitter)
+	if feedbackTask != nil {
+		defer feedbackTask.stop()
+	}
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseReviewers})
+	reviewerEvents := runner.Events{
+		ReviewerStarted: func(reviewerID int, agentName string) {
+			emitter.emit(Event{Kind: EventReviewerStarted, Phase: domain.ReviewPhaseReviewers, ReviewerID: reviewerID, AgentName: agentName})
+		},
+		ReviewerOutput: func(reviewerID int, output string) {
+			emitter.emit(Event{Kind: EventReviewerOutput, Phase: domain.ReviewPhaseReviewers, ReviewerID: reviewerID, Message: output})
+		},
+		ReviewerRetrying: func(reviewerID int, reason string, attempt, retries int, delay time.Duration) {
+			message := fmt.Sprintf("%s; retry %d/%d in %s", reason, attempt, retries, delay)
+			emitter.emit(Event{Kind: EventReviewerRetrying, Phase: domain.ReviewPhaseReviewers, ReviewerID: reviewerID, Message: message})
+		},
+		ReviewerCompleted: func(result domain.ReviewerResult) {
+			for _, warning := range result.Warnings {
+				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, ReviewerID: result.ReviewerID, AgentName: result.AgentName, Message: warning.Message})
+			}
+			emitter.emit(Event{Kind: EventReviewerCompleted, Phase: domain.ReviewPhaseReviewers, ReviewerID: result.ReviewerID, AgentName: result.AgentName, ReviewerResult: cloneReviewerResult(result)})
+		},
+	}
+	reviewRunner, err := runner.NewHeadless(runner.Config{
+		Reviewers:       values.Reviewers,
+		Concurrency:     values.Concurrency,
+		BaseRef:         run.Target.Revision.ResolvedBaseRef,
+		Timeout:         values.Timeout,
+		Retries:         values.Retries,
+		WorkDir:         run.Target.WorktreeRoot,
+		Guidance:        values.Guidance,
+		UseRefFile:      values.UseRefFile,
+		Diff:            diff,
+		DiffPrecomputed: agent.AgentsNeedDiff(reviewAgents),
+		Events:          reviewerEvents,
+	}, reviewAgents)
+	if err != nil {
+		return s.fail(run, domain.ReviewPhaseReviewers, err, emitter), nil
+	}
+	results, wallClock, err := reviewRunner.Run(ctx)
+	run.ReviewerResults = cloneReviewerResults(results)
+	run.Stats = runner.BuildStats(results, values.Reviewers, wallClock)
+	run.RawFindings = cloneFindings(runner.CollectFindings(results))
+	run.AggregatedFindings = cloneAggregatedFindings(domain.AggregateFindings(run.RawFindings))
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseReviewers})
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseReviewers, err, ctx, emitter), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseReviewers, err, emitter), nil
+	}
+	if run.Stats.AllFailed() {
+		return s.fail(run, domain.ReviewPhaseReviewers, fmt.Errorf("all reviewers failed"), emitter), nil
+	}
+	s.emitReviewerWarnings(run.Stats, emitter)
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseSummarization})
+	summaryCtx, summaryCancel := context.WithTimeout(ctx, values.SummarizerTimeout)
+	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings)
+	summaryCancel()
+	if summaryResult != nil {
+		run.Stats.SummarizerDuration = summaryResult.Duration
+		run.Summarizer = domain.SummarizerOutcome{
+			ExitCode: summaryResult.ExitCode,
+			Stderr:   boundedSummaryEvidence(summaryResult.Stderr),
+			Duration: summaryResult.Duration,
+		}
+		if summaryResult.ExitCode != 0 {
+			run.Summarizer.DiagnosticOutput = boundedSummaryEvidence(summaryResult.RawOut)
+		}
+		run.PreFilterSummary = cloneGroupedFindings(summaryResult.Grouped)
+		initializeRunFindingRecords(run)
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseSummarization})
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseSummarization, err, ctx, emitter), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseSummarization, err, emitter), nil
+	}
+	if summaryResult == nil {
+		return s.fail(run, domain.ReviewPhaseSummarization, fmt.Errorf("summarizer returned no result"), emitter), nil
+	}
+	if summaryResult.ExitCode != 0 {
+		message := strings.TrimSpace(run.Summarizer.Stderr)
+		if message == "" {
+			message = fmt.Sprintf("summarizer exited with code %d", summaryResult.ExitCode)
+		}
+		if ctx.Err() != nil {
+			return s.interrupt(run, domain.ReviewPhaseSummarization, ctx.Err(), emitter), nil
+		}
+		return s.fail(run, domain.ReviewPhaseSummarization, errors.New(message), emitter), nil
+	}
+
+	priorFeedback, err := feedbackTask.receive(ctx, emitter)
+	if err != nil {
+		return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
+	}
+	finalGrouped := cloneGroupedFindings(run.PreFilterSummary)
+	var fpRemoved []domain.FPRemovedInfo
+	var fpRemovedGroups []domain.FindingGroup
+	run.FalsePositiveFilter.Enabled = values.FPFilterEnabled
+	if values.FPFilterEnabled && len(finalGrouped.Findings) > 0 {
+		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
+		fpCtx, fpCancel := context.WithTimeout(ctx, values.FPFilterTimeout)
+		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
+		fpCancel()
+		if fpResult != nil {
+			finalGrouped = cloneGroupedFindings(fpResult.Grouped)
+			run.FalsePositiveFilter.Applied = !fpResult.Skipped
+			run.FalsePositiveFilter.Skipped = fpResult.Skipped
+			run.FalsePositiveFilter.SkipReason = fpResult.SkipReason
+			run.FalsePositiveFilter.EvalErrors = fpResult.EvalErrors
+			run.FalsePositiveFilter.Duration = fpResult.Duration
+			run.Stats.FPFilterDuration = fpResult.Duration
+			run.Stats.FPFilteredCount = fpResult.RemovedCount
+			for _, removed := range fpResult.Removed {
+				fpRemovedGroups = append(fpRemovedGroups, cloneFindingGroup(removed.Finding))
+				fpRemoved = append(fpRemoved, domain.FPRemovedInfo{
+					Sources:   slices.Clone(removed.Finding.Sources),
+					FPScore:   removed.FPScore,
+					Reasoning: removed.Reasoning,
+					Title:     removed.Finding.Title,
+				})
+			}
+			if fpResult.Skipped {
+				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFalsePositiveFilter, Message: "false-positive filter skipped: " + fpResult.SkipReason})
+			}
+		}
+		emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFalsePositiveFilter})
+		if err := ctx.Err(); err != nil {
+			run.Dispositions = domain.BuildDispositions(
+				len(run.AggregatedFindings),
+				run.PreFilterSummary.Info,
+				fpRemoved,
+				nil,
+				finalGrouped.Findings,
+			)
+			populateRunFindings(run, finalGrouped, fpRemovedGroups, nil, fpRemoved)
+			return s.interrupt(run, domain.ReviewPhaseFalsePositiveFilter, err, emitter), nil
+		}
+	}
+
+	var excludeRemoved []domain.FindingGroup
+	run.ExcludeFilter.Patterns = slices.Clone(values.ExcludePatterns)
+	if len(values.ExcludePatterns) > 0 {
+		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseExcludeFilter})
+		exclude, err := filter.New(values.ExcludePatterns)
+		if err != nil {
+			return s.fail(run, domain.ReviewPhaseExcludeFilter, err, emitter), nil
+		}
+		before := cloneGroupedFindings(finalGrouped)
+		finalGrouped = exclude.Apply(finalGrouped)
+		excludeRemoved = diffFindingGroups(before.Findings, finalGrouped.Findings)
+		emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseExcludeFilter})
+		if err := ctx.Err(); err != nil {
+			run.Dispositions = domain.BuildDispositions(
+				len(run.AggregatedFindings),
+				run.PreFilterSummary.Info,
+				fpRemoved,
+				excludeRemoved,
+				finalGrouped.Findings,
+			)
+			populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+			return s.interrupt(run, domain.ReviewPhaseExcludeFilter, err, emitter), nil
+		}
+	}
+
+	run.Dispositions = domain.BuildDispositions(
+		len(run.AggregatedFindings),
+		run.PreFilterSummary.Info,
+		fpRemoved,
+		excludeRemoved,
+		finalGrouped.Findings,
+	)
+	populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseComplete, err, emitter), nil
+	}
+
+	if len(run.Findings) == 0 {
+		return s.complete(run, domain.ReviewConclusionClean, emitter), nil
+	}
+	return s.complete(run, domain.ReviewConclusionFindings, emitter), nil
+}
+
+func validateRequest(request Request) error {
+	var invalid []string
+	if err := request.Target.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.Trigger.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.Engine.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.Configuration.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.ConfigurationSource.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid review request: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func (s *Service) initializeAgents(values domain.ReviewConfigurationValues) ([]agent.Agent, agent.Agent, error) {
+	reviewAgents := make([]agent.Agent, 0, len(values.ReviewerAgents))
+	seen := make(map[string]agent.Agent)
+	for _, name := range values.ReviewerAgents {
+		reviewAgent, ok := seen[name]
+		if !ok {
+			var err error
+			reviewAgent, err = s.dependencies.newAgent(name, values.ReviewerModel)
+			if err != nil {
+				return nil, nil, fmt.Errorf("create reviewer agent %q: %w", name, err)
+			}
+			if reviewAgent == nil {
+				return nil, nil, fmt.Errorf("create reviewer agent %q: no agent returned", name)
+			}
+			if err := reviewAgent.IsAvailable(); err != nil {
+				return nil, nil, fmt.Errorf("reviewer agent %q unavailable: %w", name, err)
+			}
+			seen[name] = reviewAgent
+		}
+		reviewAgents = append(reviewAgents, reviewAgent)
+	}
+
+	summarizerAgent, err := s.dependencies.newAgent(values.SummarizerAgent, values.SummarizerModel)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create summarizer agent %q: %w", values.SummarizerAgent, err)
+	}
+	if summarizerAgent == nil {
+		return nil, nil, fmt.Errorf("create summarizer agent %q: no agent returned", values.SummarizerAgent)
+	}
+	if err := summarizerAgent.IsAvailable(); err != nil {
+		return nil, nil, fmt.Errorf("summarizer agent %q unavailable: %w", values.SummarizerAgent, err)
+	}
+	return reviewAgents, summarizerAgent, nil
+}
+
+type priorFeedbackResult struct {
+	summary string
+	err     error
+}
+
+type priorFeedbackTask struct {
+	result <-chan priorFeedbackResult
+	done   <-chan struct{}
+	cancel context.CancelFunc
+}
+
+func (s *Service) startPriorFeedback(ctx context.Context, target domain.ReviewTarget, values domain.ReviewConfigurationValues, emitter *eventEmitter) *priorFeedbackTask {
+	if !values.PRFeedbackEnabled || !values.FPFilterEnabled || target.PullRequest == nil {
+		return nil
+	}
+	result := make(chan priorFeedbackResult, 1)
+	done := make(chan struct{})
+	feedbackCtx, cancel := context.WithTimeout(ctx, values.SummarizerTimeout)
+	task := &priorFeedbackTask{result: result, done: done, cancel: cancel}
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFeedback})
+	go func() {
+		defer close(done)
+		feedbackAgent := values.PRFeedbackAgent
+		if feedbackAgent == "" {
+			feedbackAgent = values.SummarizerAgent
+		}
+		summary, err := s.dependencies.priorFeedback(feedbackCtx, target, feedbackAgent, values.SummarizerModel)
+		result <- priorFeedbackResult{summary: summary, err: err}
+	}()
+	return task
+}
+
+func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) (string, error) {
+	if t == nil {
+		return "", nil
+	}
+	var feedbackResult priorFeedbackResult
+	select {
+	case feedbackResult = <-t.result:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback})
+	if feedbackResult.err != nil {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFeedback, Message: "prior feedback unavailable: " + feedbackResult.err.Error()})
+		return "", nil
+	}
+	return feedbackResult.summary, nil
+}
+
+func (t *priorFeedbackTask) stop() {
+	if t == nil {
+		return
+	}
+	t.cancel()
+	<-t.done
+}
+
+func (s *Service) emitReviewerWarnings(stats domain.ReviewStats, emitter *eventEmitter) {
+	if stats.ParseErrors > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("reviewer parse errors: %d", stats.ParseErrors)})
+	}
+	if len(stats.FailedReviewers) > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("failed reviewers: %v", stats.FailedReviewers)})
+	}
+	if len(stats.TimedOutReviewers) > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("timed out reviewers: %v", stats.TimedOutReviewers)})
+	}
+	if len(stats.AuthFailedReviewers) > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("authentication failed reviewers: %v", stats.AuthFailedReviewers)})
+	}
+}
+
+func (s *Service) complete(run *domain.ReviewRun, conclusion domain.ReviewConclusion, emitter *eventEmitter) *domain.ReviewRun {
+	run.Status = domain.ReviewStatusCompleted
+	run.Conclusion = conclusion
+	run.CompletedAt = s.dependencies.now()
+	emitter.emit(Event{Kind: EventRunCompleted, Phase: domain.ReviewPhaseComplete, Status: run.Status, Conclusion: run.Conclusion})
+	emitter.close()
+	return run
+}
+
+func (s *Service) fail(run *domain.ReviewRun, phase domain.ReviewPhase, err error, emitter *eventEmitter) *domain.ReviewRun {
+	run.Status = domain.ReviewStatusFailed
+	run.Conclusion = domain.ReviewConclusionNone
+	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	run.CompletedAt = s.dependencies.now()
+	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
+	emitter.close()
+	return run
+}
+
+func (s *Service) interrupt(run *domain.ReviewRun, phase domain.ReviewPhase, err error, emitter *eventEmitter) *domain.ReviewRun {
+	run.Status = domain.ReviewStatusInterrupted
+	run.Conclusion = domain.ReviewConclusionNone
+	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	run.CompletedAt = s.dependencies.now()
+	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
+	emitter.close()
+	return run
+}
+
+func (s *Service) finishFromError(run *domain.ReviewRun, phase domain.ReviewPhase, err error, ctx context.Context, emitter *eventEmitter) *domain.ReviewRun {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return s.interrupt(run, phase, err, emitter)
+	}
+	return s.fail(run, phase, err, emitter)
+}
+
+func validateResolvedRevision(expected, actual domain.RevisionEvidence) error {
+	if strings.TrimSpace(actual.RequestedBaseRef) == "" || strings.TrimSpace(actual.ResolvedBaseRef) == "" || strings.TrimSpace(actual.HeadObjectID) == "" || strings.TrimSpace(actual.BaseObjectID) == "" {
+		return fmt.Errorf("revision provider returned incomplete evidence")
+	}
+	if actual.RequestedBaseRef != expected.RequestedBaseRef {
+		return fmt.Errorf("requested base ref changed from %q to %q", expected.RequestedBaseRef, actual.RequestedBaseRef)
+	}
+	if actual.ResolvedBaseRef != expected.ResolvedBaseRef {
+		return fmt.Errorf("resolved base ref changed from %q to %q", expected.ResolvedBaseRef, actual.ResolvedBaseRef)
+	}
+	if expected.HeadObjectID != "" && expected.HeadObjectID != actual.HeadObjectID {
+		return fmt.Errorf("review head changed from %s to %s", expected.HeadObjectID, actual.HeadObjectID)
+	}
+	if expected.BaseObjectID != "" && expected.BaseObjectID != actual.BaseObjectID {
+		return fmt.Errorf("review base changed from %s to %s", expected.BaseObjectID, actual.BaseObjectID)
+	}
+	return nil
+}
+
+func resolveRevisions(ctx context.Context, target domain.ReviewTarget) (domain.RevisionEvidence, error) {
+	revision := target.Revision
+	headObjectID, err := git.ResolveCommit(ctx, target.WorktreeRoot, "HEAD")
+	if err != nil {
+		return domain.RevisionEvidence{}, err
+	}
+	baseObjectID, err := git.ResolveCommit(ctx, target.WorktreeRoot, revision.ResolvedBaseRef)
+	if err != nil {
+		return domain.RevisionEvidence{}, err
+	}
+	revision.HeadObjectID = headObjectID
+	revision.BaseObjectID = baseObjectID
+	return revision, nil
+}
+
+func loadDiff(ctx context.Context, target domain.ReviewTarget) (string, error) {
+	return git.GetDiff(ctx, target.Revision.ResolvedBaseRef, target.WorktreeRoot)
+}
+
+func summarizePriorFeedback(ctx context.Context, target domain.ReviewTarget, agentName, model string) (string, error) {
+	if target.PullRequest == nil {
+		return "", nil
+	}
+	summary := feedback.NewSummarizer(agentName, model, false, nil)
+	return summary.SummarizePullRequest(ctx, *target.PullRequest, target.WorktreeRoot)
+}
+
+func defaultRunID(startedAt time.Time) (string, error) {
+	var random [8]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", err
+	}
+	return startedAt.UTC().Format("20060102T150405.000000000Z") + "-" + hex.EncodeToString(random[:]), nil
+}
+
+const (
+	summaryDiagnosticMaxLines         = 10
+	summaryDiagnosticMaxBytes         = 4096
+	summaryDiagnosticTruncationMarker = "\n[truncated]"
+)
+
+func boundedSummaryEvidence(output string) string {
+	lines := strings.Split(output, "\n")
+	truncated := len(lines) > summaryDiagnosticMaxLines
+	if truncated {
+		lines = lines[:summaryDiagnosticMaxLines]
+	}
+	diagnostic := strings.Join(lines, "\n")
+	if len(diagnostic) > summaryDiagnosticMaxBytes {
+		truncated = true
+	}
+	if truncated {
+		limit := summaryDiagnosticMaxBytes - len(summaryDiagnosticTruncationMarker)
+		if len(diagnostic) > limit {
+			for limit > 0 && !utf8.RuneStart(diagnostic[limit]) {
+				limit--
+			}
+			diagnostic = diagnostic[:limit]
+		}
+		return diagnostic + summaryDiagnosticTruncationMarker
+	}
+	return diagnostic
+}
+
+func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fpRemovedGroups, excludeRemoved []domain.FindingGroup, fpRemoved []domain.FPRemovedInfo) {
+	if len(run.FindingRecords) == 0 && run.PreFilterSummary.TotalGroups() > 0 {
+		initializeRunFindingRecords(run)
+	}
+	run.Findings = nil
+	run.Info = nil
+	run.FalsePositiveFilter.Removed = nil
+	run.ExcludeFilter.Removed = nil
+	for i, finding := range run.FindingRecords {
+		if finding.Kind == domain.ReviewFindingActionable {
+			finding.Disposition = dispositionForGroup(finding.Group, final.Findings, fpRemovedGroups, excludeRemoved, fpRemoved)
+			run.FindingRecords[i] = finding
+		}
+		switch finding.Disposition.Kind {
+		case domain.DispositionSurvived:
+			run.Findings = append(run.Findings, finding)
+		case domain.DispositionInfo:
+			run.Info = append(run.Info, finding)
+		case domain.DispositionFilteredFP:
+			run.FalsePositiveFilter.Removed = append(run.FalsePositiveFilter.Removed, finding)
+		case domain.DispositionFilteredExclude:
+			run.ExcludeFilter.Removed = append(run.ExcludeFilter.Removed, finding)
+		}
+	}
+}
+
+func initializeRunFindingRecords(run *domain.ReviewRun) {
+	records := make([]domain.ReviewFinding, 0, run.PreFilterSummary.TotalGroups())
+	for i, group := range run.PreFilterSummary.Findings {
+		records = append(records, domain.ReviewFinding{
+			ID:    fmt.Sprintf("finding-%03d", i+1),
+			Kind:  domain.ReviewFindingActionable,
+			Group: cloneFindingGroup(group),
+			Disposition: domain.Disposition{
+				GroupTitle: group.Title,
+			},
+		})
+	}
+	for i, group := range run.PreFilterSummary.Info {
+		records = append(records, domain.ReviewFinding{
+			ID:    fmt.Sprintf("info-%03d", i+1),
+			Kind:  domain.ReviewFindingInformational,
+			Group: cloneFindingGroup(group),
+			Disposition: domain.Disposition{
+				Kind:       domain.DispositionInfo,
+				GroupTitle: group.Title,
+			},
+		})
+	}
+	run.FindingRecords = records
+}
+
+func dispositionForGroup(group domain.FindingGroup, final, fpRemoved, excludeRemoved []domain.FindingGroup, fpInfo []domain.FPRemovedInfo) domain.Disposition {
+	if containsFindingGroup(final, group) {
+		return domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: group.Title}
+	}
+	if containsFindingGroup(fpRemoved, group) {
+		disposition := domain.Disposition{Kind: domain.DispositionFilteredFP, GroupTitle: group.Title}
+		for _, info := range fpInfo {
+			if info.Title == group.Title && slices.Equal(info.Sources, group.Sources) {
+				disposition.FPScore = info.FPScore
+				disposition.Reasoning = info.Reasoning
+				break
+			}
+		}
+		return disposition
+	}
+	if containsFindingGroup(excludeRemoved, group) {
+		return domain.Disposition{Kind: domain.DispositionFilteredExclude, GroupTitle: group.Title}
+	}
+	return domain.Disposition{GroupTitle: group.Title}
+}
+
+func containsFindingGroup(groups []domain.FindingGroup, candidate domain.FindingGroup) bool {
+	for _, group := range groups {
+		if sameFindingGroup(group, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func diffFindingGroups(before, after []domain.FindingGroup) []domain.FindingGroup {
+	j := 0
+	var removed []domain.FindingGroup
+	for i := range before {
+		if j < len(after) && sameFindingGroup(before[i], after[j]) {
+			j++
+		} else {
+			removed = append(removed, cloneFindingGroup(before[i]))
+		}
+	}
+	return removed
+}
+
+func sameFindingGroup(left, right domain.FindingGroup) bool {
+	return left.Title == right.Title &&
+		left.Summary == right.Summary &&
+		left.ReviewerCount == right.ReviewerCount &&
+		slices.Equal(left.Messages, right.Messages) &&
+		slices.Equal(left.Sources, right.Sources)
+}
+
+func cloneReviewerResults(results []domain.ReviewerResult) []domain.ReviewerResult {
+	cloned := make([]domain.ReviewerResult, len(results))
+	for i, result := range results {
+		cloned[i] = cloneReviewerResult(result)
+	}
+	return cloned
+}
+
+func cloneReviewerResult(result domain.ReviewerResult) domain.ReviewerResult {
+	result.Findings = cloneFindings(result.Findings)
+	result.Warnings = slices.Clone(result.Warnings)
+	if result.Failure != nil {
+		failure := *result.Failure
+		result.Failure = &failure
+	}
+	return result
+}
+
+func cloneFindings(findings []domain.Finding) []domain.Finding {
+	return slices.Clone(findings)
+}
+
+func cloneAggregatedFindings(findings []domain.AggregatedFinding) []domain.AggregatedFinding {
+	cloned := make([]domain.AggregatedFinding, len(findings))
+	for i, finding := range findings {
+		cloned[i] = finding
+		cloned[i].Reviewers = slices.Clone(finding.Reviewers)
+	}
+	return cloned
+}
+
+func cloneGroupedFindings(grouped domain.GroupedFindings) domain.GroupedFindings {
+	cloned := domain.GroupedFindings{
+		Findings: make([]domain.FindingGroup, len(grouped.Findings)),
+		Info:     make([]domain.FindingGroup, len(grouped.Info)),
+	}
+	for i, finding := range grouped.Findings {
+		cloned.Findings[i] = cloneFindingGroup(finding)
+	}
+	for i, finding := range grouped.Info {
+		cloned.Info[i] = cloneFindingGroup(finding)
+	}
+	return cloned
+}
+
+func cloneFindingGroup(group domain.FindingGroup) domain.FindingGroup {
+	group.Messages = slices.Clone(group.Messages)
+	group.Sources = slices.Clone(group.Sources)
+	return group
+}

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -179,6 +179,13 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if err != nil {
 		return s.finishFromError(run, domain.ReviewPhaseDiff, err, ctx, emitter), nil
 	}
+	confirmedRevision, err := s.dependencies.revisions(ctx, run.Target)
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseDiff, err, ctx, emitter), nil
+	}
+	if err := validateResolvedRevision(run.Target.Revision, confirmedRevision); err != nil {
+		return s.fail(run, domain.ReviewPhaseDiff, err, emitter), nil
+	}
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseDiff})
 	if err := ctx.Err(); err != nil {
 		return s.interrupt(run, domain.ReviewPhaseDiff, err, emitter), nil
@@ -189,7 +196,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 
 	feedbackTask := s.startPriorFeedback(ctx, run.Target, values, emitter)
 	if feedbackTask != nil {
-		defer feedbackTask.stop()
+		emitter.setBeforeCompletion(feedbackTask.stop)
 	}
 
 	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseReviewers})
@@ -254,6 +261,11 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 			ExitCode: summaryResult.ExitCode,
 			Stderr:   boundedSummaryEvidence(summaryResult.Stderr),
 			Duration: summaryResult.Duration,
+		}
+		for _, warning := range summaryResult.Warnings {
+			message := boundedSummaryEvidence(warning)
+			run.Summarizer.Warnings = append(run.Summarizer.Warnings, message)
+			emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseSummarization, Message: message})
 		}
 		if summaryResult.ExitCode != 0 {
 			run.Summarizer.DiagnosticOutput = boundedSummaryEvidence(summaryResult.RawOut)

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -214,14 +214,14 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	reviewRunner, err := runner.NewHeadless(runner.Config{
 		Reviewers:       values.Reviewers,
 		Concurrency:     values.Concurrency,
-		BaseRef:         run.Target.Revision.ResolvedBaseRef,
+		BaseRef:         run.Target.Revision.BaseObjectID,
 		Timeout:         values.Timeout,
 		Retries:         values.Retries,
 		WorkDir:         run.Target.WorktreeRoot,
 		Guidance:        values.Guidance,
 		UseRefFile:      values.UseRefFile,
 		Diff:            diff,
-		DiffPrecomputed: agent.AgentsNeedDiff(reviewAgents),
+		DiffPrecomputed: true,
 		Events:          reviewerEvents,
 	}, reviewAgents)
 	if err != nil {
@@ -291,7 +291,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	}
 	finalGrouped := cloneGroupedFindings(run.PreFilterSummary)
 	var fpRemoved []domain.FPRemovedInfo
-	var fpRemovedGroups []domain.FindingGroup
+	fpRemovedByIndex := make(map[int]domain.FPRemovedInfo)
 	run.FalsePositiveFilter.Enabled = values.FPFilterEnabled
 	if values.FPFilterEnabled && len(finalGrouped.Findings) > 0 {
 		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
@@ -308,13 +308,14 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 			run.Stats.FPFilterDuration = fpResult.Duration
 			run.Stats.FPFilteredCount = fpResult.RemovedCount
 			for _, removed := range fpResult.Removed {
-				fpRemovedGroups = append(fpRemovedGroups, cloneFindingGroup(removed.Finding))
-				fpRemoved = append(fpRemoved, domain.FPRemovedInfo{
+				info := domain.FPRemovedInfo{
 					Sources:   slices.Clone(removed.Finding.Sources),
 					FPScore:   removed.FPScore,
 					Reasoning: removed.Reasoning,
 					Title:     removed.Finding.Title,
-				})
+				}
+				fpRemovedByIndex[removed.Index] = info
+				fpRemoved = append(fpRemoved, info)
 			}
 			if fpResult.Skipped {
 				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFalsePositiveFilter, Message: "false-positive filter skipped: " + fpResult.SkipReason})
@@ -329,7 +330,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 				nil,
 				finalGrouped.Findings,
 			)
-			populateRunFindings(run, finalGrouped, fpRemovedGroups, nil, fpRemoved)
+			populateRunFindings(run, finalGrouped, fpRemovedByIndex, nil)
 			return s.interrupt(run, domain.ReviewPhaseFalsePositiveFilter, err, emitter), nil
 		}
 	}
@@ -354,7 +355,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 				excludeRemoved,
 				finalGrouped.Findings,
 			)
-			populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+			populateRunFindings(run, finalGrouped, fpRemovedByIndex, excludeRemoved)
 			return s.interrupt(run, domain.ReviewPhaseExcludeFilter, err, emitter), nil
 		}
 	}
@@ -366,7 +367,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 		excludeRemoved,
 		finalGrouped.Findings,
 	)
-	populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+	populateRunFindings(run, finalGrouped, fpRemovedByIndex, excludeRemoved)
 	if err := ctx.Err(); err != nil {
 		return s.interrupt(run, domain.ReviewPhaseComplete, err, emitter), nil
 	}
@@ -579,7 +580,7 @@ func resolveRevisions(ctx context.Context, target domain.ReviewTarget) (domain.R
 }
 
 func loadDiff(ctx context.Context, target domain.ReviewTarget) (string, error) {
-	return git.GetDiff(ctx, target.Revision.ResolvedBaseRef, target.WorktreeRoot)
+	return git.GetDiff(ctx, target.Revision.BaseObjectID, target.WorktreeRoot)
 }
 
 func summarizePriorFeedback(ctx context.Context, target domain.ReviewTarget, agentName, model string) (string, error) {
@@ -627,7 +628,7 @@ func boundedSummaryEvidence(output string) string {
 	return diagnostic
 }
 
-func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fpRemovedGroups, excludeRemoved []domain.FindingGroup, fpRemoved []domain.FPRemovedInfo) {
+func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fpRemovedByIndex map[int]domain.FPRemovedInfo, excludeRemoved []domain.FindingGroup) {
 	if len(run.FindingRecords) == 0 && run.PreFilterSummary.TotalGroups() > 0 {
 		initializeRunFindingRecords(run)
 	}
@@ -635,10 +636,14 @@ func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fp
 	run.Info = nil
 	run.FalsePositiveFilter.Removed = nil
 	run.ExcludeFilter.Removed = nil
+	finalRemaining := cloneFindingGroups(final.Findings)
+	excludeRemaining := cloneFindingGroups(excludeRemoved)
+	actionableIndex := 0
 	for i, finding := range run.FindingRecords {
 		if finding.Kind == domain.ReviewFindingActionable {
-			finding.Disposition = dispositionForGroup(finding.Group, final.Findings, fpRemovedGroups, excludeRemoved, fpRemoved)
+			finding.Disposition = dispositionForFinding(actionableIndex, finding.Group, &finalRemaining, fpRemovedByIndex, &excludeRemaining)
 			run.FindingRecords[i] = finding
+			actionableIndex++
 		}
 		switch finding.Disposition.Kind {
 		case domain.DispositionSurvived:
@@ -679,34 +684,35 @@ func initializeRunFindingRecords(run *domain.ReviewRun) {
 	run.FindingRecords = records
 }
 
-func dispositionForGroup(group domain.FindingGroup, final, fpRemoved, excludeRemoved []domain.FindingGroup, fpInfo []domain.FPRemovedInfo) domain.Disposition {
-	if containsFindingGroup(final, group) {
+func dispositionForFinding(index int, group domain.FindingGroup, final *[]domain.FindingGroup, fpRemoved map[int]domain.FPRemovedInfo, excludeRemoved *[]domain.FindingGroup) domain.Disposition {
+	if info, ok := fpRemoved[index]; ok {
+		return domain.Disposition{Kind: domain.DispositionFilteredFP, GroupTitle: group.Title, FPScore: info.FPScore, Reasoning: info.Reasoning}
+	}
+	if consumeFindingGroup(final, group) {
 		return domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: group.Title}
 	}
-	if containsFindingGroup(fpRemoved, group) {
-		disposition := domain.Disposition{Kind: domain.DispositionFilteredFP, GroupTitle: group.Title}
-		for _, info := range fpInfo {
-			if info.Title == group.Title && slices.Equal(info.Sources, group.Sources) {
-				disposition.FPScore = info.FPScore
-				disposition.Reasoning = info.Reasoning
-				break
-			}
-		}
-		return disposition
-	}
-	if containsFindingGroup(excludeRemoved, group) {
+	if consumeFindingGroup(excludeRemoved, group) {
 		return domain.Disposition{Kind: domain.DispositionFilteredExclude, GroupTitle: group.Title}
 	}
 	return domain.Disposition{GroupTitle: group.Title}
 }
 
-func containsFindingGroup(groups []domain.FindingGroup, candidate domain.FindingGroup) bool {
-	for _, group := range groups {
+func consumeFindingGroup(groups *[]domain.FindingGroup, candidate domain.FindingGroup) bool {
+	for i, group := range *groups {
 		if sameFindingGroup(group, candidate) {
+			*groups = append((*groups)[:i], (*groups)[i+1:]...)
 			return true
 		}
 	}
 	return false
+}
+
+func cloneFindingGroups(groups []domain.FindingGroup) []domain.FindingGroup {
+	cloned := make([]domain.FindingGroup, len(groups))
+	for i, group := range groups {
+		cloned[i] = cloneFindingGroup(group)
+	}
+	return cloned
 }
 
 func diffFindingGroups(before, after []domain.FindingGroup) []domain.FindingGroup {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -253,7 +253,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 
 	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseSummarization})
 	summaryCtx, summaryCancel := context.WithTimeout(ctx, values.SummarizerTimeout)
-	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings)
+	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings, run.Target.WorktreeRoot)
 	summaryCancel()
 	if summaryResult != nil {
 		run.Stats.SummarizerDuration = summaryResult.Duration
@@ -308,7 +308,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if values.FPFilterEnabled && len(finalGrouped.Findings) > 0 {
 		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
 		fpCtx, fpCancel := context.WithTimeout(ctx, values.FPFilterTimeout)
-		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
+		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold, run.Target.WorktreeRoot).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
 		fpCancel()
 		if fpResult != nil {
 			finalGrouped = cloneGroupedFindings(fpResult.Grouped)
@@ -317,6 +317,11 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 			run.FalsePositiveFilter.SkipReason = fpResult.SkipReason
 			run.FalsePositiveFilter.EvalErrors = fpResult.EvalErrors
 			run.FalsePositiveFilter.Duration = fpResult.Duration
+			for _, warning := range fpResult.Warnings {
+				message := boundedSummaryEvidence(warning)
+				run.FalsePositiveFilter.Warnings = append(run.FalsePositiveFilter.Warnings, message)
+				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFalsePositiveFilter, Message: message})
+			}
 			run.Stats.FPFilterDuration = fpResult.Duration
 			run.Stats.FPFilteredCount = fpResult.RemovedCount
 			for _, removed := range fpResult.Removed {
@@ -492,8 +497,12 @@ func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) 
 	}
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback})
 	if feedbackResult.err != nil {
-		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFeedback, Message: "prior feedback unavailable: " + feedbackResult.err.Error()})
-		return "", nil
+		message := "prior feedback unavailable: " + feedbackResult.err.Error()
+		if feedbackResult.summary != "" {
+			message = "prior feedback warning: " + feedbackResult.err.Error()
+		}
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFeedback, Message: message})
+		return feedbackResult.summary, nil
 	}
 	return feedbackResult.summary, nil
 }
@@ -524,6 +533,7 @@ func (s *Service) emitReviewerWarnings(stats domain.ReviewStats, emitter *eventE
 func (s *Service) complete(run *domain.ReviewRun, conclusion domain.ReviewConclusion, emitter *eventEmitter) *domain.ReviewRun {
 	run.Status = domain.ReviewStatusCompleted
 	run.Conclusion = conclusion
+	emitter.runBeforeCompletion()
 	run.CompletedAt = s.dependencies.now()
 	emitter.emit(Event{Kind: EventRunCompleted, Phase: domain.ReviewPhaseComplete, Status: run.Status, Conclusion: run.Conclusion})
 	emitter.close()
@@ -534,6 +544,7 @@ func (s *Service) fail(run *domain.ReviewRun, phase domain.ReviewPhase, err erro
 	run.Status = domain.ReviewStatusFailed
 	run.Conclusion = domain.ReviewConclusionNone
 	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	emitter.runBeforeCompletion()
 	run.CompletedAt = s.dependencies.now()
 	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
 	emitter.close()
@@ -544,6 +555,7 @@ func (s *Service) interrupt(run *domain.ReviewRun, phase domain.ReviewPhase, err
 	run.Status = domain.ReviewStatusInterrupted
 	run.Conclusion = domain.ReviewConclusionNone
 	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	emitter.runBeforeCompletion()
 	run.CompletedAt = s.dependencies.now()
 	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
 	emitter.close()

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -291,7 +291,11 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if !summarySucceeded && errors.Is(summaryContextErr, context.DeadlineExceeded) {
 		message := boundedSummaryEvidence(fmt.Sprintf("summarizer timed out after %s", values.SummarizerTimeout))
 		run.Summarizer.ExitCode = -1
-		run.Summarizer.Stderr = message
+		stderr := ""
+		if summaryResult != nil {
+			stderr = summaryResult.Stderr
+		}
+		run.Summarizer.Stderr = boundedSummaryEvidenceWithSuffix(stderr, message)
 		return s.fail(run, domain.ReviewPhaseSummarization, errors.New(message), emitter), nil
 	}
 	if err != nil {
@@ -675,6 +679,40 @@ func boundedSummaryEvidence(output string) string {
 		return diagnostic + summaryDiagnosticTruncationMarker
 	}
 	return diagnostic
+}
+
+func boundedSummaryEvidenceWithSuffix(output, suffix string) string {
+	output = strings.TrimRight(output, "\r\n")
+	suffix = strings.TrimSpace(suffix)
+	if output == "" {
+		return boundedSummaryEvidence(suffix)
+	}
+	if suffix == "" {
+		return boundedSummaryEvidence(output)
+	}
+
+	lines := strings.Split(output, "\n")
+	truncated := len(lines) >= summaryDiagnosticMaxLines
+	if truncated {
+		lines = lines[:summaryDiagnosticMaxLines-1]
+	}
+	prefix := strings.Join(lines, "\n")
+	trailer := "\n" + suffix
+	limit := summaryDiagnosticMaxBytes - len(trailer)
+	if truncated || len(prefix) > limit {
+		limit -= len(summaryDiagnosticTruncationMarker)
+		if limit < 0 {
+			return boundedSummaryEvidence(suffix)
+		}
+		if len(prefix) > limit {
+			for limit > 0 && !utf8.RuneStart(prefix[limit]) {
+				limit--
+			}
+			prefix = prefix[:limit]
+		}
+		prefix += summaryDiagnosticTruncationMarker
+	}
+	return prefix + trailer
 }
 
 func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fpRemovedByIndex map[int]domain.FPRemovedInfo, excludeRemoved []domain.FindingGroup) {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -275,6 +275,32 @@ func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
 	}
 }
 
+func TestServicePinsEveryReviewerToCapturedRevisionAndDiff(t *testing.T) {
+	configs := make(chan agent.ReviewConfig, 2)
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(_ context.Context, config *agent.ReviewConfig) (string, int, string, error) {
+			configs <- *config
+			return codexReviewOutput("src/service.go:10: missing validation"), 0, "", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "captured diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewStatusCompleted {
+		t.Fatalf("run status = %q", run.Status)
+	}
+	for range 2 {
+		config := <-configs
+		if config.BaseRef != "base-object" || !config.DiffPrecomputed || config.Diff != "captured diff" {
+			t.Fatalf("reviewer received mutable review input: %#v", config)
+		}
+	}
+}
+
 func TestServiceEmitsReviewerCleanupWarningsHeadlessly(t *testing.T) {
 	reviewAgent := &mockReviewAgent{name: "codex", reviewClose: errors.New("temporary file cleanup failed")}
 	service := serviceForTest(t, reviewAgent, "diff --git a/file b/file")
@@ -667,6 +693,8 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	request.Configuration = configuration
 	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
 	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
 
 	run, err := service.Run(context.Background(), request)
@@ -678,6 +706,23 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if !feedbackStopped.Load() {
 		t.Fatal("prior-feedback worker remained active after service return")
+	}
+	feedbackStarted := -1
+	feedbackCompleted := -1
+	runCompleted := -1
+	for i, event := range events {
+		if event.Kind == EventPhaseStarted && event.Phase == domain.ReviewPhaseFeedback {
+			feedbackStarted = i
+		}
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseFeedback {
+			feedbackCompleted = i
+		}
+		if event.Kind == EventRunCompleted {
+			runCompleted = i
+		}
+	}
+	if feedbackStarted < 0 || feedbackCompleted <= feedbackStarted || runCompleted <= feedbackCompleted {
+		t.Fatalf("feedback phase lifecycle is unbalanced: %#v", events)
 	}
 }
 
@@ -881,6 +926,42 @@ func TestServiceRecordsFalsePositiveDisposition(t *testing.T) {
 	removed := run.FalsePositiveFilter.Removed[0]
 	if removed.ID != "finding-001" || removed.Disposition.FPScore != 95 || removed.Disposition.Reasoning != "not actionable" {
 		t.Fatalf("false-positive disposition incomplete: %#v", removed)
+	}
+}
+
+func TestServiceTracksDuplicateFindingGroupsByFilterIdentity(t *testing.T) {
+	duplicate := `{"title":"Duplicate","summary":"Same.","messages":["src/service.go:10: issue"],"reviewer_count":2,"sources":[0]}`
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[` + duplicate + `,` + duplicate + `],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":95,"reasoning":"first removed"},{"id":1,"fp_score":0,"reasoning":"second kept"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(run.Findings) != 1 || run.Findings[0].ID != "finding-002" {
+		t.Fatalf("surviving duplicate identity = %#v", run.Findings)
+	}
+	if len(run.FalsePositiveFilter.Removed) != 1 || run.FalsePositiveFilter.Removed[0].ID != "finding-001" {
+		t.Fatalf("removed duplicate identity = %#v", run.FalsePositiveFilter.Removed)
+	}
+	if run.Stats.FPFilteredCount != 1 {
+		t.Fatalf("FP filtered count = %d", run.Stats.FPFilteredCount)
 	}
 }
 

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -19,12 +19,14 @@ import (
 )
 
 type mockReviewAgent struct {
-	name         string
-	review       func(context.Context, *agent.ReviewConfig) (string, int, string, error)
-	summary      func(context.Context, int64, string, []byte) (string, int, string, error)
-	reviewClose  error
-	summaryClose error
-	summaryCalls atomic.Int64
+	name                string
+	review              func(context.Context, *agent.ReviewConfig) (string, int, string, error)
+	summary             func(context.Context, int64, string, []byte) (string, int, string, error)
+	reviewClose         error
+	summaryClose        error
+	summaryCloseForCall func(int64) error
+	summaryConfigs      chan agent.SummaryConfig
+	summaryCalls        atomic.Int64
 }
 
 type reviewErrorReadCloser struct {
@@ -62,20 +64,27 @@ func (m *mockReviewAgent) ExecuteReview(ctx context.Context, config *agent.Revie
 	return executionResult(output, exitCode, stderr), nil
 }
 
-func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*agent.ExecutionResult, error) {
+func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, config *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	call := m.summaryCalls.Add(1)
+	if m.summaryConfigs != nil {
+		m.summaryConfigs <- *config
+	}
 	output := codexSummaryOutput(`{"findings":[{"title":"Missing validation","summary":"Input is not checked.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`)
 	exitCode := 0
 	stderr := ""
 	if m.summary != nil {
 		var err error
-		output, exitCode, stderr, err = m.summary(ctx, call, prompt, input)
+		output, exitCode, stderr, err = m.summary(ctx, call, config.Prompt, config.Input)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if m.summaryClose != nil {
-		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: m.summaryClose}
+	closeErr := m.summaryClose
+	if m.summaryCloseForCall != nil {
+		closeErr = m.summaryCloseForCall(call)
+	}
+	if closeErr != nil {
+		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: closeErr}
 		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
 	}
 	return executionResult(output, exitCode, stderr), nil
@@ -302,6 +311,47 @@ func TestServicePinsEveryReviewerToCapturedRevisionAndDiff(t *testing.T) {
 		config := <-configs
 		if config.BaseRef != "base-object" || !config.DiffPrecomputed || config.Diff != "captured diff" {
 			t.Fatalf("reviewer received mutable review input: %#v", config)
+		}
+	}
+}
+
+func TestServiceScopesSummaryAndFalsePositiveExecutionToReviewTarget(t *testing.T) {
+	root := t.TempDir()
+	summaryConfigs := make(chan agent.SummaryConfig, 2)
+	reviewAgent := &mockReviewAgent{
+		name:           "codex",
+		summaryConfigs: summaryConfigs,
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":0,"reasoning":"actionable"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, root)
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewStatusCompleted {
+		t.Fatalf("run status = %q", run.Status)
+	}
+	if len(summaryConfigs) != 2 {
+		t.Fatalf("summary calls = %d, want 2", len(summaryConfigs))
+	}
+	for range 2 {
+		config := <-summaryConfigs
+		if config.WorkDir != root {
+			t.Fatalf("summary workdir = %q, want %q", config.WorkDir, root)
 		}
 	}
 }
@@ -740,9 +790,11 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 		},
 	}
 	var feedbackStopped atomic.Bool
+	var completionClock atomic.Int64
 	feedbackProvider := func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (string, error) {
 		<-ctx.Done()
 		feedbackStopped.Store(true)
+		completionClock.Store(2)
 		return "", ctx.Err()
 	}
 	request := validRequest(t, t.TempDir())
@@ -763,7 +815,13 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 			completionBeforeFeedbackStopped.Store(true)
 		}
 	})
-	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
+	service := serviceForTest(
+		t,
+		reviewAgent,
+		"diff",
+		WithPriorFeedbackProvider(feedbackProvider),
+		WithClock(func() time.Time { return time.Unix(completionClock.Load(), 0) }),
+	)
 
 	run, err := service.Run(context.Background(), request)
 	if err != nil {
@@ -777,6 +835,9 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if completionBeforeFeedbackStopped.Load() {
 		t.Fatal("run completion was emitted before prior-feedback worker stopped")
+	}
+	if run.CompletedAt.Before(time.Unix(2, 0)) {
+		t.Fatalf("run completed at %s before feedback joined", run.CompletedAt)
 	}
 	feedbackStarted := -1
 	feedbackCompleted := -1
@@ -794,6 +855,59 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if feedbackStarted < 0 || feedbackCompleted <= feedbackStarted || runCompleted <= feedbackCompleted {
 		t.Fatalf("feedback phase lifecycle is unbalanced: %#v", events)
+	}
+}
+
+func TestServiceRetainsPriorFeedbackWhenCleanupWarns(t *testing.T) {
+	var feedbackUsed atomic.Bool
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, prompt string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			if strings.Contains(prompt, "trusted prior feedback") {
+				feedbackUsed.Store(true)
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":0,"reasoning":"actionable"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	values.PRFeedbackEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	service := serviceForTest(
+		t,
+		reviewAgent,
+		"diff",
+		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (string, error) {
+			return "trusted prior feedback", errors.New("feedback cleanup failed")
+		}),
+	)
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || !feedbackUsed.Load() {
+		t.Fatalf("prior feedback was discarded: status=%q used=%v", run.Status, feedbackUsed.Load())
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseFeedback && strings.Contains(event.Message, "feedback cleanup failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("feedback cleanup warning event was not emitted")
 	}
 }
 
@@ -997,6 +1111,52 @@ func TestServiceRecordsFalsePositiveDisposition(t *testing.T) {
 	removed := run.FalsePositiveFilter.Removed[0]
 	if removed.ID != "finding-001" || removed.Disposition.FPScore != 95 || removed.Disposition.Reasoning != "not actionable" {
 		t.Fatalf("false-positive disposition incomplete: %#v", removed)
+	}
+}
+
+func TestServiceRetainsFalsePositiveCleanupWarningsHeadlessly(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":0,"reasoning":"actionable"}]}`), 0, "", nil
+		},
+		summaryCloseForCall: func(call int64) error {
+			if call == 2 {
+				return errors.New("FP temp cleanup failed")
+			}
+			return nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(run.FalsePositiveFilter.Warnings) != 1 || !strings.Contains(run.FalsePositiveFilter.Warnings[0], "FP temp cleanup failed") {
+		t.Fatalf("FP cleanup warnings = %#v", run.FalsePositiveFilter.Warnings)
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseFalsePositiveFilter && strings.Contains(event.Message, "FP temp cleanup failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("FP cleanup warning event was not emitted")
 	}
 }
 

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -975,7 +975,7 @@ func TestServiceReportsSummarizerTimeout(t *testing.T) {
 		name: "codex",
 		summary: func(ctx context.Context, _ int64, _ string, _ []byte) (string, int, string, error) {
 			<-ctx.Done()
-			return "", 0, "", ctx.Err()
+			return "", 1, "partial summarizer diagnostics", nil
 		},
 	}
 	request := validRequest(t, t.TempDir())
@@ -995,11 +995,27 @@ func TestServiceReportsSummarizerTimeout(t *testing.T) {
 	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
 		t.Fatalf("unexpected summarizer timeout outcome: %#v", run)
 	}
-	if run.Summarizer.ExitCode != -1 || run.Summarizer.Stderr != "summarizer timed out after 5ms" {
+	if run.Summarizer.ExitCode != -1 || run.Summarizer.Stderr != "partial summarizer diagnostics\nsummarizer timed out after 5ms" {
 		t.Fatalf("summarizer timeout evidence = %#v", run.Summarizer)
 	}
-	if run.Failure.Message != run.Summarizer.Stderr {
+	if run.Failure.Message != "summarizer timed out after 5ms" {
 		t.Fatalf("timeout failure = %q, evidence = %q", run.Failure.Message, run.Summarizer.Stderr)
+	}
+}
+
+func TestBoundedSummaryEvidenceWithSuffixRetainsTimeout(t *testing.T) {
+	stderr := strings.Repeat("diagnostic line\n", summaryDiagnosticMaxLines) + strings.Repeat("x", summaryDiagnosticMaxBytes)
+	timeout := "summarizer timed out after 5ms"
+	evidence := boundedSummaryEvidenceWithSuffix(stderr, timeout)
+
+	if len(evidence) > summaryDiagnosticMaxBytes {
+		t.Fatalf("summarizer timeout evidence has %d bytes, want at most %d", len(evidence), summaryDiagnosticMaxBytes)
+	}
+	if !strings.Contains(evidence, summaryDiagnosticTruncationMarker) {
+		t.Fatalf("bounded timeout evidence is not marked as truncated: %q", evidence)
+	}
+	if !strings.HasSuffix(evidence, timeout) {
+		t.Fatalf("bounded timeout evidence lost timeout suffix: %q", evidence)
 	}
 }
 

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -1,0 +1,1034 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type mockReviewAgent struct {
+	name         string
+	review       func(context.Context, *agent.ReviewConfig) (string, int, string, error)
+	summary      func(context.Context, int64, string, []byte) (string, int, string, error)
+	reviewClose  error
+	summaryCalls atomic.Int64
+}
+
+type reviewErrorReadCloser struct {
+	io.Reader
+	err error
+}
+
+func (r *reviewErrorReadCloser) Close() error {
+	return r.err
+}
+
+func (m *mockReviewAgent) Name() string {
+	return m.name
+}
+
+func (m *mockReviewAgent) IsAvailable() error {
+	return nil
+}
+
+func (m *mockReviewAgent) ExecuteReview(ctx context.Context, config *agent.ReviewConfig) (*agent.ExecutionResult, error) {
+	output := codexReviewOutput("src/service.go:10: missing validation")
+	exitCode := 0
+	stderr := ""
+	if m.review != nil {
+		var err error
+		output, exitCode, stderr, err = m.review(ctx, config)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if m.reviewClose != nil {
+		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: m.reviewClose}
+		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
+	}
+	return executionResult(output, exitCode, stderr), nil
+}
+
+func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*agent.ExecutionResult, error) {
+	call := m.summaryCalls.Add(1)
+	output := codexSummaryOutput(`{"findings":[{"title":"Missing validation","summary":"Input is not checked.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`)
+	exitCode := 0
+	stderr := ""
+	if m.summary != nil {
+		var err error
+		output, exitCode, stderr, err = m.summary(ctx, call, prompt, input)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return executionResult(output, exitCode, stderr), nil
+}
+
+func executionResult(output string, exitCode int, stderr string) *agent.ExecutionResult {
+	return agent.NewExecutionResult(io.NopCloser(strings.NewReader(output)), func() int { return exitCode }, func() string { return stderr })
+}
+
+func codexReviewOutput(findings ...string) string {
+	var lines []string
+	for _, finding := range findings {
+		payload, _ := json.Marshal(map[string]any{
+			"item": map[string]string{
+				"type": "agent_message",
+				"text": finding,
+			},
+		})
+		lines = append(lines, string(payload))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func codexSummaryOutput(content string) string {
+	return `{"type":"item.completed","item":{"type":"agent_message","text":` + strconv.Quote(content) + `}}`
+}
+
+func validRequest(t *testing.T, root string) Request {
+	t.Helper()
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         2,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		Retries:           0,
+		ReviewerAgents:    []string{"codex"},
+		ReviewerModel:     "review-model",
+		SummarizerAgent:   "codex",
+		SummarizerModel:   "summary-model",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPFilterEnabled:   false,
+		FPThreshold:       75,
+		PRFeedbackEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("create configuration: %v", err)
+	}
+	return Request{
+		Target: domain.ReviewTarget{
+			RepositoryRoot: root,
+			WorktreeRoot:   root,
+			Revision: domain.RevisionEvidence{
+				RequestedBaseRef: "main",
+				ResolvedBaseRef:  "origin/main",
+			},
+		},
+		Trigger:       domain.ReviewTriggerManual,
+		Engine:        domain.ReviewEngine{Name: "acr", Version: "test"},
+		Configuration: configuration,
+		ConfigurationSource: domain.ConfigurationSourceIdentity{
+			Kind:          "test",
+			Locator:       "test-fixture",
+			ConfigPresent: true,
+			ConfigDigest:  "test-digest",
+		},
+	}
+}
+
+func serviceForTest(t *testing.T, reviewAgent agent.Agent, diff string, options ...Option) *Service {
+	t.Helper()
+	fixedTime := time.Date(2026, time.July, 21, 8, 0, 0, 0, time.UTC)
+	baseOptions := []Option{
+		WithClock(func() time.Time { return fixedTime }),
+		WithRunIDGenerator(func(time.Time) (string, error) { return "run-test", nil }),
+		WithAgentFactory(func(string, string) (agent.Agent, error) { return reviewAgent, nil }),
+		WithRevisionProvider(func(_ context.Context, target domain.ReviewTarget) (domain.RevisionEvidence, error) {
+			revision := target.Revision
+			revision.HeadObjectID = "head-object"
+			revision.BaseObjectID = "base-object"
+			return revision, nil
+		}),
+		WithDiffProvider(func(context.Context, domain.ReviewTarget) (string, error) { return diff, nil }),
+		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (string, error) { return "", nil }),
+	}
+	service, err := NewService(append(baseOptions, options...)...)
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	return service
+}
+
+func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
+	root := t.TempDir()
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff --git a/file b/file")
+	request := validRequest(t, root)
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+	})
+
+	beforeCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	stdoutPath := filepath.Join(t.TempDir(), "stdout")
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout capture: %v", err)
+	}
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	os.Stdout = stdout
+	os.Stderr = stderr
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	})
+
+	run, runErr := service.Run(context.Background(), request)
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+	if err := stdout.Close(); err != nil {
+		t.Fatalf("close stdout capture: %v", err)
+	}
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+	if runErr != nil {
+		t.Fatalf("run review: %v", runErr)
+	}
+
+	assertEmptyFile(t, stdoutPath)
+	assertEmptyFile(t, stderrPath)
+	afterCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd after review: %v", err)
+	}
+	if afterCWD != beforeCWD {
+		t.Fatalf("process cwd changed from %q to %q", beforeCWD, afterCWD)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read target directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("headless service created files: %v", entries)
+	}
+
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("unexpected outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.ID != "run-test" || run.ConfigurationFingerprint == "" {
+		t.Fatalf("run identity not populated: %#v", run)
+	}
+	if run.ConfigurationSource != request.ConfigurationSource || run.ConfigurationSource.ConfigDigest == run.ConfigurationFingerprint {
+		t.Fatalf("configuration source evidence was lost or conflated: source=%#v fingerprint=%q", run.ConfigurationSource, run.ConfigurationFingerprint)
+	}
+	if run.Target.PullRequest != nil {
+		t.Fatalf("local review unexpectedly acquired PR identity: %#v", run.Target.PullRequest)
+	}
+	if run.Target.Revision.HeadObjectID != "head-object" || run.Target.Revision.BaseObjectID != "base-object" {
+		t.Fatalf("revision evidence not populated: %#v", run.Target.Revision)
+	}
+	if len(run.ReviewerResults) != 2 || run.Stats.SuccessfulReviewers != 2 {
+		t.Fatalf("reviewer evidence incomplete: results=%d stats=%#v", len(run.ReviewerResults), run.Stats)
+	}
+	if len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("finding evidence incomplete: raw=%d aggregated=%d", len(run.RawFindings), len(run.AggregatedFindings))
+	}
+	if !slicesEqual(run.AggregatedFindings[0].Reviewers, []int{1, 2}) {
+		t.Fatalf("aggregate reviewer evidence = %v", run.AggregatedFindings[0].Reviewers)
+	}
+	if len(run.PreFilterSummary.Findings) != 1 || len(run.Findings) != 1 {
+		t.Fatalf("summary evidence incomplete: pre=%#v final=%#v", run.PreFilterSummary, run.Findings)
+	}
+	if run.Findings[0].ID != "finding-001" || run.Findings[0].Disposition.Kind != domain.DispositionSurvived {
+		t.Fatalf("run-local finding identity or disposition missing: %#v", run.Findings[0])
+	}
+	if run.Dispositions[0].Kind != domain.DispositionSurvived {
+		t.Fatalf("raw finding disposition missing: %#v", run.Dispositions)
+	}
+	if len(events) == 0 || events[0].Kind != EventRunStarted || events[len(events)-1].Kind != EventRunCompleted {
+		t.Fatalf("unexpected event boundaries: %#v", events)
+	}
+	foundReviewerOutput := false
+	for i, event := range events {
+		if event.Sequence != uint64(i+1) {
+			t.Fatalf("event %d has sequence %d", i, event.Sequence)
+		}
+		if event.Kind == EventReviewerOutput {
+			foundReviewerOutput = true
+		}
+	}
+	if !foundReviewerOutput {
+		t.Fatal("reviewer output event was not emitted")
+	}
+}
+
+func TestServiceEmitsReviewerCleanupWarningsHeadlessly(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex", reviewClose: errors.New("temporary file cleanup failed")}
+	service := serviceForTest(t, reviewAgent, "diff --git a/file b/file")
+	request := validRequest(t, t.TempDir())
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+	})
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = originalStderr })
+
+	run, err := service.Run(context.Background(), request)
+	os.Stderr = originalStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("cleanup warning changed run outcome: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 {
+		t.Fatalf("reviewer results = %d, want 2", len(run.ReviewerResults))
+	}
+	for _, result := range run.ReviewerResults {
+		if len(result.Warnings) != 1 || result.Warnings[0].Kind != domain.ReviewerWarningCleanup {
+			t.Fatalf("reviewer cleanup warning missing: %#v", result)
+		}
+	}
+	warningEvents := 0
+	completedWithWarning := 0
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseReviewers && strings.Contains(event.Message, "reviewer cleanup failed") {
+			warningEvents++
+		}
+		if event.Kind == EventReviewerCompleted && len(event.ReviewerResult.Warnings) == 1 {
+			completedWithWarning++
+		}
+	}
+	if warningEvents != 2 || completedWithWarning != 2 {
+		t.Fatalf("cleanup warning events incomplete: warnings=%d completed=%d events=%#v", warningEvents, completedWithWarning, events)
+	}
+	captured, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	if len(captured) != 0 {
+		t.Fatalf("headless service wrote stderr for cleanup warnings: %q", captured)
+	}
+}
+
+func TestServiceDefaultDiffIncludesStagedAndUnstagedChanges(t *testing.T) {
+	root := t.TempDir()
+	runGitForServiceTest(t, root, "init")
+	runGitForServiceTest(t, root, "config", "user.email", "test@example.com")
+	runGitForServiceTest(t, root, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(root, "staged.txt"), []byte("initial staged"), 0o600); err != nil {
+		t.Fatalf("write staged fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "unstaged.txt"), []byte("initial unstaged"), 0o600); err != nil {
+		t.Fatalf("write unstaged fixture: %v", err)
+	}
+	runGitForServiceTest(t, root, "add", ".")
+	runGitForServiceTest(t, root, "commit", "-m", "initial")
+	if err := os.WriteFile(filepath.Join(root, "staged.txt"), []byte("changed staged"), 0o600); err != nil {
+		t.Fatalf("modify staged fixture: %v", err)
+	}
+	runGitForServiceTest(t, root, "add", "staged.txt")
+	if err := os.WriteFile(filepath.Join(root, "unstaged.txt"), []byte("changed unstaged"), 0o600); err != nil {
+		t.Fatalf("modify unstaged fixture: %v", err)
+	}
+
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	fixedTime := time.Date(2026, time.July, 21, 8, 0, 0, 0, time.UTC)
+	service, err := NewService(
+		WithClock(func() time.Time { return fixedTime }),
+		WithRunIDGenerator(func(time.Time) (string, error) { return "run-local-diff", nil }),
+		WithAgentFactory(func(string, string) (agent.Agent, error) { return reviewAgent, nil }),
+	)
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	request := validRequest(t, root)
+	request.Target.Revision.RequestedBaseRef = "HEAD"
+	request.Target.Revision.ResolvedBaseRef = "HEAD"
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run local review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("staged and unstaged changes were not reviewed: status=%q conclusion=%q failure=%#v", run.Status, run.Conclusion, run.Failure)
+	}
+}
+
+func TestServiceReturnsNoChangesWithoutReviewExecution(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "")
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionNoChanges {
+		t.Fatalf("unexpected no-change outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if len(run.ReviewerResults) != 0 || reviewAgent.summaryCalls.Load() != 0 {
+		t.Fatalf("review work ran for empty diff: results=%d summaries=%d", len(run.ReviewerResults), reviewAgent.summaryCalls.Load())
+	}
+}
+
+func TestServiceInterruptsNoChangesRunCanceledAtDiffBoundary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "")
+	request := validRequest(t, t.TempDir())
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseDiff {
+			cancel()
+		}
+	})
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("canceled no-change run completed: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseDiff {
+		t.Fatalf("diff-boundary interruption evidence missing: %#v", run.Failure)
+	}
+	if len(run.ReviewerResults) != 0 || reviewAgent.summaryCalls.Load() != 0 {
+		t.Fatalf("review work ran after diff cancellation: results=%d summaries=%d", len(run.ReviewerResults), reviewAgent.summaryCalls.Load())
+	}
+}
+
+func TestServiceReturnsCleanRunWithoutFindings(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return codexReviewOutput("No issues found."), 0, "", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionClean {
+		t.Fatalf("unexpected clean outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if len(run.ReviewerResults) != 2 || run.Stats.SuccessfulReviewers != 2 || len(run.RawFindings) != 0 {
+		t.Fatalf("clean run evidence incomplete: results=%d stats=%#v raw=%d", len(run.ReviewerResults), run.Stats, len(run.RawFindings))
+	}
+}
+
+func TestServiceCompletesWithPartialReviewerFailures(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(ctx context.Context, config *agent.ReviewConfig) (string, int, string, error) {
+			switch config.ReviewerID {
+			case "2":
+				return codexReviewOutput("src/service.go:10: missing validation"), 1, "failed", nil
+			case "3":
+				<-ctx.Done()
+				return "", 0, "", ctx.Err()
+			default:
+				return codexReviewOutput("src/service.go:10: missing validation"), 0, "", nil
+			}
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.Reviewers = 3
+	values.Concurrency = 3
+	values.Timeout = 20 * time.Millisecond
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create partial-failure configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("partial failure did not complete: status=%q conclusion=%q failure=%#v", run.Status, run.Conclusion, run.Failure)
+	}
+	if run.Stats.SuccessfulReviewers != 1 || !slicesEqual(run.Stats.FailedReviewers, []int{2}) || !slicesEqual(run.Stats.TimedOutReviewers, []int{3}) {
+		t.Fatalf("partial failures not classified: %#v", run.Stats)
+	}
+	results := make(map[int]domain.ReviewerResult)
+	for _, result := range run.ReviewerResults {
+		results[result.ReviewerID] = result
+	}
+	if results[2].Failure == nil || results[2].Failure.Kind != domain.ReviewerFailureExit {
+		t.Fatalf("ordinary failure missing: %#v", results[2])
+	}
+	if results[3].Failure == nil || results[3].Failure.Kind != domain.ReviewerFailureTimeout {
+		t.Fatalf("timeout failure missing: %#v", results[3])
+	}
+	if len(run.RawFindings) != 2 || !slicesEqual(run.AggregatedFindings[0].Reviewers, []int{1, 2}) {
+		t.Fatalf("failed reviewer findings were not retained: raw=%#v aggregated=%#v", run.RawFindings, run.AggregatedFindings)
+	}
+}
+
+func TestServiceReturnsPopulatedFailedRunAfterAcceptance(t *testing.T) {
+	root := t.TempDir()
+	request := validRequest(t, root)
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	fixedTime := time.Date(2026, time.July, 21, 8, 0, 0, 0, time.UTC)
+	service, err := NewService(
+		WithClock(func() time.Time { return fixedTime }),
+		WithRunIDGenerator(func(time.Time) (string, error) { return "run-failed", nil }),
+		WithAgentFactory(func(string, string) (agent.Agent, error) { return nil, errors.New("backend unavailable") }),
+	)
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+
+	run, runErr := service.Run(context.Background(), request)
+	if runErr != nil {
+		t.Fatalf("accepted execution returned Go error: %v", runErr)
+	}
+	if run == nil || run.ID != "run-failed" || run.Target.WorktreeRoot != root {
+		t.Fatalf("failed run lost request evidence: %#v", run)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("unexpected failed outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseInitialization || !strings.Contains(run.Failure.Message, "backend unavailable") {
+		t.Fatalf("failure evidence missing: %#v", run.Failure)
+	}
+	if run.StartedAt.IsZero() || run.CompletedAt.IsZero() || run.ConfigurationFingerprint == "" {
+		t.Fatalf("failed run is not persistence-ready: %#v", run)
+	}
+	assertOrderedEventBoundaries(t, events, domain.ReviewStatusFailed)
+}
+
+func TestServiceReturnsPopulatedInterruptedRunAfterAcceptance(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request := validRequest(t, t.TempDir())
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("unexpected interrupted outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || !errors.Is(ctx.Err(), context.Canceled) || !strings.Contains(run.Failure.Message, "canceled") {
+		t.Fatalf("interruption evidence missing: %#v", run.Failure)
+	}
+	if run.ID == "" || run.ConfigurationFingerprint == "" || run.CompletedAt.IsZero() {
+		t.Fatalf("interrupted run is not persistence-ready: %#v", run)
+	}
+	assertOrderedEventBoundaries(t, events, domain.ReviewStatusInterrupted)
+}
+
+func TestServiceInterruptDuringReviewersRetainsCompletedWork(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(reviewCtx context.Context, config *agent.ReviewConfig) (string, int, string, error) {
+			if config.ReviewerID == "2" {
+				<-reviewCtx.Done()
+				return "", 0, "", reviewCtx.Err()
+			}
+			return codexReviewOutput("src/service.go:10: missing validation"), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.Concurrency = 2
+	configuration, configurationErr := domain.NewReviewConfiguration(values)
+	if configurationErr != nil {
+		t.Fatalf("create interrupt configuration: %v", configurationErr)
+	}
+	request.Configuration = configuration
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+		if event.Kind == EventReviewerCompleted && event.ReviewerID == 1 {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseReviewers {
+		t.Fatalf("unexpected interrupted run: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 || len(run.RawFindings) != 1 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("completed reviewer state was lost: results=%#v raw=%#v aggregated=%#v", run.ReviewerResults, run.RawFindings, run.AggregatedFindings)
+	}
+	results := make(map[int]domain.ReviewerResult)
+	for _, result := range run.ReviewerResults {
+		results[result.ReviewerID] = result
+	}
+	if results[2].Failure == nil || results[2].Failure.Kind != domain.ReviewerFailureInterrupted {
+		t.Fatalf("canceled reviewer was not retained as interrupted: %#v", results[2])
+	}
+	completedReviewers := 0
+	reviewerPhaseCompleted := false
+	for _, event := range events {
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseReviewers {
+			reviewerPhaseCompleted = true
+		}
+		if event.Kind == EventReviewerCompleted {
+			if reviewerPhaseCompleted {
+				t.Fatalf("reviewer completion emitted after reviewer phase completion: %#v", event)
+			}
+			completedReviewers++
+		}
+		if event.Kind == EventRunCompleted && completedReviewers != 2 {
+			t.Fatalf("run completed after only %d reviewer completions", completedReviewers)
+		}
+	}
+	if completedReviewers != 2 || !reviewerPhaseCompleted {
+		t.Fatalf("reviewer event lifecycle incomplete: completions=%d phaseCompleted=%v", completedReviewers, reviewerPhaseCompleted)
+	}
+}
+
+func TestServiceReturnsPopulatedReviewerFailure(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return codexReviewOutput("partial finding"), 1, "review failed", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted reviewer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseReviewers {
+		t.Fatalf("unexpected failed run: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 || len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("failed reviewer evidence was lost: results=%d raw=%d aggregated=%d", len(run.ReviewerResults), len(run.RawFindings), len(run.AggregatedFindings))
+	}
+	for _, result := range run.ReviewerResults {
+		if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureExit || result.Attempts != 1 {
+			t.Fatalf("typed reviewer failure missing: %#v", result)
+		}
+	}
+}
+
+func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return "", 1, "review failed", nil
+		},
+	}
+	var feedbackStopped atomic.Bool
+	feedbackProvider := func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (string, error) {
+		<-ctx.Done()
+		feedbackStopped.Store(true)
+		return "", ctx.Err()
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	values.PRFeedbackEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create feedback configuration: %v", err)
+	}
+	request.Configuration = configuration
+	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed {
+		t.Fatalf("unexpected run status %q", run.Status)
+	}
+	if !feedbackStopped.Load() {
+		t.Fatal("prior-feedback worker remained active after service return")
+	}
+}
+
+func TestServiceSummarizerFailureRetainsReviewerEvidence(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(context.Context, int64, string, []byte) (string, int, string, error) {
+			return codexSummaryOutput(`{"findings":[],"info":[]}`), 1, "summary failed", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted summarizer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer failure: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 || len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("summarizer failure lost reviewer evidence: %#v", run)
+	}
+	if run.Summarizer.ExitCode != 1 || run.Summarizer.Stderr != "summary failed" || run.Summarizer.DiagnosticOutput == "" {
+		t.Fatalf("summarizer diagnostic evidence missing: %#v", run.Summarizer)
+	}
+}
+
+func TestServiceBoundsOneLineSummarizerFailureEvidence(t *testing.T) {
+	rawOutput := strings.Repeat("x", summaryDiagnosticMaxBytes*4)
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(context.Context, int64, string, []byte) (string, int, string, error) {
+			return rawOutput, 1, "summary failed", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted summarizer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer failure: %#v", run)
+	}
+	if len(run.Summarizer.DiagnosticOutput) > summaryDiagnosticMaxBytes {
+		t.Fatalf("diagnostic output has %d bytes, want at most %d", len(run.Summarizer.DiagnosticOutput), summaryDiagnosticMaxBytes)
+	}
+	if !strings.HasSuffix(run.Summarizer.DiagnosticOutput, summaryDiagnosticTruncationMarker) {
+		t.Fatalf("bounded diagnostic output is not marked as truncated: %q", run.Summarizer.DiagnosticOutput)
+	}
+	if run.Summarizer.DiagnosticOutput == rawOutput {
+		t.Fatal("raw summarizer transcript was retained")
+	}
+}
+
+func TestServiceBoundsSummarizerStderrAndFailureMessage(t *testing.T) {
+	stderr := strings.Repeat("failure detail ", summaryDiagnosticMaxBytes)
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(context.Context, int64, string, []byte) (string, int, string, error) {
+			return codexSummaryOutput(`{"findings":[],"info":[]}`), 1, stderr, nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted summarizer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer failure: %#v", run)
+	}
+	if len(run.Summarizer.Stderr) > summaryDiagnosticMaxBytes {
+		t.Fatalf("summarizer stderr has %d bytes, want at most %d", len(run.Summarizer.Stderr), summaryDiagnosticMaxBytes)
+	}
+	if !strings.HasSuffix(run.Summarizer.Stderr, summaryDiagnosticTruncationMarker) {
+		t.Fatalf("bounded summarizer stderr is not marked as truncated: %q", run.Summarizer.Stderr)
+	}
+	if run.Failure.Message != strings.TrimSpace(run.Summarizer.Stderr) {
+		t.Fatalf("failure message was not derived from bounded stderr: message=%q stderr=%q", run.Failure.Message, run.Summarizer.Stderr)
+	}
+	if strings.Contains(run.Failure.Message, stderr) {
+		t.Fatal("run failure retained full summarizer stderr")
+	}
+}
+
+func TestServiceInterruptDuringSummarizationRetainsReviewerEvidence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	request := validRequest(t, t.TempDir())
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseStarted && event.Phase == domain.ReviewPhaseSummarization {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected interrupted run: %#v", run)
+	}
+	if len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("summarization interruption lost reviewer evidence: %#v", run)
+	}
+}
+
+func TestServiceInterruptsRunCanceledAtSummarizationBoundary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	request := validRequest(t, t.TempDir())
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseSummarization {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("canceled summarized run completed: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("summarization-boundary interruption evidence missing: %#v", run.Failure)
+	}
+	if len(run.PreFilterSummary.Findings) != 1 || len(run.FindingRecords) != 1 {
+		t.Fatalf("summarization-boundary interruption lost evidence: %#v", run)
+	}
+}
+
+func TestServicePreservesPreFilterEvidenceAndExcludeDisposition(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return codexReviewOutput("src/main.go:1: bug", "generated/file.go:2: generated bug"), 0, "", nil
+		},
+		summary: func(_ context.Context, _ int64, _ string, _ []byte) (string, int, string, error) {
+			return codexSummaryOutput(`{"findings":[{"title":"Real bug","summary":"Real.","messages":["src/main.go:1: bug"],"reviewer_count":2,"sources":[0]},{"title":"Generated bug","summary":"Generated.","messages":["generated/file.go:2: generated bug"],"reviewer_count":2,"sources":[1]}],"info":[]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.ExcludePatterns = []string{"generated/"}
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create filtered configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if len(run.PreFilterSummary.Findings) != 2 || len(run.Findings) != 1 || len(run.ExcludeFilter.Removed) != 1 {
+		t.Fatalf("filter evidence incomplete: pre=%d final=%d removed=%d", len(run.PreFilterSummary.Findings), len(run.Findings), len(run.ExcludeFilter.Removed))
+	}
+	if run.Findings[0].ID != "finding-001" || run.ExcludeFilter.Removed[0].ID != "finding-002" {
+		t.Fatalf("finding identities did not follow observed summary order: final=%#v removed=%#v", run.Findings, run.ExcludeFilter.Removed)
+	}
+	if run.ExcludeFilter.Removed[0].Disposition.Kind != domain.DispositionFilteredExclude {
+		t.Fatalf("exclude disposition missing: %#v", run.ExcludeFilter.Removed[0])
+	}
+}
+
+func TestServiceRecordsFalsePositiveDisposition(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":95,"reasoning":"not actionable"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create FP configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionClean {
+		t.Fatalf("unexpected filtered outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if !run.FalsePositiveFilter.Applied || len(run.FalsePositiveFilter.Removed) != 1 {
+		t.Fatalf("false-positive outcome missing: %#v", run.FalsePositiveFilter)
+	}
+	removed := run.FalsePositiveFilter.Removed[0]
+	if removed.ID != "finding-001" || removed.Disposition.FPScore != 95 || removed.Disposition.Reasoning != "not actionable" {
+		t.Fatalf("false-positive disposition incomplete: %#v", removed)
+	}
+}
+
+func TestServiceFalsePositiveFailureIsExplicitAndFailOpen(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return "", 0, "", errors.New("FP backend unavailable")
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create FP configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings || len(run.Findings) != 1 {
+		t.Fatalf("FP failure did not fail open: %#v", run)
+	}
+	if !run.FalsePositiveFilter.Skipped || !strings.Contains(run.FalsePositiveFilter.SkipReason, "FP backend unavailable") {
+		t.Fatalf("FP skip evidence missing: %#v", run.FalsePositiveFilter)
+	}
+}
+
+func TestServiceInterruptDuringFalsePositiveFilterRetainsIntermediateState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(summaryCtx context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return "", 0, "", summaryCtx.Err()
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create FP configuration: %v", err)
+	}
+	request.Configuration = configuration
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseStarted && event.Phase == domain.ReviewPhaseFalsePositiveFilter {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseFalsePositiveFilter {
+		t.Fatalf("unexpected interrupted run: %#v", run)
+	}
+	if len(run.PreFilterSummary.Findings) != 1 || len(run.FindingRecords) != 1 || run.FindingRecords[0].ID != "finding-001" {
+		t.Fatalf("FP interruption lost intermediate finding identity: %#v", run)
+	}
+}
+
+func TestServiceRejectsInvalidRequestBeforeAcceptance(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff")
+	request := validRequest(t, t.TempDir())
+	request.Target.WorktreeRoot = "relative"
+
+	run, err := service.Run(context.Background(), request)
+	if err == nil {
+		t.Fatal("expected invalid request error")
+	}
+	if run != nil {
+		t.Fatalf("invalid request was accepted: %#v", run)
+	}
+}
+
+func TestServiceRejectsMissingConfigurationSourceBeforeAcceptance(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff")
+	request := validRequest(t, t.TempDir())
+	request.ConfigurationSource = domain.ConfigurationSourceIdentity{}
+
+	run, err := service.Run(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "configuration source") {
+		t.Fatalf("expected configuration source error, got %v", err)
+	}
+	if run != nil {
+		t.Fatalf("request without source evidence was accepted: %#v", run)
+	}
+}
+
+func assertEmptyFile(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read capture %q: %v", path, err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("unexpected process output in %q: %q", path, data)
+	}
+}
+
+func slicesEqual(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func runGitForServiceTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+	return string(output)
+}
+
+func assertOrderedEventBoundaries(t *testing.T, events []Event, status domain.ReviewStatus) {
+	t.Helper()
+	if len(events) < 2 || events[0].Kind != EventRunStarted || events[len(events)-1].Kind != EventRunCompleted {
+		t.Fatalf("unexpected event boundaries: %#v", events)
+	}
+	for i, event := range events {
+		if event.Sequence != uint64(i+1) {
+			t.Fatalf("event %d has sequence %d", i, event.Sequence)
+		}
+	}
+	if events[len(events)-1].Status != status {
+		t.Fatalf("last event status = %q, want %q", events[len(events)-1].Status, status)
+	}
+}

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -315,7 +315,7 @@ func TestServicePinsEveryReviewerToCapturedRevisionAndDiff(t *testing.T) {
 	}
 }
 
-func TestServiceScopesSummaryAndFalsePositiveExecutionToReviewTarget(t *testing.T) {
+func TestServiceIsolatesSummaryAndFalsePositiveExecutionFromReviewTarget(t *testing.T) {
 	root := t.TempDir()
 	summaryConfigs := make(chan agent.SummaryConfig, 2)
 	reviewAgent := &mockReviewAgent{
@@ -348,11 +348,20 @@ func TestServiceScopesSummaryAndFalsePositiveExecutionToReviewTarget(t *testing.
 	if len(summaryConfigs) != 2 {
 		t.Fatalf("summary calls = %d, want 2", len(summaryConfigs))
 	}
+	var postProcessDir string
 	for range 2 {
 		config := <-summaryConfigs
-		if config.WorkDir != root {
-			t.Fatalf("summary workdir = %q, want %q", config.WorkDir, root)
+		if config.WorkDir == root {
+			t.Fatalf("summary workdir uses reviewed target %q", root)
 		}
+		if postProcessDir == "" {
+			postProcessDir = config.WorkDir
+		} else if config.WorkDir != postProcessDir {
+			t.Fatalf("post-processing workdirs differ: %q and %q", postProcessDir, config.WorkDir)
+		}
+	}
+	if _, err := os.Stat(postProcessDir); !os.IsNotExist(err) {
+		t.Fatalf("post-processing workspace remains after review: %v", err)
 	}
 }
 

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -723,13 +723,16 @@ func TestServiceReturnsPopulatedInterruptedRunAfterAcceptance(t *testing.T) {
 
 func TestServiceInterruptDuringReviewersRetainsCompletedWork(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	reviewerTwoStarted := make(chan struct{})
 	reviewAgent := &mockReviewAgent{
 		name: "codex",
 		review: func(reviewCtx context.Context, config *agent.ReviewConfig) (string, int, string, error) {
 			if config.ReviewerID == "2" {
+				close(reviewerTwoStarted)
 				<-reviewCtx.Done()
 				return "", 0, "", reviewCtx.Err()
 			}
+			<-reviewerTwoStarted
 			return codexReviewOutput("src/service.go:10: missing validation"), 0, "", nil
 		},
 	}

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -1000,6 +1000,36 @@ func TestServiceReportsSummarizerTimeout(t *testing.T) {
 	}
 }
 
+func TestServiceAcceptsSuccessfulSummaryAtDeadline(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(ctx context.Context, _ int64, _ string, _ []byte) (string, int, string, error) {
+			<-ctx.Done()
+			return codexSummaryOutput(`{"findings":[{"title":"Validated finding","summary":"Validated.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.SummarizerTimeout = 5 * time.Millisecond
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("accepted successful summary returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("successful summary at deadline was rejected: %#v", run)
+	}
+	if run.Summarizer.ExitCode != 0 || len(run.Findings) != 1 {
+		t.Fatalf("successful summary evidence = %#v findings=%#v", run.Summarizer, run.Findings)
+	}
+}
+
 func TestServiceSummarizerReadFailureRecordsFailedOutcome(t *testing.T) {
 	reviewAgent := &mockReviewAgent{name: "codex", summaryRead: errors.New("summary stream failed")}
 	service := serviceForTest(t, reviewAgent, "diff")

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -25,6 +25,7 @@ type mockReviewAgent struct {
 	reviewClose         error
 	summaryClose        error
 	summaryCloseForCall func(int64) error
+	summaryRead         error
 	summaryConfigs      chan agent.SummaryConfig
 	summaryCalls        atomic.Int64
 }
@@ -32,6 +33,14 @@ type mockReviewAgent struct {
 type reviewErrorReadCloser struct {
 	io.Reader
 	err error
+}
+
+type reviewErrorReader struct {
+	err error
+}
+
+func (r reviewErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
 }
 
 func (r *reviewErrorReadCloser) Close() error {
@@ -83,6 +92,10 @@ func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, config *agent.Summ
 	if m.summaryCloseForCall != nil {
 		closeErr = m.summaryCloseForCall(call)
 	}
+	if m.summaryRead != nil {
+		reader := io.NopCloser(io.MultiReader(strings.NewReader(output), reviewErrorReader{err: m.summaryRead}))
+		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
+	}
 	if closeErr != nil {
 		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: closeErr}
 		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
@@ -114,6 +127,7 @@ func codexSummaryOutput(content string) string {
 
 func validRequest(t *testing.T, root string) Request {
 	t.Helper()
+	ensureGitRepositoryForServiceTest(t, root)
 	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
 		Reviewers:         2,
 		Concurrency:       1,
@@ -181,6 +195,10 @@ func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
 	reviewAgent := &mockReviewAgent{name: "codex"}
 	service := serviceForTest(t, reviewAgent, "diff --git a/file b/file")
 	request := validRequest(t, root)
+	targetEntriesBefore, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read target directory before review: %v", err)
+	}
 	var events []Event
 	request.Events = EventSinkFunc(func(event Event) {
 		events = append(events, event)
@@ -235,8 +253,13 @@ func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read target directory: %v", err)
 	}
-	if len(entries) != 0 {
-		t.Fatalf("headless service created files: %v", entries)
+	if len(entries) != len(targetEntriesBefore) {
+		t.Fatalf("headless service changed target entries from %v to %v", targetEntriesBefore, entries)
+	}
+	for i := range entries {
+		if entries[i].Name() != targetEntriesBefore[i].Name() {
+			t.Fatalf("headless service changed target entries from %v to %v", targetEntriesBefore, entries)
+		}
 	}
 
 	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
@@ -944,6 +967,58 @@ func TestServiceSummarizerFailureRetainsReviewerEvidence(t *testing.T) {
 	}
 }
 
+func TestServiceReportsSummarizerTimeout(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(ctx context.Context, _ int64, _ string, _ []byte) (string, int, string, error) {
+			<-ctx.Done()
+			return "", 0, "", ctx.Err()
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.SummarizerTimeout = 5 * time.Millisecond
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("accepted summarizer timeout returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer timeout outcome: %#v", run)
+	}
+	if run.Summarizer.ExitCode != -1 || run.Summarizer.Stderr != "summarizer timed out after 5ms" {
+		t.Fatalf("summarizer timeout evidence = %#v", run.Summarizer)
+	}
+	if run.Failure.Message != run.Summarizer.Stderr {
+		t.Fatalf("timeout failure = %q, evidence = %q", run.Failure.Message, run.Summarizer.Stderr)
+	}
+}
+
+func TestServiceSummarizerReadFailureRecordsFailedOutcome(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex", summaryRead: errors.New("summary stream failed")}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted summarizer read failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer read failure outcome: %#v", run)
+	}
+	if run.Summarizer.ExitCode == 0 || !strings.Contains(run.Summarizer.Stderr, "read summarizer output: summary stream failed") {
+		t.Fatalf("summarizer read failure evidence = %#v", run.Summarizer)
+	}
+	if run.Summarizer.DiagnosticOutput == "" || !strings.Contains(run.Failure.Message, "read summarizer output") {
+		t.Fatalf("summarizer read failure diagnostics missing: outcome=%#v failure=%#v", run.Summarizer, run.Failure)
+	}
+}
+
 func TestServiceBoundsOneLineSummarizerFailureEvidence(t *testing.T) {
 	rawOutput := strings.Repeat("x", summaryDiagnosticMaxBytes*4)
 	reviewAgent := &mockReviewAgent{
@@ -1290,6 +1365,23 @@ func TestServiceRejectsInvalidRequestBeforeAcceptance(t *testing.T) {
 	}
 }
 
+func TestServiceRejectsWorktreeFromDifferentRepositoryBeforeAcceptance(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	worktreeRoot := t.TempDir()
+	request := validRequest(t, repositoryRoot)
+	ensureGitRepositoryForServiceTest(t, worktreeRoot)
+	request.Target.WorktreeRoot = worktreeRoot
+	service := serviceForTest(t, &mockReviewAgent{name: "codex"}, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "different repositories") {
+		t.Fatalf("expected repository provenance error, got %v", err)
+	}
+	if run != nil {
+		t.Fatalf("mismatched worktree was accepted: %#v", run)
+	}
+}
+
 func TestServiceRejectsMissingConfigurationSourceBeforeAcceptance(t *testing.T) {
 	reviewAgent := &mockReviewAgent{name: "codex"}
 	service := serviceForTest(t, reviewAgent, "diff")
@@ -1337,6 +1429,16 @@ func runGitForServiceTest(t *testing.T, dir string, args ...string) string {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
 	}
 	return string(output)
+}
+
+func ensureGitRepositoryForServiceTest(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = dir
+	if err := cmd.Run(); err == nil {
+		return
+	}
+	runGitForServiceTest(t, dir, "init", "--quiet")
 }
 
 func assertOrderedEventBoundaries(t *testing.T, events []Event, status domain.ReviewStatus) {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -23,6 +23,7 @@ type mockReviewAgent struct {
 	review       func(context.Context, *agent.ReviewConfig) (string, int, string, error)
 	summary      func(context.Context, int64, string, []byte) (string, int, string, error)
 	reviewClose  error
+	summaryClose error
 	summaryCalls atomic.Int64
 }
 
@@ -72,6 +73,10 @@ func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, prompt string, inp
 		if err != nil {
 			return nil, err
 		}
+	}
+	if m.summaryClose != nil {
+		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: m.summaryClose}
+		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
 	}
 	return executionResult(output, exitCode, stderr), nil
 }
@@ -360,6 +365,34 @@ func TestServiceEmitsReviewerCleanupWarningsHeadlessly(t *testing.T) {
 	}
 }
 
+func TestServiceRetainsSummarizerCleanupWarningsHeadlessly(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex", summaryClose: errors.New("temporary summary cleanup failed")}
+	service := serviceForTest(t, reviewAgent, "diff")
+	request := validRequest(t, t.TempDir())
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("cleanup warning changed run outcome: %#v", run)
+	}
+	if len(run.Summarizer.Warnings) != 1 || !strings.Contains(run.Summarizer.Warnings[0], "summary cleanup failed") {
+		t.Fatalf("summarizer cleanup warning missing: %#v", run.Summarizer)
+	}
+	warningEvents := 0
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseSummarization && event.Message == run.Summarizer.Warnings[0] {
+			warningEvents++
+		}
+	}
+	if warningEvents != 1 {
+		t.Fatalf("summarizer cleanup warning events = %d, events=%#v", warningEvents, events)
+	}
+}
+
 func TestServiceDefaultDiffIncludesStagedAndUnstagedChanges(t *testing.T) {
 	root := t.TempDir()
 	runGitForServiceTest(t, root, "init")
@@ -401,6 +434,35 @@ func TestServiceDefaultDiffIncludesStagedAndUnstagedChanges(t *testing.T) {
 	}
 	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
 		t.Fatalf("staged and unstaged changes were not reviewed: status=%q conclusion=%q failure=%#v", run.Status, run.Conclusion, run.Failure)
+	}
+}
+
+func TestServiceFailsWhenHeadMovesDuringDiffCapture(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	var revisionCalls atomic.Int32
+	service := serviceForTest(t, reviewAgent, "diff", WithRevisionProvider(func(_ context.Context, target domain.ReviewTarget) (domain.RevisionEvidence, error) {
+		revision := target.Revision
+		revision.BaseObjectID = "base-object"
+		if revisionCalls.Add(1) == 1 {
+			revision.HeadObjectID = "head-a"
+		} else {
+			revision.HeadObjectID = "head-b"
+		}
+		return revision, nil
+	}))
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseDiff {
+		t.Fatalf("moving head was accepted: %#v", run)
+	}
+	if !strings.Contains(run.Failure.Message, "review head changed") {
+		t.Fatalf("failure = %#v", run.Failure)
+	}
+	if len(run.ReviewerResults) != 0 || reviewAgent.summaryCalls.Load() != 0 {
+		t.Fatalf("review continued after head movement: %#v", run)
 	}
 }
 
@@ -694,7 +756,13 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	request.Configuration = configuration
 	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
 	var events []Event
-	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	var completionBeforeFeedbackStopped atomic.Bool
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+		if event.Kind == EventRunCompleted && !feedbackStopped.Load() {
+			completionBeforeFeedbackStopped.Store(true)
+		}
+	})
 	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
 
 	run, err := service.Run(context.Background(), request)
@@ -706,6 +774,9 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if !feedbackStopped.Load() {
 		t.Fatal("prior-feedback worker remained active after service return")
+	}
+	if completionBeforeFeedbackStopped.Load() {
+		t.Fatal("run completion was emitted before prior-feedback worker stopped")
 	}
 	feedbackStarted := -1
 	feedbackCompleted := -1

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -548,6 +548,38 @@ func TestServiceFailsWhenHeadMovesDuringDiffCapture(t *testing.T) {
 	}
 }
 
+func TestServiceFailsWhenHeadMovesDuringReviewerExecution(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	var revisionCalls atomic.Int32
+	service := serviceForTest(t, reviewAgent, "diff", WithRevisionProvider(func(_ context.Context, target domain.ReviewTarget) (domain.RevisionEvidence, error) {
+		revision := target.Revision
+		revision.BaseObjectID = "base-object"
+		if revisionCalls.Add(1) < 3 {
+			revision.HeadObjectID = "head-a"
+		} else {
+			revision.HeadObjectID = "head-b"
+		}
+		return revision, nil
+	}))
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if revisionCalls.Load() != 3 {
+		t.Fatalf("revision checks = %d, want 3", revisionCalls.Load())
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseReviewers {
+		t.Fatalf("moving head was accepted: %#v", run)
+	}
+	if !strings.Contains(run.Failure.Message, "review head changed") {
+		t.Fatalf("failure = %#v", run.Failure)
+	}
+	if len(run.ReviewerResults) != 2 || reviewAgent.summaryCalls.Load() != 0 {
+		t.Fatalf("reviewer evidence or execution boundary is wrong: %#v", run)
+	}
+}
+
 func TestServiceReturnsNoChangesWithoutReviewExecution(t *testing.T) {
 	reviewAgent := &mockReviewAgent{name: "codex"}
 	service := serviceForTest(t, reviewAgent, "")
@@ -890,6 +922,65 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if feedbackStarted < 0 || feedbackCompleted <= feedbackStarted || runCompleted <= feedbackCompleted {
 		t.Fatalf("feedback phase lifecycle is unbalanced: %#v", events)
+	}
+}
+
+func TestServiceCancelsPriorFeedbackWhenSummaryHasNoFindings(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(context.Context, int64, string, []byte) (string, int, string, error) {
+			return codexSummaryOutput(`{"findings":[],"info":[]}`), 0, "", nil
+		},
+	}
+	var feedbackStopped atomic.Bool
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	values.PRFeedbackEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create feedback configuration: %v", err)
+	}
+	request.Configuration = configuration
+	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	service := serviceForTest(
+		t,
+		reviewAgent,
+		"diff",
+		WithPriorFeedbackProvider(func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (string, error) {
+			<-ctx.Done()
+			feedbackStopped.Store(true)
+			return "", ctx.Err()
+		}),
+	)
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionClean {
+		t.Fatalf("unexpected clean review outcome: %#v", run)
+	}
+	if !feedbackStopped.Load() {
+		t.Fatal("unused prior-feedback worker remained active")
+	}
+	if reviewAgent.summaryCalls.Load() != 1 {
+		t.Fatalf("summary calls = %d, want 1", reviewAgent.summaryCalls.Load())
+	}
+	feedbackCompleted := 0
+	feedbackWarnings := 0
+	for _, event := range events {
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseFeedback {
+			feedbackCompleted++
+		}
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseFeedback {
+			feedbackWarnings++
+		}
+	}
+	if feedbackCompleted != 1 || feedbackWarnings != 0 {
+		t.Fatalf("feedback lifecycle: completed=%d warnings=%d events=%#v", feedbackCompleted, feedbackWarnings, events)
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -149,12 +149,11 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 
 			result, started := r.runReviewerAfterAcquiring(ctx, id, agentName)
 
-			<-sem
-
 			r.completed.Add(1)
 			if started {
 				r.reviewerCompleted(result)
 			}
+			<-sem
 			resultCh <- result
 		}(i)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -142,7 +142,7 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 						Message: ctx.Err().Error(),
 					},
 				}
-				r.reviewerCompleted(result)
+				r.completed.Add(1)
 				resultCh <- result
 				return
 			}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -128,12 +128,14 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 
 	for i := 1; i <= r.config.Reviewers; i++ {
 		go func(id int) {
+			agentName := r.reviewerAgentName(id)
 
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():
 				result := domain.ReviewerResult{
 					ReviewerID: id,
+					AgentName:  agentName,
 					ExitCode:   -1,
 					Failure: &domain.ReviewerFailure{
 						Kind:    domain.ReviewerFailureInterrupted,
@@ -189,12 +191,14 @@ func finishRun(ctx context.Context, results []domain.ReviewerResult, startedAt t
 func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domain.ReviewerResult {
 	var result domain.ReviewerResult
 	var warnings []domain.ReviewerWarning
+	agentName := r.reviewerAgentName(reviewerID)
 
 	for attempt := 0; attempt <= r.config.Retries; attempt++ {
 		select {
 		case <-ctx.Done():
 			return domain.ReviewerResult{
 				ReviewerID: reviewerID,
+				AgentName:  agentName,
 				ExitCode:   -1,
 				Attempts:   attempt,
 				Failure: &domain.ReviewerFailure{
@@ -394,6 +398,10 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) (result domain
 	result.ExitCode = execResult.ExitCode()
 	result.Duration = time.Since(start)
 
+	if result.ExitCode == 0 {
+		return result
+	}
+
 	if ctx.Err() != nil {
 		result.TimedOut = false
 		result.AuthFailed = false
@@ -421,6 +429,14 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) (result domain
 	}
 
 	return result
+}
+
+func (r *Runner) reviewerAgentName(reviewerID int) string {
+	selectedAgent := agent.AgentForReviewer(r.agents, reviewerID)
+	if selectedAgent == nil {
+		return ""
+	}
+	return selectedAgent.Name()
 }
 
 func (r *Runner) verbose() bool {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -246,6 +246,10 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 			select {
 			case <-time.After(delay):
 			case <-ctx.Done():
+				result.ExitCode = -1
+				result.TimedOut = false
+				result.AuthFailed = false
+				result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
 				return result
 			}
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -57,37 +57,63 @@ type Config struct {
 	UseRefFile      bool
 	Diff            string
 	DiffPrecomputed bool
+	Events          Events
+}
+
+type Events struct {
+	ReviewerStarted   func(int, string)
+	ReviewerOutput    func(int, string)
+	ReviewerRetrying  func(int, string, int, int, time.Duration)
+	ReviewerCompleted func(domain.ReviewerResult)
 }
 
 type Runner struct {
-	config    Config
-	agents    []agent.Agent
-	logger    *terminal.Logger
-	completed *atomic.Int32
+	config       Config
+	agents       []agent.Agent
+	logger       *terminal.Logger
+	completed    *atomic.Int32
+	showProgress bool
 }
 
 func New(config Config, agents []agent.Agent, logger *terminal.Logger) (*Runner, error) {
+	return newRunner(config, agents, logger, true)
+}
+
+func NewHeadless(config Config, agents []agent.Agent) (*Runner, error) {
+	return newRunner(config, agents, nil, false)
+}
+
+func newRunner(config Config, agents []agent.Agent, logger *terminal.Logger, showProgress bool) (*Runner, error) {
 	if len(agents) == 0 {
 		return nil, fmt.Errorf("at least one agent is required")
 	}
 	return &Runner{
-		config:    config,
-		agents:    agents,
-		logger:    logger,
-		completed: &atomic.Int32{},
+		config:       config,
+		agents:       agents,
+		logger:       logger,
+		completed:    &atomic.Int32{},
+		showProgress: showProgress,
 	}, nil
 }
 
 func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duration, error) {
-	spinner := terminal.NewSpinner(r.config.Reviewers)
-	r.completed = spinner.Completed()
-
-	spinnerCtx, spinnerCancel := context.WithCancel(context.Background())
-	spinnerDone := make(chan struct{})
-	go func() {
-		spinner.Run(spinnerCtx)
-		close(spinnerDone)
-	}()
+	stopProgress := func() {}
+	if r.showProgress {
+		spinner := terminal.NewSpinner(r.config.Reviewers)
+		r.completed = spinner.Completed()
+		spinnerCtx, spinnerCancel := context.WithCancel(context.Background())
+		spinnerDone := make(chan struct{})
+		go func() {
+			spinner.Run(spinnerCtx)
+			close(spinnerDone)
+		}()
+		stopProgress = func() {
+			spinnerCancel()
+			<-spinnerDone
+		}
+	} else {
+		r.completed = &atomic.Int32{}
+	}
 
 	start := time.Now()
 
@@ -106,10 +132,16 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():
-				resultCh <- domain.ReviewerResult{
+				result := domain.ReviewerResult{
 					ReviewerID: id,
 					ExitCode:   -1,
+					Failure: &domain.ReviewerFailure{
+						Kind:    domain.ReviewerFailureInterrupted,
+						Message: ctx.Err().Error(),
+					},
 				}
+				r.reviewerCompleted(result)
+				resultCh <- result
 				return
 			}
 
@@ -118,30 +150,45 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 			<-sem
 
 			r.completed.Add(1)
+			r.reviewerCompleted(result)
 			resultCh <- result
 		}(i)
 	}
 
 	results := make([]domain.ReviewerResult, 0, r.config.Reviewers)
-	for i := 0; i < r.config.Reviewers; i++ {
+	var runErr error
+	for len(results) < r.config.Reviewers {
+		if runErr != nil {
+			results = append(results, <-resultCh)
+			continue
+		}
 		select {
 		case result := <-resultCh:
 			results = append(results, result)
 		case <-ctx.Done():
-			spinnerCancel()
-			<-spinnerDone
-			return nil, time.Since(start), ctx.Err()
+			runErr = ctx.Err()
 		}
 	}
 
-	spinnerCancel()
-	<-spinnerDone
+	stopProgress()
+	if runErr != nil {
+		return results, time.Since(start), runErr
+	}
 
-	return results, time.Since(start), nil
+	return finishRun(ctx, results, start)
+}
+
+func finishRun(ctx context.Context, results []domain.ReviewerResult, startedAt time.Time) ([]domain.ReviewerResult, time.Duration, error) {
+	duration := time.Since(startedAt)
+	if err := ctx.Err(); err != nil {
+		return results, duration, err
+	}
+	return results, duration, nil
 }
 
 func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domain.ReviewerResult {
 	var result domain.ReviewerResult
+	var warnings []domain.ReviewerWarning
 
 	for attempt := 0; attempt <= r.config.Retries; attempt++ {
 		select {
@@ -149,19 +196,30 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 			return domain.ReviewerResult{
 				ReviewerID: reviewerID,
 				ExitCode:   -1,
+				Attempts:   attempt,
+				Failure: &domain.ReviewerFailure{
+					Kind:    domain.ReviewerFailureInterrupted,
+					Message: ctx.Err().Error(),
+				},
+				Warnings: append([]domain.ReviewerWarning(nil), warnings...),
 			}
 		default:
 		}
 
 		result = r.runReviewer(ctx, reviewerID)
+		warnings = append(warnings, result.Warnings...)
+		result.Warnings = append([]domain.ReviewerWarning(nil), warnings...)
+		result.Attempts = attempt + 1
 
 		if result.ExitCode == 0 {
 			return result
 		}
 
 		if result.AuthFailed {
-			r.logger.Logf(terminal.StyleError, "Reviewer #%d (%s) authentication failed: %s",
-				reviewerID, result.AgentName, agent.AuthHint(result.AgentName))
+			if r.logger != nil {
+				r.logger.Logf(terminal.StyleError, "Reviewer #%d (%s) authentication failed: %s",
+					reviewerID, result.AgentName, agent.AuthHint(result.AgentName))
+			}
 			return result
 		}
 
@@ -173,8 +231,13 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 			if result.TimedOut {
 				reason = "timed out"
 			}
-			r.logger.Logf(terminal.StyleWarning, "Reviewer #%d %s (exit %d), retry %d/%d in %v",
-				reviewerID, reason, result.ExitCode, attempt+1, r.config.Retries, delay)
+			if r.logger != nil {
+				r.logger.Logf(terminal.StyleWarning, "Reviewer #%d %s (exit %d), retry %d/%d in %v",
+					reviewerID, reason, result.ExitCode, attempt+1, r.config.Retries, delay)
+			}
+			if r.config.Events.ReviewerRetrying != nil {
+				r.config.Events.ReviewerRetrying(reviewerID, reason, attempt+1, r.config.Retries, delay)
+			}
 
 			select {
 			case <-time.After(delay):
@@ -187,7 +250,7 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 	return result
 }
 
-func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.ReviewerResult {
+func (r *Runner) runReviewer(ctx context.Context, reviewerID int) (result domain.ReviewerResult) {
 	start := time.Now()
 
 	selectedAgent := agent.AgentForReviewer(r.agents, reviewerID)
@@ -197,12 +260,19 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 			ReviewerID: reviewerID,
 			ExitCode:   -1,
 			Duration:   time.Since(start),
+			Failure: &domain.ReviewerFailure{
+				Kind:    domain.ReviewerFailureExecution,
+				Message: "no reviewer agent available",
+			},
 		}
 	}
 
-	result := domain.ReviewerResult{
+	result = domain.ReviewerResult{
 		ReviewerID: reviewerID,
 		AgentName:  selectedAgent.Name(),
+	}
+	if r.config.Events.ReviewerStarted != nil {
+		r.config.Events.ReviewerStarted(reviewerID, selectedAgent.Name())
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, r.config.Timeout)
@@ -224,19 +294,40 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 	if err != nil {
 		result.ExitCode = -1
 		result.Duration = time.Since(start)
+		if ctx.Err() != nil {
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+		} else if timeoutCtx.Err() == context.DeadlineExceeded {
+			result.TimedOut = true
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureTimeout, Message: timeoutCtx.Err().Error()}
+		} else {
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureExecution, Message: err.Error()}
+		}
 		return result
 	}
 
-	defer func() {
-		if closeErr := execResult.Close(); closeErr != nil && r.verbose() {
-			r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: close error (non-fatal): %v", reviewerID, closeErr)
+	closed := false
+	closeExecution := func() {
+		if closed {
+			return
 		}
-	}()
+		closed = true
+		if closeErr := execResult.Close(); closeErr != nil {
+			result.Warnings = append(result.Warnings, domain.ReviewerWarning{
+				Kind:    domain.ReviewerWarningCleanup,
+				Message: fmt.Sprintf("reviewer cleanup failed: %v", closeErr),
+			})
+			if r.verbose() {
+				r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: close error (non-fatal): %v", reviewerID, closeErr)
+			}
+		}
+	}
+	defer closeExecution()
 
 	parser, err := agent.NewReviewParser(selectedAgent.Name(), reviewerID)
 	if err != nil {
 		result.ExitCode = -1
 		result.Duration = time.Since(start)
+		result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureParser, Message: err.Error()}
 		return result
 	}
 
@@ -246,11 +337,19 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 
 	for {
 
+		if ctx.Err() != nil {
+			result.ParseErrors += parser.ParseErrors()
+			result.ExitCode = -1
+			result.Duration = time.Since(start)
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+			return result
+		}
 		if timeoutCtx.Err() == context.DeadlineExceeded {
 			result.ParseErrors += parser.ParseErrors()
 			result.TimedOut = true
 			result.ExitCode = -1
 			result.Duration = time.Since(start)
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureTimeout, Message: timeoutCtx.Err().Error()}
 			return result
 		}
 
@@ -274,6 +373,9 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		}
 
 		result.Findings = append(result.Findings, *finding)
+		if r.config.Events.ReviewerOutput != nil {
+			r.config.Events.ReviewerOutput(reviewerID, finding.Text)
+		}
 
 		if r.verbose() {
 			text := finding.Text
@@ -288,32 +390,47 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 
 	result.ParseErrors += parser.ParseErrors()
 
-	if closeErr := execResult.Close(); closeErr != nil && r.verbose() {
-		r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: close error (non-fatal): %v", reviewerID, closeErr)
-	}
+	closeExecution()
 	result.ExitCode = execResult.ExitCode()
-
-	if result.ExitCode != 0 {
-		result.AuthFailed = agent.IsAuthFailure(selectedAgent.Name(), result.ExitCode, execResult.Stderr(), stdoutCapture.String())
-		if result.AuthFailed {
-			result.Findings = nil
-		}
-	}
-
 	result.Duration = time.Since(start)
+
+	if ctx.Err() != nil {
+		result.TimedOut = false
+		result.AuthFailed = false
+		result.ExitCode = -1
+		result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+		return result
+	}
 
 	if timeoutCtx.Err() == context.DeadlineExceeded {
 		result.TimedOut = true
 		result.AuthFailed = false
 		result.ExitCode = -1
+		result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureTimeout, Message: timeoutCtx.Err().Error()}
 		return result
+	}
+
+	if result.ExitCode != 0 {
+		result.AuthFailed = agent.IsAuthFailure(selectedAgent.Name(), result.ExitCode, execResult.Stderr(), stdoutCapture.String())
+		if result.AuthFailed {
+			result.Findings = nil
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureAuth, Message: selectedAgent.Name() + " authentication failed"}
+		} else if result.Failure == nil {
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureExit, Message: fmt.Sprintf("reviewer exited with code %d", result.ExitCode)}
+		}
 	}
 
 	return result
 }
 
 func (r *Runner) verbose() bool {
-	return r.config.Verbose
+	return r.config.Verbose && r.logger != nil
+}
+
+func (r *Runner) reviewerCompleted(result domain.ReviewerResult) {
+	if r.config.Events.ReviewerCompleted != nil {
+		r.config.Events.ReviewerCompleted(result)
+	}
 }
 
 func BuildStats(results []domain.ReviewerResult, totalReviewers int, wallClock time.Duration) domain.ReviewStats {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -147,12 +147,14 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 				return
 			}
 
-			result := r.runReviewerWithRetry(ctx, id)
+			result, started := r.runReviewerAfterAcquiring(ctx, id, agentName)
 
 			<-sem
 
 			r.completed.Add(1)
-			r.reviewerCompleted(result)
+			if started {
+				r.reviewerCompleted(result)
+			}
 			resultCh <- result
 		}(i)
 	}
@@ -178,6 +180,22 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 	}
 
 	return finishRun(ctx, results, start)
+}
+
+func (r *Runner) runReviewerAfterAcquiring(ctx context.Context, reviewerID int, agentName string) (domain.ReviewerResult, bool) {
+	if err := ctx.Err(); err != nil {
+		return domain.ReviewerResult{
+			ReviewerID: reviewerID,
+			AgentName:  agentName,
+			ExitCode:   -1,
+			Failure: &domain.ReviewerFailure{
+				Kind:    domain.ReviewerFailureInterrupted,
+				Message: err.Error(),
+			},
+		}, false
+	}
+	r.reviewerStarted(reviewerID, agentName)
+	return r.runReviewerWithRetry(ctx, reviewerID), true
 }
 
 func finishRun(ctx context.Context, results []domain.ReviewerResult, startedAt time.Time) ([]domain.ReviewerResult, time.Duration, error) {
@@ -287,9 +305,6 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) (result domain
 	result = domain.ReviewerResult{
 		ReviewerID: reviewerID,
 		AgentName:  selectedAgent.Name(),
-	}
-	if r.config.Events.ReviewerStarted != nil {
-		r.config.Events.ReviewerStarted(reviewerID, selectedAgent.Name())
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, r.config.Timeout)
@@ -454,6 +469,12 @@ func (r *Runner) reviewerAgentName(reviewerID int) string {
 
 func (r *Runner) verbose() bool {
 	return r.config.Verbose && r.logger != nil
+}
+
+func (r *Runner) reviewerStarted(reviewerID int, agentName string) {
+	if r.config.Events.ReviewerStarted != nil {
+		r.config.Events.ReviewerStarted(reviewerID, agentName)
+	}
 }
 
 func (r *Runner) reviewerCompleted(result domain.ReviewerResult) {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -218,6 +218,15 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 		if result.ExitCode == 0 {
 			return result
 		}
+		if ctx.Err() != nil || (result.Failure != nil && result.Failure.Kind == domain.ReviewerFailureInterrupted) {
+			if ctx.Err() != nil {
+				result.ExitCode = -1
+				result.TimedOut = false
+				result.AuthFailed = false
+				result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+			}
+			return result
+		}
 
 		if result.AuthFailed {
 			if r.logger != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -290,7 +290,7 @@ func (m *mockAgent) ExecuteReview(_ context.Context, _ *agent.ReviewConfig) (*ag
 	return nil, nil
 }
 
-func (m *mockAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
+func (m *mockAgent) ExecuteSummary(_ context.Context, _ *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -319,7 +319,7 @@ func (a *cleanupWarningAgent) ExecuteReview(context.Context, *agent.ReviewConfig
 	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
 }
 
-func (a *cleanupWarningAgent) ExecuteSummary(context.Context, string, []byte) (*agent.ExecutionResult, error) {
+func (a *cleanupWarningAgent) ExecuteSummary(context.Context, *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -339,7 +339,7 @@ func (m *mockStreamingAgent) ExecuteReview(_ context.Context, _ *agent.ReviewCon
 	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
 }
 
-func (m *mockStreamingAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
+func (m *mockStreamingAgent) ExecuteSummary(_ context.Context, _ *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -619,6 +619,7 @@ type mockAuthFailAgent struct {
 	exitCode  int
 	stdout    string
 	stderr    string
+	onReview  func()
 	callCount atomic.Int32
 }
 
@@ -627,13 +628,16 @@ func (m *mockAuthFailAgent) IsAvailable() error { return nil }
 
 func (m *mockAuthFailAgent) ExecuteReview(_ context.Context, _ *agent.ReviewConfig) (*agent.ExecutionResult, error) {
 	m.callCount.Add(1)
+	if m.onReview != nil {
+		m.onReview()
+	}
 	reader := &stringReadCloser{strings.NewReader(m.stdout)}
 	exitCode := m.exitCode
 	stderr := m.stderr
 	return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
 }
 
-func (m *mockAuthFailAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
+func (m *mockAuthFailAgent) ExecuteSummary(_ context.Context, _ *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -733,5 +737,32 @@ func TestRunReviewerWithRetryMarksBackoffCancellationInterrupted(t *testing.T) {
 	}
 	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
 		t.Fatalf("backoff cancellation was misclassified: %#v", result)
+	}
+}
+
+func TestRunReviewerWithRetrySkipsRetryEventAfterInterruption(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	retryEvents := 0
+	mock := &mockAuthFailAgent{name: "codex", exitCode: 1, stderr: "some error", onReview: cancel}
+	r := &Runner{
+		config: Config{
+			Reviewers: 1,
+			Retries:   1,
+			Timeout:   10 * time.Second,
+			Events: Events{
+				ReviewerRetrying: func(int, string, int, int, time.Duration) { retryEvents++ },
+			},
+		},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewerWithRetry(ctx, 1)
+
+	if mock.callCount.Load() != 1 || retryEvents != 0 {
+		t.Fatalf("interrupted review retried: calls=%d retry-events=%d", mock.callCount.Load(), retryEvents)
+	}
+	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted || result.ExitCode != -1 {
+		t.Fatalf("interrupted result = %#v", result)
 	}
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -706,3 +706,32 @@ func TestRunReviewerWithRetry_RetriesNonAuthFailure(t *testing.T) {
 		t.Error("expected AuthFailed to be false for non-auth failure")
 	}
 }
+
+func TestRunReviewerWithRetryMarksBackoffCancellationInterrupted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockAuthFailAgent{name: "codex", exitCode: 1, stderr: "some error"}
+	r := &Runner{
+		config: Config{
+			Reviewers: 1,
+			Retries:   1,
+			Timeout:   10 * time.Second,
+			Events: Events{
+				ReviewerRetrying: func(int, string, int, int, time.Duration) { cancel() },
+			},
+		},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewerWithRetry(ctx, 1)
+
+	if mock.callCount.Load() != 1 || result.Attempts != 1 {
+		t.Fatalf("retry started after cancellation: calls=%d result=%#v", mock.callCount.Load(), result)
+	}
+	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted {
+		t.Fatalf("backoff cancellation was not interrupted: %#v", result)
+	}
+	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
+		t.Fatalf("backoff cancellation was misclassified: %#v", result)
+	}
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -663,6 +663,60 @@ func TestQueuedCancellationKeepsProgressAndEventsConsistent(t *testing.T) {
 	}
 }
 
+func TestReviewerCompletionPrecedesNextStartAtConcurrencyLimit(t *testing.T) {
+	firstCompletionEntered := make(chan struct{})
+	releaseFirstCompletion := make(chan struct{})
+	secondStarted := make(chan struct{})
+	var starts atomic.Int32
+	var completions atomic.Int32
+	r, err := NewHeadless(Config{
+		Reviewers:   2,
+		Concurrency: 1,
+		Timeout:     time.Second,
+		Events: Events{
+			ReviewerStarted: func(int, string) {
+				if starts.Add(1) == 2 {
+					close(secondStarted)
+				}
+			},
+			ReviewerCompleted: func(domain.ReviewerResult) {
+				if completions.Add(1) == 1 {
+					close(firstCompletionEntered)
+					<-releaseFirstCompletion
+				}
+			},
+		},
+	}, []agent.Agent{&mockStreamingAgent{name: "codex"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, _, runErr := r.Run(context.Background())
+		done <- runErr
+	}()
+
+	select {
+	case <-firstCompletionEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first completion event did not begin")
+	}
+	select {
+	case <-secondStarted:
+		close(releaseFirstCompletion)
+		<-done
+		t.Fatal("next reviewer started before prior completion event returned")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseFirstCompletion)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if starts.Load() != 2 || completions.Load() != 2 {
+		t.Fatalf("lifecycle counts: starts=%d completions=%d", starts.Load(), completions.Load())
+	}
+}
+
 func TestCanceledReviewerAfterAcquiringSlotEmitsNoLifecycleEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -527,7 +527,10 @@ func TestRunReviewerParentCancellationTakesPriority(t *testing.T) {
 		completed: new(atomic.Int32),
 	}
 
-	result := r.runReviewer(ctx, 1)
+	result, started := r.runReviewerAfterAcquiring(ctx, 1, r.reviewerAgentName(1))
+	if !started {
+		t.Fatal("reviewer did not start")
+	}
 
 	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted {
 		t.Fatalf("reviewer cancellation was not classified as interrupted: %#v", result)
@@ -657,6 +660,38 @@ func TestQueuedCancellationKeepsProgressAndEventsConsistent(t *testing.T) {
 	}
 	if completedID := <-completed; completedID != startedID {
 		t.Fatalf("completion reviewer = %d, started reviewer = %d", completedID, startedID)
+	}
+}
+
+func TestCanceledReviewerAfterAcquiringSlotEmitsNoLifecycleEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var startedEvents atomic.Int32
+	var completedEvents atomic.Int32
+	r, err := NewHeadless(Config{
+		Reviewers:   1,
+		Concurrency: 1,
+		Timeout:     time.Minute,
+		Events: Events{
+			ReviewerStarted: func(int, string) { startedEvents.Add(1) },
+			ReviewerCompleted: func(domain.ReviewerResult) {
+				completedEvents.Add(1)
+			},
+		},
+	}, []agent.Agent{&mockStreamingAgent{name: "codex"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, started := r.runReviewerAfterAcquiring(ctx, 1, r.reviewerAgentName(1))
+	if started {
+		r.reviewerCompleted(result)
+	}
+	if startedEvents.Load() != 0 || completedEvents.Load() != 0 {
+		t.Fatalf("canceled lifecycle events: started=%d completed=%d", startedEvents.Load(), completedEvents.Load())
+	}
+	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted {
+		t.Fatalf("canceled result = %#v", result)
 	}
 }
 
@@ -808,6 +843,38 @@ func TestRunReviewerWithRetry_RetriesNonAuthFailure(t *testing.T) {
 	}
 	if result.AuthFailed {
 		t.Error("expected AuthFailed to be false for non-auth failure")
+	}
+}
+
+func TestReviewerLifecycleStartsOnceAcrossRetries(t *testing.T) {
+	mock := &mockAuthFailAgent{name: "codex", exitCode: 1, stderr: "some error"}
+	var startedEvents atomic.Int32
+	var completedEvents atomic.Int32
+	r, err := NewHeadless(Config{
+		Reviewers:   1,
+		Concurrency: 1,
+		Retries:     1,
+		Timeout:     10 * time.Second,
+		Events: Events{
+			ReviewerStarted: func(int, string) { startedEvents.Add(1) },
+			ReviewerCompleted: func(domain.ReviewerResult) {
+				completedEvents.Add(1)
+			},
+		},
+	}, []agent.Agent{mock})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, _, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mock.callCount.Load() != 2 || len(results) != 1 || results[0].Attempts != 2 {
+		t.Fatalf("retry result = %#v calls=%d", results, mock.callCount.Load())
+	}
+	if startedEvents.Load() != 1 || completedEvents.Load() != 1 {
+		t.Fatalf("lifecycle events: started=%d completed=%d", startedEvents.Load(), completedEvents.Load())
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -25,10 +25,14 @@ func (s *stringReadCloser) Close() error {
 
 type errorReadCloser struct {
 	*strings.Reader
-	err error
+	err     error
+	onClose func()
 }
 
 func (r *errorReadCloser) Close() error {
+	if r.onClose != nil {
+		r.onClose()
+	}
 	return r.err
 }
 
@@ -299,6 +303,7 @@ type cleanupWarningAgent struct {
 	name     string
 	output   string
 	closeErr error
+	onClose  func()
 }
 
 func (a *cleanupWarningAgent) Name() string {
@@ -310,7 +315,7 @@ func (a *cleanupWarningAgent) IsAvailable() error {
 }
 
 func (a *cleanupWarningAgent) ExecuteReview(context.Context, *agent.ReviewConfig) (*agent.ExecutionResult, error) {
-	reader := &errorReadCloser{Reader: strings.NewReader(a.output), err: a.closeErr}
+	reader := &errorReadCloser{Reader: strings.NewReader(a.output), err: a.closeErr, onClose: a.onClose}
 	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
 }
 
@@ -504,6 +509,54 @@ func TestRunReviewerParentCancellationTakesPriority(t *testing.T) {
 	}
 	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
 		t.Fatalf("reviewer cancellation was misclassified: %#v", result)
+	}
+}
+
+func TestRunReviewerKeepsSuccessfulResultWhenCancellationArrivesAfterCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &cleanupWarningAgent{
+		name:    "codex",
+		output:  `{"item":{"type":"agent_message","text":"finding"}}`,
+		onClose: cancel,
+	}
+	r := &Runner{
+		config:    Config{Reviewers: 1, Timeout: time.Minute},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(ctx, 1)
+
+	if result.ExitCode != 0 || result.Failure != nil || len(result.Findings) != 1 {
+		t.Fatalf("completed reviewer was reclassified after cancellation: %#v", result)
+	}
+}
+
+func TestCanceledReviewersRetainAssignedAgentNames(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r, err := NewHeadless(Config{Reviewers: 2, Concurrency: 1, Timeout: time.Minute}, []agent.Agent{
+		&mockStreamingAgent{name: "codex"},
+		&mockStreamingAgent{name: "claude"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, _, runErr := r.Run(ctx)
+	if !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("Run() error = %v", runErr)
+	}
+	byID := make(map[int]domain.ReviewerResult)
+	for _, result := range results {
+		byID[result.ReviewerID] = result
+	}
+	if byID[1].AgentName != "codex" || byID[2].AgentName != "claude" {
+		t.Fatalf("canceled reviewer identities = %#v", byID)
+	}
+	stats := BuildStats(results, 2, 0)
+	if stats.ReviewerAgentNames[1] != "codex" || stats.ReviewerAgentNames[2] != "claude" {
+		t.Fatalf("canceled reviewer stats identities = %#v", stats.ReviewerAgentNames)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,6 +2,9 @@ package runner
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -18,6 +21,15 @@ type stringReadCloser struct {
 
 func (s *stringReadCloser) Close() error {
 	return nil
+}
+
+type errorReadCloser struct {
+	*strings.Reader
+	err error
+}
+
+func (r *errorReadCloser) Close() error {
+	return r.err
 }
 
 func TestBuildStats_CategorizesResults(t *testing.T) {
@@ -41,6 +53,21 @@ func TestBuildStats_CategorizesResults(t *testing.T) {
 	}
 	if stats.ParseErrors != 2 {
 		t.Errorf("expected 2 parse errors, got %d", stats.ParseErrors)
+	}
+}
+
+func TestFinishRunReportsCancellationAfterResultsWereCollected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	want := []domain.ReviewerResult{{ReviewerID: 1, ExitCode: 0}}
+
+	got, _, err := finishRun(ctx, want, time.Now())
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("finishRun error = %v, want context cancellation", err)
+	}
+	if len(got) != 1 || got[0].ReviewerID != 1 {
+		t.Fatalf("collected reviewer results were lost: %#v", got)
 	}
 }
 
@@ -268,6 +295,29 @@ type mockStreamingAgent struct {
 	output string
 }
 
+type cleanupWarningAgent struct {
+	name     string
+	output   string
+	closeErr error
+}
+
+func (a *cleanupWarningAgent) Name() string {
+	return a.name
+}
+
+func (a *cleanupWarningAgent) IsAvailable() error {
+	return nil
+}
+
+func (a *cleanupWarningAgent) ExecuteReview(context.Context, *agent.ReviewConfig) (*agent.ExecutionResult, error) {
+	reader := &errorReadCloser{Reader: strings.NewReader(a.output), err: a.closeErr}
+	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
+}
+
+func (a *cleanupWarningAgent) ExecuteSummary(context.Context, string, []byte) (*agent.ExecutionResult, error) {
+	return nil, nil
+}
+
 func (m *mockStreamingAgent) Name() string {
 	if m.name == "" {
 		return "codex"
@@ -310,6 +360,150 @@ invalid json line here
 	}
 	if result.ParseErrors != 1 {
 		t.Errorf("expected 1 parse error, got %d", result.ParseErrors)
+	}
+}
+
+func TestRunReviewerCleanupFailureIsNonfatalWarning(t *testing.T) {
+	mock := &cleanupWarningAgent{
+		name:     "codex",
+		output:   `{"item":{"type":"agent_message","text":"finding"}}`,
+		closeErr: errors.New("temporary file cleanup failed"),
+	}
+	r := &Runner{
+		config:    Config{Reviewers: 1, Timeout: time.Second},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(context.Background(), 1)
+
+	if result.ExitCode != 0 || result.Failure != nil || len(result.Findings) != 1 {
+		t.Fatalf("cleanup failure changed reviewer outcome: %#v", result)
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0].Kind != domain.ReviewerWarningCleanup {
+		t.Fatalf("cleanup warning missing: %#v", result.Warnings)
+	}
+}
+
+func TestHeadlessRunnerEmitsEarlyReturnCleanupWarningWithoutStderr(t *testing.T) {
+	mock := &cleanupWarningAgent{
+		name:     "unsupported",
+		output:   "ignored",
+		closeErr: errors.New("temporary file cleanup failed"),
+	}
+	var completed domain.ReviewerResult
+	r, err := NewHeadless(Config{
+		Reviewers:   1,
+		Concurrency: 1,
+		Timeout:     time.Second,
+		Events: Events{
+			ReviewerCompleted: func(result domain.ReviewerResult) {
+				completed = result
+			},
+		},
+	}, []agent.Agent{mock})
+	if err != nil {
+		t.Fatalf("create headless runner: %v", err)
+	}
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = originalStderr })
+
+	results, _, runErr := r.Run(context.Background())
+	os.Stderr = originalStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+
+	if runErr != nil {
+		t.Fatalf("run headless reviewer: %v", runErr)
+	}
+	if len(results) != 1 || results[0].Failure == nil || results[0].Failure.Kind != domain.ReviewerFailureParser {
+		t.Fatalf("early return outcome missing: %#v", results)
+	}
+	if len(results[0].Warnings) != 1 || results[0].Warnings[0].Kind != domain.ReviewerWarningCleanup {
+		t.Fatalf("early-return cleanup warning missing: %#v", results[0])
+	}
+	if len(completed.Warnings) != 1 || completed.Warnings[0] != results[0].Warnings[0] {
+		t.Fatalf("ReviewerCompleted did not receive cleanup warning: completed=%#v result=%#v", completed, results[0])
+	}
+	captured, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	if len(captured) != 0 {
+		t.Fatalf("headless cleanup failure wrote stderr: %q", captured)
+	}
+}
+
+func TestVerboseRunnerLogsCleanupWarningOnce(t *testing.T) {
+	mock := &cleanupWarningAgent{
+		name:     "codex",
+		output:   `{"item":{"type":"agent_message","text":"finding"}}`,
+		closeErr: errors.New("temporary file cleanup failed"),
+	}
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = originalStderr })
+	r := &Runner{
+		config:    Config{Reviewers: 1, Timeout: time.Second, Verbose: true},
+		agents:    []agent.Agent{mock},
+		logger:    terminal.NewLogger(),
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(context.Background(), 1)
+	os.Stderr = originalStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+
+	if len(result.Warnings) != 1 || result.Warnings[0].Kind != domain.ReviewerWarningCleanup {
+		t.Fatalf("typed cleanup warning missing: %#v", result.Warnings)
+	}
+	captured, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	if strings.Count(string(captured), "close error (non-fatal)") != 1 {
+		t.Fatalf("verbose cleanup warning output = %q", captured)
+	}
+}
+
+func TestRunReviewerParentCancellationTakesPriority(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockStreamingAgent{
+		output: `{"item":{"type":"agent_message","text":"finding"}}`,
+	}
+	r := &Runner{
+		config: Config{
+			Reviewers: 1,
+			Timeout:   time.Minute,
+			Events: Events{
+				ReviewerStarted: func(int, string) { cancel() },
+			},
+		},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(ctx, 1)
+
+	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted {
+		t.Fatalf("reviewer cancellation was not classified as interrupted: %#v", result)
+	}
+	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
+		t.Fatalf("reviewer cancellation was misclassified: %#v", result)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -306,6 +306,31 @@ type cleanupWarningAgent struct {
 	onClose  func()
 }
 
+type blockingReviewAgent struct {
+	name    string
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (a *blockingReviewAgent) Name() string {
+	return a.name
+}
+
+func (a *blockingReviewAgent) IsAvailable() error {
+	return nil
+}
+
+func (a *blockingReviewAgent) ExecuteReview(context.Context, *agent.ReviewConfig) (*agent.ExecutionResult, error) {
+	close(a.entered)
+	<-a.release
+	reader := &stringReadCloser{strings.NewReader("")}
+	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
+}
+
+func (a *blockingReviewAgent) ExecuteSummary(context.Context, *agent.SummaryConfig) (*agent.ExecutionResult, error) {
+	return nil, nil
+}
+
 func (a *cleanupWarningAgent) Name() string {
 	return a.name
 }
@@ -557,6 +582,81 @@ func TestCanceledReviewersRetainAssignedAgentNames(t *testing.T) {
 	stats := BuildStats(results, 2, 0)
 	if stats.ReviewerAgentNames[1] != "codex" || stats.ReviewerAgentNames[2] != "claude" {
 		t.Fatalf("canceled reviewer stats identities = %#v", stats.ReviewerAgentNames)
+	}
+}
+
+func TestQueuedCancellationKeepsProgressAndEventsConsistent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	started := make(chan int, 2)
+	completed := make(chan int, 2)
+	r, err := NewHeadless(Config{
+		Reviewers:   2,
+		Concurrency: 1,
+		Timeout:     time.Minute,
+		Events: Events{
+			ReviewerStarted: func(id int, _ string) { started <- id },
+			ReviewerCompleted: func(result domain.ReviewerResult) {
+				completed <- result.ReviewerID
+			},
+		},
+	}, []agent.Agent{&blockingReviewAgent{name: "codex", entered: entered, release: release}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	type outcome struct {
+		results []domain.ReviewerResult
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		results, _, runErr := r.Run(ctx)
+		done <- outcome{results: results, err: runErr}
+	}()
+
+	<-entered
+	startedID := <-started
+	cancel()
+
+	deadline := time.NewTimer(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	for r.completed.Load() == 0 {
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatal("queued reviewer did not reach terminal progress state")
+		}
+	}
+	ticker.Stop()
+	if !deadline.Stop() {
+		select {
+		case <-deadline.C:
+		default:
+		}
+	}
+	close(release)
+
+	var result outcome
+	select {
+	case result = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not finish after cancellation")
+	}
+	if !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("Run() error = %v", result.err)
+	}
+	if len(result.results) != 2 || r.completed.Load() != 2 {
+		t.Fatalf("terminal progress = %d, results = %#v", r.completed.Load(), result.results)
+	}
+	if len(started) != 0 {
+		t.Fatalf("queued reviewer emitted a start event")
+	}
+	if len(completed) != 1 {
+		t.Fatalf("completion event count = %d, want 1", len(completed))
+	}
+	if completedID := <-completed; completedID != startedID {
+		t.Fatalf("completion reviewer = %d, started reviewer = %d", completedID, startedID)
 	}
 }
 

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -74,7 +74,7 @@ type inputItem struct {
 	Reviewers []int  `json:"reviewers"`
 }
 
-func Summarize(ctx context.Context, agentName, model string, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
+func Summarize(ctx context.Context, agentName, model string, aggregated []domain.AggregatedFinding, workDir string, verbose bool, logger *terminal.Logger) (*Result, error) {
 	start := time.Now()
 	if len(aggregated) == 0 {
 		return &Result{
@@ -87,10 +87,10 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 	if err != nil {
 		return nil, err
 	}
-	return summarize(ctx, ag, aggregated, verbose, logger)
+	return summarize(ctx, ag, aggregated, workDir, verbose, logger)
 }
 
-func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding) (*Result, error) {
+func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, workDir string) (*Result, error) {
 	start := time.Now()
 	if len(aggregated) == 0 {
 		return &Result{Grouped: domain.GroupedFindings{}, Duration: time.Since(start)}, nil
@@ -98,10 +98,10 @@ func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain
 	if ag == nil {
 		return nil, fmt.Errorf("summarizer agent is required")
 	}
-	return summarize(ctx, ag, aggregated, false, nil)
+	return summarize(ctx, ag, aggregated, workDir, false, nil)
 }
 
-func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
+func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, workDir string, verbose bool, logger *terminal.Logger) (*Result, error) {
 	start := time.Now()
 	agentName := ag.Name()
 
@@ -127,7 +127,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 		}, nil
 	}
 
-	execResult, err := ag.ExecuteSummary(ctx, groupPrompt, payload)
+	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: groupPrompt, Input: payload, WorkDir: workDir})
 	if err != nil {
 
 		if ctx.Err() != nil {
@@ -168,7 +168,10 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 				Warnings: append([]string(nil), warnings...),
 			}, nil
 		}
-		return nil, err
+		return &Result{
+			Duration: time.Since(start),
+			Warnings: append([]string(nil), warnings...),
+		}, err
 	}
 
 	closeExecution()

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -65,6 +65,7 @@ type Result struct {
 	Stderr   string
 	RawOut   string
 	Duration time.Duration
+	Warnings []string
 }
 
 type inputItem struct {
@@ -139,28 +140,38 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 		return nil, err
 	}
 
-	defer func() {
-		if err := execResult.Close(); err != nil && verbose && logger != nil {
-			logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
+	closed := false
+	var warnings []string
+	closeExecution := func() {
+		if closed {
+			return
 		}
-	}()
+		closed = true
+		if err := execResult.Close(); err != nil {
+			warnings = append(warnings, fmt.Sprintf("summarizer cleanup failed: %v", err))
+			if verbose && logger != nil {
+				logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
+			}
+		}
+	}
+	defer closeExecution()
 
 	output, err := io.ReadAll(execResult)
 	if err != nil {
+		closeExecution()
 
 		if ctx.Err() != nil {
 			return &Result{
 				ExitCode: -1,
 				Stderr:   "context canceled",
 				Duration: time.Since(start),
+				Warnings: append([]string(nil), warnings...),
 			}, nil
 		}
 		return nil, err
 	}
 
-	if err := execResult.Close(); err != nil && verbose && logger != nil {
-		logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
-	}
+	closeExecution()
 	exitCode := execResult.ExitCode()
 	stderr := execResult.Stderr()
 	duration := time.Since(start)
@@ -173,6 +184,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 			Stderr:   fmt.Sprintf("%s authentication failed: %s", agentName, agent.AuthHint(agentName)),
 			RawOut:   rawOut,
 			Duration: duration,
+			Warnings: append([]string(nil), warnings...),
 		}, nil
 	}
 
@@ -182,6 +194,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 			ExitCode: exitCode,
 			Stderr:   stderr,
 			Duration: duration,
+			Warnings: append([]string(nil), warnings...),
 		}, nil
 	}
 
@@ -202,6 +215,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 			Stderr:   parseErr,
 			RawOut:   rawOut,
 			Duration: duration,
+			Warnings: append([]string(nil), warnings...),
 		}, nil
 	}
 
@@ -211,5 +225,6 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 		Stderr:   stderr,
 		RawOut:   rawOut,
 		Duration: duration,
+		Warnings: append([]string(nil), warnings...),
 	}, nil
 }

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -75,7 +75,6 @@ type inputItem struct {
 
 func Summarize(ctx context.Context, agentName, model string, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
 	start := time.Now()
-
 	if len(aggregated) == 0 {
 		return &Result{
 			Grouped:  domain.GroupedFindings{},
@@ -87,6 +86,23 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 	if err != nil {
 		return nil, err
 	}
+	return summarize(ctx, ag, aggregated, verbose, logger)
+}
+
+func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding) (*Result, error) {
+	start := time.Now()
+	if len(aggregated) == 0 {
+		return &Result{Grouped: domain.GroupedFindings{}, Duration: time.Since(start)}, nil
+	}
+	if ag == nil {
+		return nil, fmt.Errorf("summarizer agent is required")
+	}
+	return summarize(ctx, ag, aggregated, false, nil)
+}
+
+func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
+	start := time.Now()
+	agentName := ag.Name()
 
 	items := make([]inputItem, len(aggregated))
 	for i, a := range aggregated {
@@ -124,7 +140,7 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 	}
 
 	defer func() {
-		if err := execResult.Close(); err != nil && verbose {
+		if err := execResult.Close(); err != nil && verbose && logger != nil {
 			logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
 		}
 	}()
@@ -142,7 +158,7 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 		return nil, err
 	}
 
-	if err := execResult.Close(); err != nil && verbose {
+	if err := execResult.Close(); err != nil && verbose && logger != nil {
 		logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
 	}
 	exitCode := execResult.ExitCode()

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -168,10 +168,23 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 				Warnings: append([]string(nil), warnings...),
 			}, nil
 		}
+		readErr := fmt.Errorf("read summarizer output: %w", err)
+		exitCode := execResult.ExitCode()
+		if exitCode == 0 {
+			exitCode = -1
+		}
+		stderr := execResult.Stderr()
+		if stderr != "" {
+			stderr += "\n"
+		}
+		stderr += readErr.Error()
 		return &Result{
+			ExitCode: exitCode,
+			Stderr:   stderr,
+			RawOut:   string(output),
 			Duration: time.Since(start),
 			Warnings: append([]string(nil), warnings...),
-		}, err
+		}, readErr
 	}
 
 	closeExecution()

--- a/internal/summarizer/summarizer_test.go
+++ b/internal/summarizer/summarizer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestSummarize_EmptyInput(t *testing.T) {
-	result, err := Summarize(context.Background(), "codex", "", nil, false, terminal.NewLogger())
+	result, err := Summarize(context.Background(), "codex", "", nil, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestSummarize_EmptyInput(t *testing.T) {
 }
 
 func TestSummarize_EmptySlice(t *testing.T) {
-	result, err := Summarize(context.Background(), "codex", "", []domain.AggregatedFinding{}, false, terminal.NewLogger())
+	result, err := Summarize(context.Background(), "codex", "", []domain.AggregatedFinding{}, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestSummarize_ContextCanceled(t *testing.T) {
 		{Text: "Test finding", Reviewers: []int{1}},
 	}
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -105,7 +105,7 @@ EOF
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -148,7 +148,7 @@ exit 1
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "claude", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "claude", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ echo "this is not valid JSON"
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestSummarize_EmptyOutput(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -264,7 +264,7 @@ exit 42
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -305,7 +305,7 @@ EOF
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -119,6 +119,7 @@ type loop struct {
 	ciErrors        int
 	cycleErrors     int
 	retryPending    bool
+	retryHead       string
 }
 
 func (l *loop) logf(format string, args ...any) {
@@ -208,6 +209,15 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			l.requestArmed = false
 		}
 
+		if trigger == "" && l.retryPending {
+			if st.HeadSHA == l.retryHead {
+				trigger = "retry after transient preparation failure"
+			} else {
+				l.retryPending = false
+				l.retryHead = ""
+			}
+		}
+
 		if trigger == "" && l.pendingApproval != "" {
 			if st.HeadSHA == l.lastHead {
 				if reason, done := l.tryApprove(ctx); done {
@@ -220,10 +230,6 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			if reason, done := l.checkMaxReviews(); done {
 				return reason
 			}
-		}
-
-		if trigger == "" && l.retryPending {
-			trigger = "retry after transient preparation failure"
 		}
 
 		if trigger == "" {
@@ -338,6 +344,8 @@ func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 
 func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, bool) {
 	l.retryPending = false
+	l.retryHead = ""
+	l.pendingApproval = ""
 	l.reviews++
 	l.logf("Review #%d/%d starting (%s)", l.reviews, l.cfg.MaxReviews, trigger)
 
@@ -361,6 +369,7 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 				return ReasonError, true
 			}
 			l.retryPending = true
+			l.retryHead = head
 			return 0, false
 		}
 		l.logf("Review #%d failed: %v", l.reviews, err)

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -2,9 +2,12 @@ package watch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
+
+var ErrRetryableCycle = errors.New("retryable watch cycle failure")
 
 type PostMode string
 
@@ -114,6 +117,8 @@ type loop struct {
 	requestArmed    bool
 	pendingApproval string
 	ciErrors        int
+	cycleErrors     int
+	retryPending    bool
 }
 
 func (l *loop) logf(format string, args ...any) {
@@ -215,6 +220,10 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			if reason, done := l.checkMaxReviews(); done {
 				return reason
 			}
+		}
+
+		if trigger == "" && l.retryPending {
+			trigger = "retry after transient preparation failure"
 		}
 
 		if trigger == "" {
@@ -328,6 +337,7 @@ func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 }
 
 func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, bool) {
+	l.retryPending = false
 	l.reviews++
 	l.logf("Review #%d/%d starting (%s)", l.reviews, l.cfg.MaxReviews, trigger)
 
@@ -343,9 +353,20 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 			l.logf("Reached maximum duration (%s) during review #%d; stopping.", l.cfg.MaxDuration, l.reviews)
 			return ReasonMaxDuration, true
 		}
+		if errors.Is(err, ErrRetryableCycle) {
+			l.reviews--
+			l.cycleErrors++
+			l.logf("Review preparation failed (%d/%d); will retry: %v", l.cycleErrors, maxConsecutivePollErrors, err)
+			if l.cycleErrors >= maxConsecutivePollErrors {
+				return ReasonError, true
+			}
+			l.retryPending = true
+			return 0, false
+		}
 		l.logf("Review #%d failed: %v", l.reviews, err)
 		return ReasonError, true
 	}
+	l.cycleErrors = 0
 
 	if c.Result != CycleStaleHead {
 		l.lastHead = head

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -215,6 +215,7 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			} else {
 				l.retryPending = false
 				l.retryHead = ""
+				l.cycleErrors = 0
 			}
 		}
 

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -364,10 +364,11 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 		if errors.Is(err, ErrRetryableCycle) {
 			l.reviews--
 			l.cycleErrors++
-			l.logf("Review preparation failed (%d/%d); will retry: %v", l.cycleErrors, maxConsecutivePollErrors, err)
 			if l.cycleErrors >= maxConsecutivePollErrors {
+				l.logf("Review preparation failed (%d/%d); stopping: %v", l.cycleErrors, maxConsecutivePollErrors, err)
 				return ReasonError, true
 			}
+			l.logf("Review preparation failed (%d/%d); will retry: %v", l.cycleErrors, maxConsecutivePollErrors, err)
 			l.retryPending = true
 			l.retryHead = head
 			return 0, false

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -198,6 +198,11 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		if reason, done := l.checkOpen(st); done {
 			return reason
 		}
+		if l.retryPending && st.HeadSHA != l.retryHead {
+			l.retryPending = false
+			l.retryHead = ""
+			l.cycleErrors = 0
+		}
 
 		if !st.ReviewRequested {
 			l.requestArmed = true
@@ -210,13 +215,7 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 
 		if trigger == "" && l.retryPending {
-			if st.HeadSHA == l.retryHead {
-				trigger = "retry after transient preparation failure"
-			} else {
-				l.retryPending = false
-				l.retryHead = ""
-				l.cycleErrors = 0
-			}
+			trigger = "retry after transient preparation failure"
 		}
 
 		if trigger == "" && l.pendingApproval != "" {

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -40,6 +41,7 @@ type harness struct {
 
 	triggers     []string
 	approvedWith []string
+	logs         []string
 }
 
 func newHarness(t *testing.T) *harness {
@@ -81,6 +83,9 @@ func (h *harness) deps() Deps {
 		Approve: func(ctx context.Context, body string) error {
 			h.approvedWith = append(h.approvedWith, body)
 			return nil
+		},
+		Logf: func(format string, args ...any) {
+			h.logs = append(h.logs, fmt.Sprintf(format, args...))
 		},
 	}
 }
@@ -474,6 +479,24 @@ func TestRetryableCycleFailuresBecomeFatalAfterLimit(t *testing.T) {
 	}
 	if attempts != maxConsecutivePollErrors {
 		t.Fatalf("attempts = %d, want %d", attempts, maxConsecutivePollErrors)
+	}
+	var preparationLogs []string
+	for _, entry := range h.logs {
+		if strings.Contains(entry, "Review preparation failed") {
+			preparationLogs = append(preparationLogs, entry)
+		}
+	}
+	if len(preparationLogs) != maxConsecutivePollErrors {
+		t.Fatalf("preparation logs = %v", preparationLogs)
+	}
+	for _, entry := range preparationLogs[:len(preparationLogs)-1] {
+		if !strings.Contains(entry, "will retry") {
+			t.Fatalf("retrying log = %q", entry)
+		}
+	}
+	finalLog := preparationLogs[len(preparationLogs)-1]
+	if !strings.Contains(finalLog, "stopping") || strings.Contains(finalLog, "will retry") {
+		t.Fatalf("terminal log = %q", finalLog)
 	}
 }
 

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -477,6 +477,62 @@ func TestRetryableCycleFailuresBecomeFatalAfterLimit(t *testing.T) {
 	}
 }
 
+func TestRetryableRequestedReviewCannotPostPriorPendingApproval(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa"), requested("aaa")}
+	h.ci = []bool{true}
+	deps := h.deps()
+	attempts := 0
+	deps.RunCycle = func(_ context.Context, _ int, trigger string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		switch attempts {
+		case 1:
+			return Cycle{Result: CycleLGTMCommentCIPending, LGTMBody: "obsolete"}, nil
+		case 2:
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		default:
+			return Cycle{Result: CycleLGTMApproved}, nil
+		}
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.approvedWith) != 0 {
+		t.Fatalf("obsolete approval posted: %v", h.approvedWith)
+	}
+	if len(h.triggers) != 3 || h.triggers[1] != "re-review requested" || h.triggers[2] != "retry after transient preparation failure" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+}
+
+func TestRetryablePreparationFailureSettlesChangedHead(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa"), open("bbb")}
+	deps := h.deps()
+	attempts := 0
+	deps.RunCycle = func(_ context.Context, _ int, trigger string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		if attempts == 1 {
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		}
+		return Cycle{Result: CycleLGTMApproved}, nil
+	}
+	startedAt := h.clock.Now()
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "commits settled" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	if elapsed := h.clock.Now().Sub(startedAt); elapsed < defaultConfig(PostModeApprove).SettleTime {
+		t.Fatalf("changed head settled for %s", elapsed)
+	}
+}
+
 func TestParsePostMode(t *testing.T) {
 	for _, valid := range []string{"interactive", "comment", "approve"} {
 		if _, err := ParsePostMode(valid); err != nil {

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -430,6 +431,49 @@ func TestStateErrorsAreToleratedThenFatal(t *testing.T) {
 	}
 	if stateCalls != 1+maxConsecutivePollErrors {
 		t.Errorf("state calls = %d, want %d", stateCalls, 1+maxConsecutivePollErrors)
+	}
+}
+
+func TestRetryableCycleFailureDoesNotConsumeReviewBudget(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	deps := h.deps()
+	var reviewNumbers []int
+	deps.RunCycle = func(_ context.Context, reviewNum int, trigger string) (Cycle, error) {
+		reviewNumbers = append(reviewNumbers, reviewNum)
+		h.triggers = append(h.triggers, trigger)
+		if len(reviewNumbers) == 1 {
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		}
+		return Cycle{Result: CycleLGTMApproved}, nil
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(reviewNumbers) != 2 || reviewNumbers[0] != 1 || reviewNumbers[1] != 1 {
+		t.Fatalf("review numbers = %v, want [1 1]", reviewNumbers)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "retry after transient preparation failure" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+}
+
+func TestRetryableCycleFailuresBecomeFatalAfterLimit(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	deps := h.deps()
+	attempts := 0
+	deps.RunCycle = func(_ context.Context, _ int, _ string) (Cycle, error) {
+		attempts++
+		return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), deps); reason != ReasonError {
+		t.Fatalf("reason = %v, want ReasonError", reason)
+	}
+	if attempts != maxConsecutivePollErrors {
+		t.Fatalf("attempts = %d, want %d", attempts, maxConsecutivePollErrors)
 	}
 }
 

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -558,6 +558,37 @@ func TestRetryablePreparationFailuresResetWhenHeadChanges(t *testing.T) {
 	}
 }
 
+func TestRetryablePreparationFailuresResetForRequestedNewHead(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		open("aaa"),
+		open("aaa"),
+		open("aaa"),
+		requested("bbb"),
+	}
+	deps := h.deps()
+	attempts := 0
+	deps.RunCycle = func(_ context.Context, _ int, trigger string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		if attempts <= 2*(maxConsecutivePollErrors-1) {
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		}
+		return Cycle{Result: CycleLGTMApproved}, nil
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if attempts != 2*maxConsecutivePollErrors-1 {
+		t.Fatalf("attempts = %d, want %d", attempts, 2*maxConsecutivePollErrors-1)
+	}
+	if h.triggers[maxConsecutivePollErrors-1] != "re-review requested" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+}
+
 func TestParsePostMode(t *testing.T) {
 	for _, valid := range []string{"interactive", "comment", "approve"} {
 		if _, err := ParsePostMode(valid); err != nil {

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -533,6 +533,31 @@ func TestRetryablePreparationFailureSettlesChangedHead(t *testing.T) {
 	}
 }
 
+func TestRetryablePreparationFailuresResetWhenHeadChanges(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa"), open("bbb")}
+	deps := h.deps()
+	attempts := 0
+	deps.RunCycle = func(_ context.Context, _ int, trigger string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		if attempts <= maxConsecutivePollErrors {
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		}
+		return Cycle{Result: CycleLGTMApproved}, nil
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if attempts != maxConsecutivePollErrors+1 {
+		t.Fatalf("attempts = %d, want %d", attempts, maxConsecutivePollErrors+1)
+	}
+	if h.triggers[1] != "commits settled" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+}
+
 func TestParsePostMode(t *testing.T) {
 	for _, valid := range []string{"interactive", "comment", "approve"} {
 		if _, err := ParsePostMode(valid); err != nil {


### PR DESCRIPTION
## Summary

- resolve review configuration from an immutable snapshot of the canonical remote default branch
- fall back only to a committed local `main` snapshot when no canonical remote exists, then to built-in defaults when no trusted repository snapshot is available
- never load `.acr.yaml`, guidance, or other config-relative inputs from the PR head, target checkout, or review worktree
- fail closed for invalid or unavailable trusted inputs instead of falling back to reviewed code
- preserve typed source identity and distinguish explicit `--no-config` from an absent trusted config
- apply the same resolver contract to ordinary, PR, worktree-branch, and watch reviews

No user-level `~/.acr.yaml` source is introduced here; that can be added later without weakening the trust boundary.

Closes #220
Part of #191

## Validation

- `go test ./cmd/acr ./internal/config ./internal/git`
- `go test -race ./cmd/acr ./internal/config ./internal/git`
- `make vet`
- `make staticcheck`
- `make lint`
- integrated stack: `go test ./cmd/acr ./internal/...`
- integrated stack: focused race tests across command, config, domain, feedback, git, review, and runner packages
- `git diff --check`

`make check` reaches the repository's pre-existing unrelated `integration/TestVersion` fixture mismatch: the development binary reports `acr dev` while the fixture expects `acr v`. All other packages pass.