### PR TITLE
[P1] Extract typed headless review service

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -142,7 +142,10 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			feedbackCtx, feedbackCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 			defer feedbackCancel()
 
-			summary, err := summarizer.Summarize(feedbackCtx, opts.DetectedPR)
+			summary, err := summarizer.SummarizeFromDir(feedbackCtx, opts.DetectedPR, opts.WorkDir)
+			if summary != "" {
+				priorFeedback = summary
+			}
 			if err != nil {
 
 				if ctx.Err() != nil {
@@ -161,11 +164,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			} else {
 				logger.Log("No relevant PR feedback found", terminal.StyleDim)
 			}
-			priorFeedback = summary
 		}()
 	}
 
 	results, wallClock, err := r.Run(ctx)
+	if !opts.Verbose {
+		for _, result := range results {
+			for _, warning := range result.Warnings {
+				logger.Logf(terminal.StyleWarning, "Reviewer #%d: %s", result.ReviewerID, warning.Message)
+			}
+		}
+	}
 	if err != nil {
 		if ctx.Err() != nil {
 			return domain.ExitInterrupted
@@ -194,9 +203,14 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 	summarizerCtx, summarizerCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 	defer summarizerCancel()
-	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, opts.SummarizerModel, aggregated, opts.Verbose, logger)
+	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, opts.SummarizerModel, aggregated, opts.WorkDir, opts.Verbose, logger)
 	spinnerCancel()
 	<-spinnerDone
+	if summaryResult != nil && !opts.Verbose {
+		for _, warning := range summaryResult.Warnings {
+			logger.Log(warning, terminal.StyleWarning)
+		}
+	}
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -227,7 +241,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 		fpCtx, fpCancel := context.WithTimeout(ctx, opts.FPFilterTimeout)
 		defer fpCancel()
-		fpFilter := fpfilter.New(opts.SummarizerAgent, opts.SummarizerModel, opts.FPThreshold, opts.Verbose, logger)
+		fpFilter := fpfilter.New(opts.SummarizerAgent, opts.SummarizerModel, opts.FPThreshold, opts.WorkDir, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, priorFeedback, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone
@@ -236,6 +250,11 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			logger.Logf(terminal.StyleWarning, "FP filter skipped (%s): showing all findings", fpResult.SkipReason)
 		}
 		if fpResult != nil {
+			if !opts.Verbose {
+				for _, warning := range fpResult.Warnings {
+					logger.Log(warning, terminal.StyleWarning)
+				}
+			}
 			summaryResult.Grouped = fpResult.Grouped
 			fpFilteredCount = fpResult.RemovedCount
 			stats.FPFilterDuration = fpResult.Duration

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,5 +11,5 @@ type Agent interface {
 
 	ExecuteReview(ctx context.Context, config *ReviewConfig) (*ExecutionResult, error)
 
-	ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error)
+	ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error)
 }

--- a/internal/agent/antigravity.go
+++ b/internal/agent/antigravity.go
@@ -47,15 +47,15 @@ func (a *AntigravityAgent) ExecuteReview(ctx context.Context, config *ReviewConf
 	})
 }
 
-func (a *AntigravityAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (a *AntigravityAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := a.IsAvailable(); err != nil {
 		return nil, err
 	}
 
 	stdin := io.MultiReader(
-		strings.NewReader(prompt),
+		strings.NewReader(config.Prompt),
 		strings.NewReader("\n\nINPUT JSON:\n"),
-		bytes.NewReader(input),
+		bytes.NewReader(config.Input),
 		strings.NewReader("\n"),
 	)
 
@@ -63,6 +63,7 @@ func (a *AntigravityAgent) ExecuteSummary(ctx context.Context, prompt string, in
 		Command: "agy",
 		Args:    antigravityPrintArgs(antigravityPrintTimeoutCeilingFromContext(ctx, time.Now())),
 		Stdin:   stdin,
+		WorkDir: config.WorkDir,
 	})
 }
 

--- a/internal/agent/antigravity_test.go
+++ b/internal/agent/antigravity_test.go
@@ -82,7 +82,7 @@ func TestAntigravityAgent_ExecuteSummary_AgyNotAvailable(t *testing.T) {
 	agent := NewAntigravityAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -276,7 +276,7 @@ func TestAntigravityAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewAntigravityAgent("ignored-model")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -48,7 +48,7 @@ func (c *ClaudeAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (
 	})
 }
 
-func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := c.IsAvailable(); err != nil {
 		return nil, err
 	}
@@ -56,18 +56,18 @@ func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 	var stdin io.Reader
 	var tempFilePath string
 
-	if len(input) > RefFileSizeThreshold {
+	if len(config.Input) > RefFileSizeThreshold {
 
-		absPath, err := WriteInputToTempFile("", input, "summary-input.json")
+		absPath, err := WriteInputToTempFile(config.WorkDir, config.Input, "summary-input.json")
 		if err != nil {
 			return nil, err
 		}
 		tempFilePath = absPath
-		fullPrompt := fmt.Sprintf("%s\n\nThe input JSON is in file: %s\nUse the Read tool to examine it.", prompt, absPath)
+		fullPrompt := fmt.Sprintf("%s\n\nThe input JSON is in file: %s\nUse the Read tool to examine it.", config.Prompt, absPath)
 		stdin = bytes.NewReader([]byte(fullPrompt))
 	} else {
 
-		fullPrompt := prompt + "\n\nINPUT JSON:\n" + string(input) + "\n"
+		fullPrompt := config.Prompt + "\n\nINPUT JSON:\n" + string(config.Input) + "\n"
 		stdin = bytes.NewReader([]byte(fullPrompt))
 	}
 
@@ -80,6 +80,7 @@ func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 		Command:      "claude",
 		Args:         args,
 		Stdin:        stdin,
+		WorkDir:      config.WorkDir,
 		TempFilePath: tempFilePath,
 	})
 }

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -87,7 +87,7 @@ func TestClaudeAgent_ExecuteSummary_ClaudeNotAvailable(t *testing.T) {
 	agent := NewClaudeAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -329,7 +329,7 @@ func TestClaudeAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewClaudeAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}
@@ -353,5 +353,45 @@ func TestClaudeAgent_ExecuteSummary_Args(t *testing.T) {
 
 	if strings.Contains(outputStr, "ARG:--json-schema") {
 		t.Errorf("unexpected --json-schema in args — ExecuteSummary must not constrain output format")
+	}
+}
+
+func TestClaudeAgentExecuteSummaryUsesWorkDirForLargeInput(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := t.TempDir()
+	mockScript := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\ncat\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", originalPath)
+	os.Setenv("PATH", binDir+":"+originalPath)
+
+	claudeAgent := NewClaudeAgent("")
+	result, err := claudeAgent.ExecuteSummary(context.Background(), &SummaryConfig{
+		Prompt:  "summarize",
+		Input:   []byte(strings.Repeat("x", RefFileSizeThreshold+1)),
+		WorkDir: workDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(output), workDir) {
+		t.Fatalf("summary prompt did not reference workdir temp file: %q", output)
+	}
+	if err := result.Close(); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(workDir, ".acr-summary-input.json-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("summary temp files remain: %v", matches)
 	}
 }

--- a/internal/agent/cmd_reader.go
+++ b/internal/agent/cmd_reader.go
@@ -16,6 +16,7 @@ type cmdReader struct {
 	stderr       stderrBuffer
 	exitCode     int
 	closeOnce    sync.Once
+	closeErr     error
 	tempFilePath string
 }
 
@@ -41,10 +42,10 @@ func (r *cmdReader) Close() error {
 			}
 		}
 
-		CleanupTempFile(r.tempFilePath)
+		r.closeErr = CleanupTempFile(r.tempFilePath)
 	})
 
-	return nil
+	return r.closeErr
 }
 
 func (r *cmdReader) ExitCode() int {

--- a/internal/agent/cmd_reader_test.go
+++ b/internal/agent/cmd_reader_test.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -131,6 +133,27 @@ func TestCmdReader_Close_Idempotent(t *testing.T) {
 	}
 	if err := reader.Close(); err != nil {
 		t.Errorf("Second Close() error = %v, want nil", err)
+	}
+}
+
+func TestCmdReader_CloseReturnsStoredCleanupError(t *testing.T) {
+	cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+	if err := os.Mkdir(cleanupPath, 0700); err != nil {
+		t.Fatalf("create cleanup directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+		t.Fatalf("create cleanup child: %v", err)
+	}
+	reader := &cmdReader{Reader: strings.NewReader(""), tempFilePath: cleanupPath}
+
+	firstErr := reader.Close()
+	secondErr := reader.Close()
+
+	if firstErr == nil || !strings.Contains(firstErr.Error(), "failed to clean up temp file") {
+		t.Fatalf("first Close() error = %v", firstErr)
+	}
+	if secondErr == nil || secondErr.Error() != firstErr.Error() {
+		t.Fatalf("second Close() error = %v, want %v", secondErr, firstErr)
 	}
 }
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -36,7 +36,7 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 		return nil, err
 	}
 
-	if config.Guidance != "" {
+	if config.Guidance != "" || config.DiffPrecomputed {
 		args := []string{"exec", "--json", "--color", "never", "-"}
 		if c.model != "" {
 			args = append([]string{"--model", c.model}, args...)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -61,7 +61,7 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 	})
 }
 
-func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (c *CodexAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := c.IsAvailable(); err != nil {
 		return nil, err
 	}
@@ -72,9 +72,9 @@ func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []
 	}
 
 	stdin := io.MultiReader(
-		strings.NewReader(prompt),
+		strings.NewReader(config.Prompt),
 		strings.NewReader("\n\nINPUT JSON:\n"),
-		bytes.NewReader(input),
+		bytes.NewReader(config.Input),
 		strings.NewReader("\n"),
 	)
 
@@ -82,5 +82,6 @@ func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []
 		Command: "codex",
 		Args:    args,
 		Stdin:   stdin,
+		WorkDir: config.WorkDir,
 	})
 }

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -221,6 +221,29 @@ func TestCodexAgent_ExecuteReview_ArgsWithGuidance(t *testing.T) {
 	if !strings.Contains(outputStr, "Focus on security issues") {
 		t.Errorf("expected guidance in stdin prompt, got:\n%s", outputStr)
 	}
+
+	pinnedConfig := &ReviewConfig{
+		BaseRef:         "base-object-id",
+		WorkDir:         tmpDir,
+		Diff:            "pinned diff content",
+		DiffPrecomputed: true,
+	}
+	pinnedResult, err := agent.ExecuteReview(ctx, pinnedConfig)
+	if err != nil {
+		t.Fatalf("ExecuteReview() with pinned diff error: %v", err)
+	}
+	defer pinnedResult.Close()
+	pinnedOutput, err := io.ReadAll(pinnedResult)
+	if err != nil {
+		t.Fatalf("read pinned review output: %v", err)
+	}
+	pinnedOutputText := string(pinnedOutput)
+	if strings.Contains(pinnedOutputText, "ARG:review") || strings.Contains(pinnedOutputText, "ARG:--base") {
+		t.Fatalf("pinned review used mutable native review mode:\n%s", pinnedOutputText)
+	}
+	if !strings.Contains(pinnedOutputText, "pinned diff content") {
+		t.Fatalf("pinned review omitted captured diff:\n%s", pinnedOutputText)
+	}
 }
 
 func TestCodexAgent_ExecuteSummary_Args(t *testing.T) {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -87,7 +87,7 @@ func TestCodexAgent_ExecuteSummary_CodexNotAvailable(t *testing.T) {
 	agent := NewCodexAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -103,7 +103,7 @@ func TestCodexAgent_ExecuteSummary_CodexNotAvailable(t *testing.T) {
 func TestCodexAgent_ExecuteReview_ArgsWithoutGuidance(t *testing.T) {
 	tmpDir := t.TempDir()
 	mockScript := filepath.Join(tmpDir, "codex")
-	err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"$arg\"; done\n"), 0755)
+	err := os.WriteFile(mockScript, []byte("#!/bin/sh\npwd -P\nfor arg in \"$@\"; do echo \"$arg\"; done\n"), 0755)
 	if err != nil {
 		t.Fatalf("failed to write mock script: %v", err)
 	}
@@ -130,7 +130,15 @@ func TestCodexAgent_ExecuteReview_ArgsWithoutGuidance(t *testing.T) {
 		t.Fatalf("failed to read output: %v", err)
 	}
 
-	args := strings.Split(strings.TrimSpace(string(output)), "\n")
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	wantWorkDir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) == 0 || lines[0] != wantWorkDir {
+		t.Fatalf("summary workdir = %q, want %q", lines[0], wantWorkDir)
+	}
+	args := lines[1:]
 	expected := []string{"exec", "--json", "--color", "never", "review", "--base", "main"}
 	if len(args) != len(expected) {
 		t.Fatalf("got %d args %v, want %d args %v", len(args), args, len(expected), expected)
@@ -261,7 +269,7 @@ func TestCodexAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewCodexAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize this", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize this", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}

--- a/internal/agent/cohort_test.go
+++ b/internal/agent/cohort_test.go
@@ -322,6 +322,6 @@ func (m *mockAgent) ExecuteReview(_ context.Context, _ *ReviewConfig) (*Executio
 	return nil, nil
 }
 
-func (m *mockAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*ExecutionResult, error) {
+func (m *mockAgent) ExecuteSummary(_ context.Context, _ *SummaryConfig) (*ExecutionResult, error) {
 	return nil, nil
 }

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -21,3 +21,9 @@ type ReviewConfig struct {
 
 	DiffPrecomputed bool
 }
+
+type SummaryConfig struct {
+	Prompt  string
+	Input   []byte
+	WorkDir string
+}

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -78,13 +79,17 @@ func executeCommand(ctx context.Context, opts executeOptions) (*ExecutionResult,
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		CleanupTempFile(opts.TempFilePath)
-		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to create stdout pipe: %w", err),
+			CleanupTempFile(opts.TempFilePath),
+		)
 	}
 
 	if err := cmd.Start(); err != nil {
-		CleanupTempFile(opts.TempFilePath)
-		return nil, fmt.Errorf("failed to start %s: %w", opts.Command, err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to start %s: %w", opts.Command, err),
+			CleanupTempFile(opts.TempFilePath),
+		)
 	}
 
 	reader := &cmdReader{

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -83,5 +85,53 @@ func TestExecuteCommand_StartFailureCleansTempFile(t *testing.T) {
 	}
 	if _, statErr := os.Stat(tempPath); !os.IsNotExist(statErr) {
 		t.Fatalf("expected temp file to be removed, stat err: %v", statErr)
+	}
+}
+
+func TestExecuteCommand_StartFailureIncludesCleanupFailure(t *testing.T) {
+	cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+	if err := os.Mkdir(cleanupPath, 0700); err != nil {
+		t.Fatalf("create cleanup directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+		t.Fatalf("create cleanup child: %v", err)
+	}
+
+	_, err := executeCommand(context.Background(), executeOptions{
+		Command:      "definitely-not-a-real-acr-command",
+		TempFilePath: cleanupPath,
+	})
+
+	if err == nil {
+		t.Fatal("expected executeCommand to fail")
+	}
+	if !strings.Contains(err.Error(), "failed to start") || !strings.Contains(err.Error(), "failed to clean up temp file") {
+		t.Fatalf("combined setup and cleanup error = %v", err)
+	}
+}
+
+func TestExecuteCommand_CloseReturnsCleanupFailure(t *testing.T) {
+	cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+	if err := os.Mkdir(cleanupPath, 0700); err != nil {
+		t.Fatalf("create cleanup directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+		t.Fatalf("create cleanup child: %v", err)
+	}
+
+	result, err := executeCommand(context.Background(), executeOptions{
+		Command:      "true",
+		TempFilePath: cleanupPath,
+	})
+	if err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+	if _, err := io.ReadAll(result); err != nil {
+		t.Fatalf("read command output: %v", err)
+	}
+	firstErr := result.Close()
+
+	if firstErr == nil || !strings.Contains(firstErr.Error(), "failed to clean up temp file") {
+		t.Fatalf("first Close() error = %v", firstErr)
 	}
 }

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -49,7 +49,7 @@ func (g *GeminiAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (
 	})
 }
 
-func (g *GeminiAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+func (g *GeminiAgent) ExecuteSummary(ctx context.Context, config *SummaryConfig) (*ExecutionResult, error) {
 	if err := g.IsAvailable(); err != nil {
 		return nil, err
 	}
@@ -60,9 +60,9 @@ func (g *GeminiAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 	}
 
 	stdin := io.MultiReader(
-		strings.NewReader(prompt),
+		strings.NewReader(config.Prompt),
 		strings.NewReader("\n\nINPUT JSON:\n"),
-		bytes.NewReader(input),
+		bytes.NewReader(config.Input),
 		strings.NewReader("\n"),
 	)
 
@@ -70,5 +70,6 @@ func (g *GeminiAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 		Command: "gemini",
 		Args:    args,
 		Stdin:   stdin,
+		WorkDir: config.WorkDir,
 	})
 }

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -87,7 +87,7 @@ func TestGeminiAgent_ExecuteSummary_GeminiNotAvailable(t *testing.T) {
 	agent := NewGeminiAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "test prompt", Input: []byte(`{"findings":[]}`)})
 	if err == nil {
 		if result != nil {
 			result.Close()
@@ -261,7 +261,7 @@ func TestGeminiAgent_ExecuteSummary_Args(t *testing.T) {
 	agent := NewGeminiAgent("")
 	ctx := context.Background()
 
-	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	result, err := agent.ExecuteSummary(ctx, &SummaryConfig{Prompt: "summarize", Input: []byte(`{"findings":[]}`), WorkDir: tmpDir})
 	if err != nil {
 		t.Fatalf("ExecuteSummary() error: %v", err)
 	}

--- a/internal/agent/reffile.go
+++ b/internal/agent/reffile.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,11 +35,10 @@ func WriteDiffToTempFile(workDir, diff string) (string, error) {
 
 	absPath, err := filepath.Abs(tempPath)
 	if err != nil {
-
-		if rmErr := os.Remove(tempPath); rmErr != nil && !os.IsNotExist(rmErr) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to clean up temp file %s during error handling: %v\n", tempPath, rmErr)
-		}
-		return "", fmt.Errorf("failed to get absolute path for temp file: %w", err)
+		return "", errors.Join(
+			fmt.Errorf("failed to get absolute path for temp file: %w", err),
+			CleanupTempFile(tempPath),
+		)
 	}
 
 	return absPath, nil
@@ -57,21 +57,21 @@ func WriteInputToTempFile(workDir string, input []byte, suffix string) (string, 
 
 	absPath, err := filepath.Abs(tempPath)
 	if err != nil {
-
-		if rmErr := os.Remove(tempPath); rmErr != nil && !os.IsNotExist(rmErr) {
-			fmt.Fprintf(os.Stderr, "Warning: failed to clean up temp file %s during error handling: %v\n", tempPath, rmErr)
-		}
-		return "", fmt.Errorf("failed to get absolute path for temp file: %w", err)
+		return "", errors.Join(
+			fmt.Errorf("failed to get absolute path for temp file: %w", err),
+			CleanupTempFile(tempPath),
+		)
 	}
 
 	return absPath, nil
 }
 
-func CleanupTempFile(path string) {
+func CleanupTempFile(path string) error {
 	if path == "" {
-		return
+		return nil
 	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Warning: failed to clean up temp file %s: %v\n", path, err)
+		return fmt.Errorf("failed to clean up temp file %s: %w", path, err)
 	}
+	return nil
 }

--- a/internal/agent/reffile_test.go
+++ b/internal/agent/reffile_test.go
@@ -71,7 +71,9 @@ func TestWriteDiffToTempFile(t *testing.T) {
 		t.Errorf("WriteDiffToTempFile() path = %s, want absolute path", absPath)
 	}
 
-	CleanupTempFile(absPath)
+	if err := CleanupTempFile(absPath); err != nil {
+		t.Fatalf("CleanupTempFile() error = %v", err)
+	}
 	if _, err := os.Stat(absPath); !os.IsNotExist(err) {
 		t.Errorf("CleanupTempFile() failed to remove file")
 	}
@@ -102,7 +104,9 @@ func TestWriteInputToTempFile(t *testing.T) {
 		t.Errorf("WriteInputToTempFile() path = %s, want absolute path", absPath)
 	}
 
-	CleanupTempFile(absPath)
+	if err := CleanupTempFile(absPath); err != nil {
+		t.Fatalf("CleanupTempFile() error = %v", err)
+	}
 }
 
 func TestCleanupTempFile(t *testing.T) {
@@ -113,7 +117,9 @@ func TestCleanupTempFile(t *testing.T) {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 
-		CleanupTempFile(tmpFile)
+		if err := CleanupTempFile(tmpFile); err != nil {
+			t.Fatalf("CleanupTempFile() error = %v", err)
+		}
 
 		if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
 			t.Error("CleanupTempFile() failed to remove existing file")
@@ -122,12 +128,48 @@ func TestCleanupTempFile(t *testing.T) {
 
 	t.Run("cleanup non-existent file does not panic", func(t *testing.T) {
 
-		CleanupTempFile("/nonexistent/path/file.txt")
+		if err := CleanupTempFile("/nonexistent/path/file.txt"); err != nil {
+			t.Fatalf("CleanupTempFile() error = %v", err)
+		}
 	})
 
 	t.Run("cleanup empty path does nothing", func(t *testing.T) {
 
-		CleanupTempFile("")
+		if err := CleanupTempFile(""); err != nil {
+			t.Fatalf("CleanupTempFile() error = %v", err)
+		}
+	})
+
+	t.Run("cleanup failure returns error without stderr", func(t *testing.T) {
+		cleanupPath := filepath.Join(t.TempDir(), "not-empty")
+		if err := os.Mkdir(cleanupPath, 0700); err != nil {
+			t.Fatalf("create cleanup directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(cleanupPath, "child"), []byte("data"), 0600); err != nil {
+			t.Fatalf("create cleanup child: %v", err)
+		}
+		stderrPath := filepath.Join(t.TempDir(), "stderr")
+		stderr, err := os.Create(stderrPath)
+		if err != nil {
+			t.Fatalf("create stderr capture: %v", err)
+		}
+		originalStderr := os.Stderr
+		os.Stderr = stderr
+		cleanupErr := CleanupTempFile(cleanupPath)
+		os.Stderr = originalStderr
+		if err := stderr.Close(); err != nil {
+			t.Fatalf("close stderr capture: %v", err)
+		}
+		if cleanupErr == nil || !strings.Contains(cleanupErr.Error(), "failed to clean up temp file") {
+			t.Fatalf("CleanupTempFile() error = %v", cleanupErr)
+		}
+		captured, err := os.ReadFile(stderrPath)
+		if err != nil {
+			t.Fatalf("read stderr capture: %v", err)
+		}
+		if len(captured) != 0 {
+			t.Fatalf("CleanupTempFile() wrote stderr: %q", captured)
+		}
 	})
 }
 

--- a/internal/domain/result.go
+++ b/internal/domain/result.go
@@ -2,15 +2,43 @@ package domain
 
 import "time"
 
+type ReviewerFailureKind string
+
+const (
+	ReviewerFailureExecution   ReviewerFailureKind = "execution"
+	ReviewerFailureExit        ReviewerFailureKind = "exit"
+	ReviewerFailureTimeout     ReviewerFailureKind = "timeout"
+	ReviewerFailureAuth        ReviewerFailureKind = "authentication"
+	ReviewerFailureInterrupted ReviewerFailureKind = "interrupted"
+	ReviewerFailureParser      ReviewerFailureKind = "parser"
+)
+
+type ReviewerFailure struct {
+	Kind    ReviewerFailureKind
+	Message string
+}
+
+type ReviewerWarningKind string
+
+const ReviewerWarningCleanup ReviewerWarningKind = "cleanup"
+
+type ReviewerWarning struct {
+	Kind    ReviewerWarningKind
+	Message string
+}
+
 type ReviewerResult struct {
 	ReviewerID  int
 	AgentName   string
 	Findings    []Finding
 	ExitCode    int
+	Attempts    int
 	ParseErrors int
 	TimedOut    bool
 	AuthFailed  bool
 	Duration    time.Duration
+	Failure     *ReviewerFailure
+	Warnings    []ReviewerWarning
 }
 
 type ReviewStats struct {

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -344,6 +344,7 @@ type FalsePositiveFilterOutcome struct {
 	SkipReason string
 	EvalErrors int
 	Duration   time.Duration
+	Warnings   []string
 	Removed    []ReviewFinding
 }
 

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -320,6 +320,7 @@ type SummarizerOutcome struct {
 	Stderr           string
 	DiagnosticOutput string
 	Duration         time.Duration
+	Warnings         []string
 }
 
 type ReviewFindingKind string

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -1,0 +1,379 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+type PullRequestKey struct {
+	Host       string
+	Owner      string
+	Repository string
+	Number     int
+}
+
+func (k PullRequestKey) Validate() error {
+	var invalid []string
+	if strings.TrimSpace(k.Host) == "" {
+		invalid = append(invalid, "host is required")
+	}
+	if strings.TrimSpace(k.Owner) == "" {
+		invalid = append(invalid, "owner is required")
+	}
+	if strings.TrimSpace(k.Repository) == "" {
+		invalid = append(invalid, "repository is required")
+	}
+	if k.Number < 1 {
+		invalid = append(invalid, "pull request number must be positive")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid pull request key: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func (k PullRequestKey) String() string {
+	return fmt.Sprintf("%s/%s/%s#%d", k.Host, k.Owner, k.Repository, k.Number)
+}
+
+type RevisionEvidence struct {
+	RequestedBaseRef string
+	ResolvedBaseRef  string
+	HeadObjectID     string
+	BaseObjectID     string
+}
+
+type ReviewTarget struct {
+	RepositoryRoot string
+	WorktreeRoot   string
+	Revision       RevisionEvidence
+	PullRequest    *PullRequestKey
+}
+
+func (t ReviewTarget) Validate() error {
+	var invalid []string
+	if !filepath.IsAbs(t.RepositoryRoot) {
+		invalid = append(invalid, "repository root must be absolute")
+	}
+	if !filepath.IsAbs(t.WorktreeRoot) {
+		invalid = append(invalid, "worktree root must be absolute")
+	}
+	if strings.TrimSpace(t.Revision.RequestedBaseRef) == "" {
+		invalid = append(invalid, "requested base ref is required")
+	}
+	if strings.TrimSpace(t.Revision.ResolvedBaseRef) == "" {
+		invalid = append(invalid, "resolved base ref is required")
+	}
+	if t.PullRequest != nil {
+		if err := t.PullRequest.Validate(); err != nil {
+			invalid = append(invalid, err.Error())
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid review target: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func (t ReviewTarget) Clone() ReviewTarget {
+	clone := t
+	if t.PullRequest != nil {
+		key := *t.PullRequest
+		clone.PullRequest = &key
+	}
+	return clone
+}
+
+type ReviewTrigger string
+
+const (
+	ReviewTriggerManual ReviewTrigger = "manual"
+	ReviewTriggerWatch  ReviewTrigger = "watch"
+	ReviewTriggerDesk   ReviewTrigger = "desk"
+)
+
+func (t ReviewTrigger) Validate() error {
+	switch t {
+	case ReviewTriggerManual, ReviewTriggerWatch, ReviewTriggerDesk:
+		return nil
+	default:
+		return fmt.Errorf("invalid review trigger %q", t)
+	}
+}
+
+type ReviewStatus string
+
+const (
+	ReviewStatusCompleted   ReviewStatus = "completed"
+	ReviewStatusFailed      ReviewStatus = "failed"
+	ReviewStatusInterrupted ReviewStatus = "interrupted"
+)
+
+type ReviewConclusion string
+
+const (
+	ReviewConclusionNone      ReviewConclusion = ""
+	ReviewConclusionNoChanges ReviewConclusion = "no_changes"
+	ReviewConclusionClean     ReviewConclusion = "clean"
+	ReviewConclusionFindings  ReviewConclusion = "findings"
+)
+
+type ReviewPhase string
+
+const (
+	ReviewPhaseInitialization      ReviewPhase = "initialization"
+	ReviewPhaseRevisions           ReviewPhase = "revisions"
+	ReviewPhaseDiff                ReviewPhase = "diff"
+	ReviewPhaseReviewers           ReviewPhase = "reviewers"
+	ReviewPhaseFeedback            ReviewPhase = "feedback"
+	ReviewPhaseSummarization       ReviewPhase = "summarization"
+	ReviewPhaseFalsePositiveFilter ReviewPhase = "false_positive_filter"
+	ReviewPhaseExcludeFilter       ReviewPhase = "exclude_filter"
+	ReviewPhaseComplete            ReviewPhase = "complete"
+)
+
+type ReviewEngine struct {
+	Name    string
+	Version string
+}
+
+func (e ReviewEngine) Validate() error {
+	if strings.TrimSpace(e.Name) == "" {
+		return fmt.Errorf("review engine name is required")
+	}
+	if strings.TrimSpace(e.Version) == "" {
+		return fmt.Errorf("review engine version is required")
+	}
+	return nil
+}
+
+type ConfigurationSourceIdentity struct {
+	Kind          string
+	Locator       string
+	Ref           string
+	Revision      string
+	ConfigPresent bool
+	ConfigDigest  string
+}
+
+func (s ConfigurationSourceIdentity) Validate() error {
+	if strings.TrimSpace(s.Kind) == "" {
+		return fmt.Errorf("configuration source kind is required")
+	}
+	if s.ConfigPresent && strings.TrimSpace(s.ConfigDigest) == "" {
+		return fmt.Errorf("configuration source digest is required when configuration is present")
+	}
+	if !s.ConfigPresent && s.ConfigDigest != "" {
+		return fmt.Errorf("configuration source digest requires a present configuration")
+	}
+	return nil
+}
+
+type ReviewConfigurationValues struct {
+	Reviewers         int
+	Concurrency       int
+	Timeout           time.Duration
+	Retries           int
+	ReviewerAgents    []string
+	ReviewerModel     string
+	SummarizerAgent   string
+	SummarizerModel   string
+	SummarizerTimeout time.Duration
+	FPFilterTimeout   time.Duration
+	Guidance          string
+	UseRefFile        bool
+	FPFilterEnabled   bool
+	FPThreshold       int
+	PRFeedbackEnabled bool
+	PRFeedbackAgent   string
+	ExcludePatterns   []string
+}
+
+type ReviewConfiguration struct {
+	values      ReviewConfigurationValues
+	fingerprint string
+}
+
+func NewReviewConfiguration(values ReviewConfigurationValues) (ReviewConfiguration, error) {
+	values.ReviewerAgents = cloneStrings(values.ReviewerAgents)
+	values.ExcludePatterns = cloneStrings(values.ExcludePatterns)
+
+	if err := validateReviewConfiguration(values); err != nil {
+		return ReviewConfiguration{}, err
+	}
+
+	payload, err := json.Marshal(values)
+	if err != nil {
+		return ReviewConfiguration{}, fmt.Errorf("fingerprint review configuration: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+
+	return ReviewConfiguration{
+		values:      values,
+		fingerprint: "sha256:" + hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+func (c ReviewConfiguration) Values() ReviewConfigurationValues {
+	values := c.values
+	values.ReviewerAgents = slices.Clone(c.values.ReviewerAgents)
+	values.ExcludePatterns = slices.Clone(c.values.ExcludePatterns)
+	return values
+}
+
+func (c ReviewConfiguration) Fingerprint() string {
+	return c.fingerprint
+}
+
+func (c ReviewConfiguration) Validate() error {
+	if err := validateReviewConfiguration(c.values); err != nil {
+		return err
+	}
+	if c.fingerprint == "" {
+		return fmt.Errorf("review configuration fingerprint is required")
+	}
+	return nil
+}
+
+func validateReviewConfiguration(values ReviewConfigurationValues) error {
+	var invalid []string
+	if values.Reviewers < 1 {
+		invalid = append(invalid, "reviewers must be positive")
+	}
+	if values.Concurrency < 1 {
+		invalid = append(invalid, "concurrency must be positive")
+	} else if values.Concurrency > values.Reviewers {
+		invalid = append(invalid, "concurrency cannot exceed reviewers")
+	}
+	if values.Timeout <= 0 {
+		invalid = append(invalid, "reviewer timeout must be positive")
+	}
+	if values.Retries < 0 {
+		invalid = append(invalid, "retries cannot be negative")
+	}
+	if len(values.ReviewerAgents) == 0 {
+		invalid = append(invalid, "at least one reviewer agent is required")
+	}
+	for i, name := range values.ReviewerAgents {
+		if strings.TrimSpace(name) == "" {
+			invalid = append(invalid, fmt.Sprintf("reviewer agent %d is empty", i+1))
+		}
+	}
+	if strings.TrimSpace(values.SummarizerAgent) == "" {
+		invalid = append(invalid, "summarizer agent is required")
+	}
+	if values.SummarizerTimeout <= 0 {
+		invalid = append(invalid, "summarizer timeout must be positive")
+	}
+	if values.FPFilterTimeout <= 0 {
+		invalid = append(invalid, "false-positive filter timeout must be positive")
+	}
+	if values.FPThreshold < 1 || values.FPThreshold > 100 {
+		invalid = append(invalid, "false-positive threshold must be between 1 and 100")
+	}
+	for _, pattern := range values.ExcludePatterns {
+		if _, err := regexp.Compile(pattern); err != nil {
+			invalid = append(invalid, fmt.Sprintf("invalid exclude pattern %q: %v", pattern, err))
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid review configuration: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return slices.Clone(values)
+}
+
+type ReviewFailure struct {
+	Phase   ReviewPhase
+	Message string
+}
+
+type SummarizerOutcome struct {
+	ExitCode         int
+	Stderr           string
+	DiagnosticOutput string
+	Duration         time.Duration
+}
+
+type ReviewFindingKind string
+
+const (
+	ReviewFindingActionable    ReviewFindingKind = "actionable"
+	ReviewFindingInformational ReviewFindingKind = "informational"
+)
+
+type ReviewFinding struct {
+	ID          string
+	Kind        ReviewFindingKind
+	Group       FindingGroup
+	Disposition Disposition
+}
+
+type FalsePositiveFilterOutcome struct {
+	Enabled    bool
+	Applied    bool
+	Skipped    bool
+	SkipReason string
+	EvalErrors int
+	Duration   time.Duration
+	Removed    []ReviewFinding
+}
+
+type ExcludeFilterOutcome struct {
+	Patterns []string
+	Removed  []ReviewFinding
+}
+
+type ReviewRun struct {
+	ID                       string
+	Target                   ReviewTarget
+	Trigger                  ReviewTrigger
+	Engine                   ReviewEngine
+	StartedAt                time.Time
+	CompletedAt              time.Time
+	Configuration            ReviewConfiguration
+	ConfigurationSource      ConfigurationSourceIdentity
+	ConfigurationFingerprint string
+	Status                   ReviewStatus
+	Conclusion               ReviewConclusion
+	Failure                  *ReviewFailure
+	ReviewerResults          []ReviewerResult
+	Stats                    ReviewStats
+	Summarizer               SummarizerOutcome
+	RawFindings              []Finding
+	AggregatedFindings       []AggregatedFinding
+	PreFilterSummary         GroupedFindings
+	FindingRecords           []ReviewFinding
+	Findings                 []ReviewFinding
+	Info                     []ReviewFinding
+	FalsePositiveFilter      FalsePositiveFilterOutcome
+	ExcludeFilter            ExcludeFilterOutcome
+	Dispositions             map[int]Disposition
+}
+
+func (r ReviewRun) FinalGroupedFindings() GroupedFindings {
+	grouped := GroupedFindings{
+		Findings: make([]FindingGroup, 0, len(r.Findings)),
+		Info:     make([]FindingGroup, 0, len(r.Info)),
+	}
+	for _, finding := range r.Findings {
+		grouped.Findings = append(grouped.Findings, finding.Group)
+	}
+	for _, finding := range r.Info {
+		grouped.Info = append(grouped.Info, finding.Group)
+	}
+	return grouped
+}

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -19,16 +19,26 @@ type PullRequestKey struct {
 	Number     int
 }
 
+var pullRequestHostPattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[0-9]{1,5})?$`)
+
+var pullRequestPathComponentPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
 func (k PullRequestKey) Validate() error {
 	var invalid []string
 	if strings.TrimSpace(k.Host) == "" {
 		invalid = append(invalid, "host is required")
+	} else if strings.TrimSpace(k.Host) != k.Host || !pullRequestHostPattern.MatchString(k.Host) {
+		invalid = append(invalid, "host contains invalid characters")
 	}
 	if strings.TrimSpace(k.Owner) == "" {
 		invalid = append(invalid, "owner is required")
+	} else if !validPullRequestPathComponent(k.Owner) {
+		invalid = append(invalid, "owner contains invalid characters")
 	}
 	if strings.TrimSpace(k.Repository) == "" {
 		invalid = append(invalid, "repository is required")
+	} else if !validPullRequestPathComponent(k.Repository) {
+		invalid = append(invalid, "repository contains invalid characters")
 	}
 	if k.Number < 1 {
 		invalid = append(invalid, "pull request number must be positive")
@@ -37,6 +47,10 @@ func (k PullRequestKey) Validate() error {
 		return fmt.Errorf("invalid pull request key: %s", strings.Join(invalid, "; "))
 	}
 	return nil
+}
+
+func validPullRequestPathComponent(value string) bool {
+	return strings.TrimSpace(value) == value && value != "." && value != ".." && pullRequestPathComponentPattern.MatchString(value)
 }
 
 func (k PullRequestKey) String() string {

--- a/internal/domain/review_test.go
+++ b/internal/domain/review_test.go
@@ -28,12 +28,17 @@ func validReviewConfigurationValues() ReviewConfigurationValues {
 }
 
 func TestPullRequestKeyValidate(t *testing.T) {
-	valid := PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
-	if err := valid.Validate(); err != nil {
-		t.Fatalf("valid key rejected: %v", err)
+	valid := []PullRequestKey{
+		{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42},
+		{Host: "github.example.com:8443", Owner: "owner-name", Repository: ".github", Number: 1},
 	}
-	if valid.String() != "github.com/owner/repo#42" {
-		t.Fatalf("unexpected key string %q", valid.String())
+	for _, key := range valid {
+		if err := key.Validate(); err != nil {
+			t.Fatalf("valid key rejected: %v", err)
+		}
+	}
+	if valid[0].String() != "github.com/owner/repo#42" {
+		t.Fatalf("unexpected key string %q", valid[0].String())
 	}
 
 	invalid := PullRequestKey{}
@@ -44,6 +49,23 @@ func TestPullRequestKeyValidate(t *testing.T) {
 	for _, part := range []string{"host", "owner", "repository", "number"} {
 		if !strings.Contains(err.Error(), part) {
 			t.Errorf("validation error %q does not mention %q", err, part)
+		}
+	}
+}
+
+func TestPullRequestKeyRejectsUnsafeComponents(t *testing.T) {
+	tests := []PullRequestKey{
+		{Host: "https://github.com", Owner: "owner", Repository: "repo", Number: 1},
+		{Host: "github.com/other", Owner: "owner", Repository: "repo", Number: 1},
+		{Host: "github.com", Owner: "..", Repository: "repo", Number: 1},
+		{Host: "github.com", Owner: "owner/replacement", Repository: "repo", Number: 1},
+		{Host: "github.com", Owner: "owner", Repository: "..", Number: 1},
+		{Host: "github.com", Owner: "owner", Repository: "repo/name", Number: 1},
+		{Host: "github.com", Owner: "owner", Repository: "%2F", Number: 1},
+	}
+	for _, key := range tests {
+		if err := key.Validate(); err == nil {
+			t.Errorf("unsafe key accepted: %#v", key)
 		}
 	}
 }

--- a/internal/domain/review_test.go
+++ b/internal/domain/review_test.go
@@ -1,0 +1,200 @@
+package domain
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func validReviewConfigurationValues() ReviewConfigurationValues {
+	return ReviewConfigurationValues{
+		Reviewers:         3,
+		Concurrency:       2,
+		Timeout:           time.Minute,
+		Retries:           1,
+		ReviewerAgents:    []string{"codex", "claude"},
+		ReviewerModel:     "review-model",
+		SummarizerAgent:   "codex",
+		SummarizerModel:   "summary-model",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		Guidance:          "focus on correctness",
+		FPFilterEnabled:   true,
+		FPThreshold:       75,
+		PRFeedbackEnabled: true,
+		ExcludePatterns:   []string{"generated/"},
+	}
+}
+
+func TestPullRequestKeyValidate(t *testing.T) {
+	valid := PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid key rejected: %v", err)
+	}
+	if valid.String() != "github.com/owner/repo#42" {
+		t.Fatalf("unexpected key string %q", valid.String())
+	}
+
+	invalid := PullRequestKey{}
+	err := invalid.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	for _, part := range []string{"host", "owner", "repository", "number"} {
+		if !strings.Contains(err.Error(), part) {
+			t.Errorf("validation error %q does not mention %q", err, part)
+		}
+	}
+}
+
+func TestReviewTargetAllowsLocalReviewWithoutPullRequest(t *testing.T) {
+	root := t.TempDir()
+	target := ReviewTarget{
+		RepositoryRoot: root,
+		WorktreeRoot:   filepath.Join(root, "worktree"),
+		Revision: RevisionEvidence{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "origin/main",
+		},
+	}
+
+	if err := target.Validate(); err != nil {
+		t.Fatalf("local target rejected: %v", err)
+	}
+}
+
+func TestReviewConfigurationIsImmutableAndFingerprintIsDeterministic(t *testing.T) {
+	values := validReviewConfigurationValues()
+	first, err := NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create first configuration: %v", err)
+	}
+	second, err := NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create second configuration: %v", err)
+	}
+	if first.Fingerprint() != second.Fingerprint() {
+		t.Fatalf("fingerprints differ: %q != %q", first.Fingerprint(), second.Fingerprint())
+	}
+
+	values.ReviewerAgents[0] = "changed"
+	values.ExcludePatterns[0] = "changed"
+	got := first.Values()
+	if got.ReviewerAgents[0] != "codex" {
+		t.Fatalf("reviewer agents changed through input alias: %v", got.ReviewerAgents)
+	}
+	if got.ExcludePatterns[0] != "generated/" {
+		t.Fatalf("exclude patterns changed through input alias: %v", got.ExcludePatterns)
+	}
+
+	got.ReviewerAgents[0] = "changed-again"
+	if first.Values().ReviewerAgents[0] != "codex" {
+		t.Fatal("configuration values exposed mutable reviewer agents")
+	}
+}
+
+func TestReviewConfigurationFingerprintChangesWithSemanticInput(t *testing.T) {
+	firstValues := validReviewConfigurationValues()
+	secondValues := validReviewConfigurationValues()
+	secondValues.FPThreshold = 90
+
+	first, err := NewReviewConfiguration(firstValues)
+	if err != nil {
+		t.Fatalf("create first configuration: %v", err)
+	}
+	second, err := NewReviewConfiguration(secondValues)
+	if err != nil {
+		t.Fatalf("create second configuration: %v", err)
+	}
+	if first.Fingerprint() == second.Fingerprint() {
+		t.Fatal("semantic configuration change did not alter fingerprint")
+	}
+}
+
+func TestReviewConfigurationRejectsInvalidInputs(t *testing.T) {
+	values := validReviewConfigurationValues()
+	values.Reviewers = 0
+	values.ExcludePatterns = []string{"["}
+
+	_, err := NewReviewConfiguration(values)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "reviewers") || !strings.Contains(err.Error(), "exclude") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestReviewConfigurationRequiresResolvedConcurrency(t *testing.T) {
+	tests := []struct {
+		name        string
+		concurrency int
+	}{
+		{name: "zero", concurrency: 0},
+		{name: "greater than reviewers", concurrency: 4},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values := validReviewConfigurationValues()
+			values.Concurrency = test.concurrency
+			_, err := NewReviewConfiguration(values)
+			if err == nil || !strings.Contains(err.Error(), "concurrency") {
+				t.Fatalf("expected concurrency validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestConfigurationSourceIdentityValidation(t *testing.T) {
+	valid := []ConfigurationSourceIdentity{
+		{Kind: "test", Locator: "fixture", ConfigPresent: true, ConfigDigest: "digest"},
+		{Kind: "repository-revision", Locator: "/repo", Ref: "main", Revision: "object"},
+		{Kind: "disabled", Locator: "--no-config"},
+		{Kind: "defaults", Locator: "configuration absent"},
+	}
+	for _, source := range valid {
+		if err := source.Validate(); err != nil {
+			t.Errorf("valid source %#v rejected: %v", source, err)
+		}
+	}
+
+	invalid := []ConfigurationSourceIdentity{
+		{},
+		{Kind: "test", ConfigPresent: true},
+		{Kind: "test", ConfigDigest: "digest"},
+	}
+	for _, source := range invalid {
+		if err := source.Validate(); err == nil {
+			t.Errorf("invalid source %#v accepted", source)
+		}
+	}
+}
+
+func TestReviewRunBuildsPresentationNeutralFinalGroups(t *testing.T) {
+	run := ReviewRun{
+		Findings: []ReviewFinding{{
+			ID:   "finding-001",
+			Kind: ReviewFindingActionable,
+			Group: FindingGroup{
+				Title: "Bug",
+			},
+		}},
+		Info: []ReviewFinding{{
+			ID:   "info-001",
+			Kind: ReviewFindingInformational,
+			Group: FindingGroup{
+				Title: "Note",
+			},
+		}},
+	}
+
+	grouped := run.FinalGroupedFindings()
+	if len(grouped.Findings) != 1 || grouped.Findings[0].Title != "Bug" {
+		t.Fatalf("unexpected actionable groups: %#v", grouped.Findings)
+	}
+	if len(grouped.Info) != 1 || grouped.Info[0].Title != "Note" {
+		t.Fatalf("unexpected informational groups: %#v", grouped.Info)
+	}
+}

--- a/internal/feedback/fetch.go
+++ b/internal/feedback/fetch.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strconv"
 	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 type PRContext struct {
@@ -33,19 +36,34 @@ func (p *PRContext) HasContent() bool {
 }
 
 func FetchPRContext(ctx context.Context, prNumber string) (*PRContext, error) {
+	return FetchPRContextFromDir(ctx, prNumber, "")
+}
+
+func FetchPRContextFromDir(ctx context.Context, prNumber, workDir string) (*PRContext, error) {
+	return fetchPRContext(ctx, prNumber, workDir, nil)
+}
+
+func FetchPRContextForPullRequest(ctx context.Context, key domain.PullRequestKey, workDir string) (*PRContext, error) {
+	if err := key.Validate(); err != nil {
+		return nil, err
+	}
+	return fetchPRContext(ctx, strconv.Itoa(key.Number), workDir, &key)
+}
+
+func fetchPRContext(ctx context.Context, prNumber, workDir string, key *domain.PullRequestKey) (*PRContext, error) {
 	if prNumber == "" {
 		return nil, errors.New("PR number is required")
 	}
 
 	result := &PRContext{Number: prNumber}
 
-	desc, err := fetchPRDescription(ctx, prNumber)
+	desc, err := fetchPRDescription(ctx, prNumber, workDir, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch PR description: %w", err)
 	}
 	result.Description = desc
 
-	comments, err := fetchPRComments(ctx, prNumber)
+	comments, err := fetchPRComments(ctx, prNumber, workDir, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch PR comments: %w", err)
 	}
@@ -54,8 +72,13 @@ func FetchPRContext(ctx context.Context, prNumber string) (*PRContext, error) {
 	return result, nil
 }
 
-func fetchPRDescription(ctx context.Context, prNumber string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "body", "--jq", ".body")
+func fetchPRDescription(ctx context.Context, prNumber, workDir string, key *domain.PullRequestKey) (string, error) {
+	args := []string{"pr", "view", prNumber, "--json", "body", "--jq", ".body"}
+	if key != nil {
+		args = append(args, "--repo", repositorySelector(*key))
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = workDir
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -70,11 +93,12 @@ type prCommentResponse struct {
 	Body string `json:"body"`
 }
 
-func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
+func fetchPRComments(ctx context.Context, prNumber, workDir string, key *domain.PullRequestKey) ([]Comment, error) {
 	var comments []Comment
 
-	endpoint := "repos/{owner}/{repo}/pulls/" + prNumber + "/comments"
-	cmd := exec.CommandContext(ctx, "gh", "api", "--paginate", "--jq", ".[]", endpoint)
+	endpoint := pullRequestEndpoint(key, "pulls/"+prNumber+"/comments")
+	cmd := exec.CommandContext(ctx, "gh", apiArgs(key, endpoint)...)
+	cmd.Dir = workDir
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch review comments: %w", err)
@@ -94,8 +118,9 @@ func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
 		}
 	}
 
-	endpoint = "repos/{owner}/{repo}/issues/" + prNumber + "/comments"
-	cmd = exec.CommandContext(ctx, "gh", "api", "--paginate", "--jq", ".[]", endpoint)
+	endpoint = pullRequestEndpoint(key, "issues/"+prNumber+"/comments")
+	cmd = exec.CommandContext(ctx, "gh", apiArgs(key, endpoint)...)
+	cmd.Dir = workDir
 	out, err = cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch issue comments: %w", err)
@@ -115,8 +140,9 @@ func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
 		}
 	}
 
-	endpoint = "repos/{owner}/{repo}/pulls/" + prNumber + "/reviews"
-	cmd = exec.CommandContext(ctx, "gh", "api", "--paginate", "--jq", ".[]", endpoint)
+	endpoint = pullRequestEndpoint(key, "pulls/"+prNumber+"/reviews")
+	cmd = exec.CommandContext(ctx, "gh", apiArgs(key, endpoint)...)
+	cmd.Dir = workDir
 	out, err = cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch review summaries: %w", err)
@@ -137,6 +163,25 @@ func fetchPRComments(ctx context.Context, prNumber string) ([]Comment, error) {
 	}
 
 	return comments, nil
+}
+
+func repositorySelector(key domain.PullRequestKey) string {
+	return key.Host + "/" + key.Owner + "/" + key.Repository
+}
+
+func pullRequestEndpoint(key *domain.PullRequestKey, suffix string) string {
+	if key == nil {
+		return "repos/{owner}/{repo}/" + suffix
+	}
+	return "repos/" + key.Owner + "/" + key.Repository + "/" + suffix
+}
+
+func apiArgs(key *domain.PullRequestKey, endpoint string) []string {
+	args := []string{"api"}
+	if key != nil {
+		args = append(args, "--hostname", key.Host)
+	}
+	return append(args, "--paginate", "--jq", ".[]", endpoint)
 }
 
 func parseNDJSON(data []byte) ([]prCommentResponse, error) {

--- a/internal/feedback/fetch_test.go
+++ b/internal/feedback/fetch_test.go
@@ -3,8 +3,11 @@ package feedback
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 func TestFetchPRContext_NoPRNumber(t *testing.T) {
@@ -12,6 +15,27 @@ func TestFetchPRContext_NoPRNumber(t *testing.T) {
 	_, err := FetchPRContext(ctx, "")
 	if err == nil {
 		t.Error("expected error for empty PR number")
+	}
+}
+
+func TestPullRequestScopeUsesGlobalKey(t *testing.T) {
+	key := domain.PullRequestKey{Host: "github.example.com", Owner: "owner", Repository: "repo", Number: 42}
+	if repositorySelector(key) != "github.example.com/owner/repo" {
+		t.Fatalf("unexpected repository selector %q", repositorySelector(key))
+	}
+	endpoint := pullRequestEndpoint(&key, "pulls/42/comments")
+	if endpoint != "repos/owner/repo/pulls/42/comments" {
+		t.Fatalf("unexpected endpoint %q", endpoint)
+	}
+	wantArgs := []string{"api", "--hostname", "github.example.com", "--paginate", "--jq", ".[]", endpoint}
+	if got := apiArgs(&key, endpoint); !slices.Equal(got, wantArgs) {
+		t.Fatalf("API args = %v, want %v", got, wantArgs)
+	}
+}
+
+func TestFetchPRContextForPullRequestRejectsInvalidKey(t *testing.T) {
+	if _, err := FetchPRContextForPullRequest(context.Background(), domain.PullRequestKey{}, ""); err == nil {
+		t.Fatal("expected invalid pull request key error")
 	}
 }
 

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -71,9 +71,7 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 		return "", fmt.Errorf("agent execution failed: %w", err)
 	}
 	defer func() {
-		if err := execResult.Close(); err != nil && s.verbose {
-			s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
-		}
+		s.logCloseError(execResult.Close())
 	}()
 
 	output, err := io.ReadAll(execResult)
@@ -93,6 +91,12 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 	}
 
 	return summary, nil
+}
+
+func (s *Summarizer) logCloseError(err error) {
+	if err != nil && s.verbose && s.logger != nil {
+		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
+	}
 }
 
 func (s *Summarizer) buildInput(prCtx *PRContext) string {

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -40,7 +41,7 @@ func (s *Summarizer) SummarizeFromDir(ctx context.Context, prNumber, workDir str
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
-	return s.summarizeContext(ctx, prCtx)
+	return s.summarizeContext(ctx, prCtx, workDir)
 }
 
 func (s *Summarizer) SummarizePullRequest(ctx context.Context, key domain.PullRequestKey, workDir string) (string, error) {
@@ -48,10 +49,10 @@ func (s *Summarizer) SummarizePullRequest(ctx context.Context, key domain.PullRe
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
-	return s.summarizeContext(ctx, prCtx)
+	return s.summarizeContext(ctx, prCtx, workDir)
 }
 
-func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (string, error) {
+func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext, workDir string) (string, error) {
 	if !prCtx.HasContent() {
 		return "", nil
 	}
@@ -63,23 +64,20 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 		return "", fmt.Errorf("failed to create agent: %w", err)
 	}
 
-	execResult, err := ag.ExecuteSummary(ctx, summarizePrompt, []byte(input))
+	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: summarizePrompt, Input: []byte(input), WorkDir: workDir})
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
 		return "", fmt.Errorf("agent execution failed: %w", err)
 	}
-	defer func() {
-		s.logCloseError(execResult.Close())
-	}()
-
 	output, err := io.ReadAll(execResult)
+	closeErr := execResult.Close()
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", ctx.Err()
+			return "", errors.Join(ctx.Err(), closeErr)
 		}
-		return "", fmt.Errorf("failed to read agent output: %w", err)
+		return "", errors.Join(fmt.Errorf("failed to read agent output: %w", err), closeErr)
 	}
 
 	summary := strings.TrimSpace(string(output))
@@ -87,16 +85,21 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (st
 	summary = agent.StripMarkdownCodeFence(summary)
 
 	if strings.Contains(strings.ToLower(summary), "no prior feedback") {
-		return "", nil
+		summary = ""
 	}
 
-	return summary, nil
+	return summary, s.handleCloseError(closeErr)
 }
 
-func (s *Summarizer) logCloseError(err error) {
-	if err != nil && s.verbose && s.logger != nil {
-		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
+func (s *Summarizer) handleCloseError(err error) error {
+	if err == nil {
+		return nil
 	}
+	if s.verbose && s.logger != nil {
+		s.logger.Logf(terminal.StyleDim, "feedback close error (non-fatal): %v", err)
+		return nil
+	}
+	return fmt.Errorf("feedback cleanup failed: %w", err)
 }
 
 func (s *Summarizer) buildInput(prCtx *PRContext) string {

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
 
@@ -27,15 +28,30 @@ func NewSummarizer(agentName, model string, verbose bool, logger *terminal.Logge
 }
 
 func (s *Summarizer) Summarize(ctx context.Context, prNumber string) (string, error) {
+	return s.SummarizeFromDir(ctx, prNumber, "")
+}
+
+func (s *Summarizer) SummarizeFromDir(ctx context.Context, prNumber, workDir string) (string, error) {
 	if prNumber == "" {
 		return "", fmt.Errorf("PR number is required")
 	}
 
-	prCtx, err := FetchPRContext(ctx, prNumber)
+	prCtx, err := FetchPRContextFromDir(ctx, prNumber, workDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch PR context: %w", err)
 	}
+	return s.summarizeContext(ctx, prCtx)
+}
 
+func (s *Summarizer) SummarizePullRequest(ctx context.Context, key domain.PullRequestKey, workDir string) (string, error) {
+	prCtx, err := FetchPRContextForPullRequest(ctx, key, workDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch PR context: %w", err)
+	}
+	return s.summarizeContext(ctx, prCtx)
+}
+
+func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext) (string, error) {
 	if !prCtx.HasContent() {
 		return "", nil
 	}

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -26,7 +26,9 @@ func TestNewSummarizer(t *testing.T) {
 
 func TestSummarizerCloseErrorWithNilLoggerDoesNotPanic(t *testing.T) {
 	s := NewSummarizer("codex", "", true, nil)
-	s.logCloseError(errors.New("cleanup failed"))
+	if err := s.handleCloseError(errors.New("cleanup failed")); err == nil {
+		t.Fatal("handleCloseError succeeded")
+	}
 }
 
 func TestBuildInput_DescriptionOnly(t *testing.T) {

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -21,6 +22,11 @@ func TestNewSummarizer(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewSummarizer returned nil")
 	}
+}
+
+func TestSummarizerCloseErrorWithNilLoggerDoesNotPanic(t *testing.T) {
+	s := NewSummarizer("codex", "", true, nil)
+	s.logCloseError(errors.New("cleanup failed"))
 }
 
 func TestBuildInput_DescriptionOnly(t *testing.T) {

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -3,6 +3,7 @@ package fpfilter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
@@ -28,6 +29,7 @@ type Result struct {
 	EvalErrors   int
 	Skipped      bool
 	SkipReason   string
+	Warnings     []string
 }
 
 type Filter struct {
@@ -35,11 +37,12 @@ type Filter struct {
 	model     string
 	agent     agent.Agent
 	threshold int
+	workDir   string
 	verbose   bool
 	logger    *terminal.Logger
 }
 
-func New(agentName, model string, threshold int, verbose bool, logger *terminal.Logger) *Filter {
+func New(agentName, model string, threshold int, workDir string, verbose bool, logger *terminal.Logger) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
@@ -47,19 +50,26 @@ func New(agentName, model string, threshold int, verbose bool, logger *terminal.
 		agentName: agentName,
 		model:     model,
 		threshold: threshold,
+		workDir:   workDir,
 		logger:    logger,
 		verbose:   verbose,
 	}
 }
 
-func NewWithAgent(ag agent.Agent, threshold int) *Filter {
+func NewWithAgent(ag agent.Agent, threshold int, workDir string) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
 	return &Filter{
 		agent:     ag,
 		threshold: threshold,
+		workDir:   workDir,
 	}
+}
+
+func withWarnings(result *Result, warnings []string) *Result {
+	result.Warnings = append([]string(nil), warnings...)
+	return result
 }
 
 func skippedResult(grouped domain.GroupedFindings, start time.Time, reason string) *Result {
@@ -148,7 +158,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 	}
 
 	prompt := buildPromptWithFeedback(fpEvaluationPrompt, priorFeedback)
-	execResult, err := ag.ExecuteSummary(ctx, prompt, payload)
+	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: prompt, Input: payload, WorkDir: f.workDir})
 	if err != nil {
 		if ctx.Err() != nil {
 			return skippedResult(grouped, start, "context canceled")
@@ -156,35 +166,36 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		return skippedResult(grouped, start, "LLM execution failed: "+err.Error())
 	}
 
-	defer func() {
-		if err := execResult.Close(); err != nil && f.verbose && f.logger != nil {
-			f.logger.Logf(terminal.StyleDim, "fp-filter close error (non-fatal): %v", err)
-		}
-	}()
-
 	output, err := io.ReadAll(execResult)
+	var warnings []string
+	if closeErr := execResult.Close(); closeErr != nil {
+		warnings = append(warnings, fmt.Sprintf("false-positive filter cleanup failed: %v", closeErr))
+		if f.verbose && f.logger != nil {
+			f.logger.Logf(terminal.StyleDim, "fp-filter close error (non-fatal): %v", closeErr)
+		}
+	}
 	if err != nil {
 		if ctx.Err() != nil {
-			return skippedResult(grouped, start, "context canceled")
+			return withWarnings(skippedResult(grouped, start, "context canceled"), warnings)
 		}
-		return skippedResult(grouped, start, "response read failed: "+err.Error())
+		return withWarnings(skippedResult(grouped, start, "response read failed: "+err.Error()), warnings)
 	}
 
 	parser, err := agent.NewSummaryParser(ag.Name())
 	if err != nil {
-		return skippedResult(grouped, start, "parser creation failed: "+err.Error())
+		return withWarnings(skippedResult(grouped, start, "parser creation failed: "+err.Error()), warnings)
 	}
 
 	responseText, err := parser.ExtractText(output)
 	if err != nil {
-		return skippedResult(grouped, start, "response extraction failed: "+err.Error())
+		return withWarnings(skippedResult(grouped, start, "response extraction failed: "+err.Error()), warnings)
 	}
 
 	var response evaluationResponse
 	if err := json.Unmarshal([]byte(responseText), &response); err != nil {
 		r := skippedResult(grouped, start, "response parse failed: "+err.Error())
 		r.EvalErrors = len(grouped.Findings)
-		return r
+		return withWarnings(r, warnings)
 	}
 
 	evalMap := make(map[int]findingEvaluation)
@@ -218,7 +229,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		}
 	}
 
-	return &Result{
+	return withWarnings(&Result{
 		Grouped: domain.GroupedFindings{
 			Findings: kept,
 			Info:     grouped.Info,
@@ -227,5 +238,5 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		RemovedCount: len(removed),
 		Duration:     time.Since(start),
 		EvalErrors:   evalErrors,
-	}
+	}, warnings)
 }

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -32,6 +32,7 @@ type Result struct {
 type Filter struct {
 	agentName string
 	model     string
+	agent     agent.Agent
 	threshold int
 	verbose   bool
 	logger    *terminal.Logger
@@ -47,6 +48,16 @@ func New(agentName, model string, threshold int, verbose bool, logger *terminal.
 		threshold: threshold,
 		logger:    logger,
 		verbose:   verbose,
+	}
+}
+
+func NewWithAgent(ag agent.Agent, threshold int) *Filter {
+	if threshold < 1 || threshold > 100 {
+		threshold = DefaultThreshold
+	}
+	return &Filter{
+		agent:     ag,
+		threshold: threshold,
 	}
 }
 
@@ -108,9 +119,13 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		}
 	}
 
-	ag, err := agent.NewAgentWithModel(f.agentName, f.model)
-	if err != nil {
-		return skippedResult(grouped, start, "agent creation failed: "+err.Error())
+	ag := f.agent
+	if ag == nil {
+		var err error
+		ag, err = agent.NewAgentWithModel(f.agentName, f.model)
+		if err != nil {
+			return skippedResult(grouped, start, "agent creation failed: "+err.Error())
+		}
 	}
 
 	req := evaluationRequest{
@@ -141,7 +156,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 	}
 
 	defer func() {
-		if err := execResult.Close(); err != nil && f.verbose {
+		if err := execResult.Close(); err != nil && f.verbose && f.logger != nil {
 			f.logger.Logf(terminal.StyleDim, "fp-filter close error (non-fatal): %v", err)
 		}
 	}()
@@ -154,7 +169,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		return skippedResult(grouped, start, "response read failed: "+err.Error())
 	}
 
-	parser, err := agent.NewSummaryParser(f.agentName)
+	parser, err := agent.NewSummaryParser(ag.Name())
 	if err != nil {
 		return skippedResult(grouped, start, "parser creation failed: "+err.Error())
 	}

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -14,6 +14,7 @@ import (
 const DefaultThreshold = 75
 
 type EvaluatedFinding struct {
+	Index     int
 	Finding   domain.FindingGroup
 	FPScore   int
 	Reasoning string
@@ -207,6 +208,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 
 		if adjusted >= f.threshold {
 			removed = append(removed, EvaluatedFinding{
+				Index:     i,
 				Finding:   finding,
 				FPScore:   adjusted,
 				Reasoning: eval.Reasoning,

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFilter_New(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	if f == nil {
 		t.Fatal("New returned nil")
 	}
@@ -183,7 +183,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := New("codex", "", tt.threshold, false, logger)
+			f := New("codex", "", tt.threshold, "", false, logger)
 			if f.threshold != tt.expectedThreshold {
 				t.Errorf("threshold = %d, want %d", f.threshold, tt.expectedThreshold)
 			}
@@ -192,7 +192,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 }
 
 func TestApply_EmptyFindings(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -217,7 +217,7 @@ func TestApply_EmptyFindings(t *testing.T) {
 }
 
 func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -231,7 +231,7 @@ func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
 }
 
 func TestApply_EmptyFindingsPreservesInfo(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", 75, "", false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 		Info: []domain.FindingGroup{

--- a/internal/review/events.go
+++ b/internal/review/events.go
@@ -46,13 +46,14 @@ func (f EventSinkFunc) HandleReviewEvent(event Event) {
 }
 
 type eventEmitter struct {
-	mu       sync.Mutex
-	sink     EventSink
-	now      func() time.Time
-	runID    string
-	sequence uint64
-	closed   bool
-	open     []domain.ReviewPhase
+	mu               sync.Mutex
+	sink             EventSink
+	now              func() time.Time
+	runID            string
+	sequence         uint64
+	closed           bool
+	open             []domain.ReviewPhase
+	beforeCompletion func()
 }
 
 func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventEmitter {
@@ -60,7 +61,13 @@ func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventE
 }
 
 func (e *eventEmitter) emit(event Event) {
-	if e == nil || e.sink == nil {
+	if e == nil {
+		return
+	}
+	if event.Kind == EventRunCompleted {
+		e.runBeforeCompletion()
+	}
+	if e.sink == nil {
 		return
 	}
 	e.mu.Lock()
@@ -74,6 +81,25 @@ func (e *eventEmitter) emit(event Event) {
 		}
 	}
 	e.emitLocked(event)
+}
+
+func (e *eventEmitter) setBeforeCompletion(fn func()) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.beforeCompletion = fn
+	e.mu.Unlock()
+}
+
+func (e *eventEmitter) runBeforeCompletion() {
+	e.mu.Lock()
+	fn := e.beforeCompletion
+	e.beforeCompletion = nil
+	e.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 func (e *eventEmitter) emitLocked(event Event) {

--- a/internal/review/events.go
+++ b/internal/review/events.go
@@ -1,0 +1,84 @@
+package review
+
+import (
+	"sync"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type EventKind string
+
+const (
+	EventRunStarted        EventKind = "run_started"
+	EventPhaseStarted      EventKind = "phase_started"
+	EventPhaseCompleted    EventKind = "phase_completed"
+	EventWarning           EventKind = "warning"
+	EventReviewerStarted   EventKind = "reviewer_started"
+	EventReviewerOutput    EventKind = "reviewer_output"
+	EventReviewerRetrying  EventKind = "reviewer_retrying"
+	EventReviewerCompleted EventKind = "reviewer_completed"
+	EventRunCompleted      EventKind = "run_completed"
+)
+
+type Event struct {
+	Sequence       uint64
+	At             time.Time
+	RunID          string
+	Kind           EventKind
+	Phase          domain.ReviewPhase
+	Message        string
+	ReviewerID     int
+	AgentName      string
+	ReviewerResult domain.ReviewerResult
+	Status         domain.ReviewStatus
+	Conclusion     domain.ReviewConclusion
+}
+
+type EventSink interface {
+	HandleReviewEvent(Event)
+}
+
+type EventSinkFunc func(Event)
+
+func (f EventSinkFunc) HandleReviewEvent(event Event) {
+	f(event)
+}
+
+type eventEmitter struct {
+	mu       sync.Mutex
+	sink     EventSink
+	now      func() time.Time
+	runID    string
+	sequence uint64
+	closed   bool
+}
+
+func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventEmitter {
+	return &eventEmitter{sink: sink, now: now, runID: runID}
+}
+
+func (e *eventEmitter) emit(event Event) {
+	if e == nil || e.sink == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return
+	}
+	e.sequence++
+	event.Sequence = e.sequence
+	event.At = e.now()
+	event.RunID = e.runID
+	e.sink.HandleReviewEvent(event)
+}
+
+func (e *eventEmitter) close() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.closed = true
+	e.mu.Unlock()
+}

--- a/internal/review/events.go
+++ b/internal/review/events.go
@@ -52,6 +52,7 @@ type eventEmitter struct {
 	runID    string
 	sequence uint64
 	closed   bool
+	open     []domain.ReviewPhase
 }
 
 func newEventEmitter(sink EventSink, now func() time.Time, runID string) *eventEmitter {
@@ -67,11 +68,46 @@ func (e *eventEmitter) emit(event Event) {
 	if e.closed {
 		return
 	}
+	if event.Kind == EventRunCompleted {
+		for len(e.open) > 0 {
+			e.emitLocked(Event{Kind: EventPhaseCompleted, Phase: e.open[0]})
+		}
+	}
+	e.emitLocked(event)
+}
+
+func (e *eventEmitter) emitLocked(event Event) {
+	if event.Kind == EventPhaseStarted {
+		if !e.phaseOpen(event.Phase) {
+			e.open = append(e.open, event.Phase)
+		}
+	}
+	if event.Kind == EventPhaseCompleted {
+		e.closePhase(event.Phase)
+	}
 	e.sequence++
 	event.Sequence = e.sequence
 	event.At = e.now()
 	event.RunID = e.runID
 	e.sink.HandleReviewEvent(event)
+}
+
+func (e *eventEmitter) phaseOpen(phase domain.ReviewPhase) bool {
+	for _, candidate := range e.open {
+		if candidate == phase {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *eventEmitter) closePhase(phase domain.ReviewPhase) {
+	for i, candidate := range e.open {
+		if candidate == phase {
+			e.open = append(e.open[:i], e.open[i+1:]...)
+			return
+		}
+	}
 }
 
 func (e *eventEmitter) close() {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -1,0 +1,782 @@
+package review
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/feedback"
+	"github.com/richhaase/agentic-code-reviewer/internal/filter"
+	"github.com/richhaase/agentic-code-reviewer/internal/fpfilter"
+	"github.com/richhaase/agentic-code-reviewer/internal/git"
+	"github.com/richhaase/agentic-code-reviewer/internal/runner"
+	"github.com/richhaase/agentic-code-reviewer/internal/summarizer"
+)
+
+type Request struct {
+	Target              domain.ReviewTarget
+	Trigger             domain.ReviewTrigger
+	Engine              domain.ReviewEngine
+	Configuration       domain.ReviewConfiguration
+	ConfigurationSource domain.ConfigurationSourceIdentity
+	Events              EventSink
+}
+
+type AgentFactory func(string, string) (agent.Agent, error)
+
+type RevisionProvider func(context.Context, domain.ReviewTarget) (domain.RevisionEvidence, error)
+
+type DiffProvider func(context.Context, domain.ReviewTarget) (string, error)
+
+type PriorFeedbackProvider func(context.Context, domain.ReviewTarget, string, string) (string, error)
+
+type RunIDGenerator func(time.Time) (string, error)
+
+type Option func(*serviceDependencies)
+
+type serviceDependencies struct {
+	now           func() time.Time
+	newRunID      RunIDGenerator
+	newAgent      AgentFactory
+	revisions     RevisionProvider
+	diff          DiffProvider
+	priorFeedback PriorFeedbackProvider
+}
+
+type Service struct {
+	dependencies serviceDependencies
+}
+
+func NewService(options ...Option) (*Service, error) {
+	dependencies := serviceDependencies{
+		now:           time.Now,
+		newRunID:      defaultRunID,
+		newAgent:      agent.NewAgentWithModel,
+		revisions:     resolveRevisions,
+		diff:          loadDiff,
+		priorFeedback: summarizePriorFeedback,
+	}
+	for _, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("review service option cannot be nil")
+		}
+		option(&dependencies)
+	}
+	if dependencies.now == nil || dependencies.newRunID == nil || dependencies.newAgent == nil || dependencies.revisions == nil || dependencies.diff == nil || dependencies.priorFeedback == nil {
+		return nil, fmt.Errorf("review service dependencies must not be nil")
+	}
+	return &Service{dependencies: dependencies}, nil
+}
+
+func WithClock(now func() time.Time) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.now = now
+	}
+}
+
+func WithRunIDGenerator(generator RunIDGenerator) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.newRunID = generator
+	}
+}
+
+func WithAgentFactory(factory AgentFactory) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.newAgent = factory
+	}
+}
+
+func WithRevisionProvider(provider RevisionProvider) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.revisions = provider
+	}
+}
+
+func WithDiffProvider(provider DiffProvider) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.diff = provider
+	}
+}
+
+func WithPriorFeedbackProvider(provider PriorFeedbackProvider) Option {
+	return func(dependencies *serviceDependencies) {
+		dependencies.priorFeedback = provider
+	}
+}
+
+func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("review service is required")
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("review context is required")
+	}
+	if err := validateRequest(request); err != nil {
+		return nil, err
+	}
+
+	startedAt := s.dependencies.now()
+	runID, err := s.dependencies.newRunID(startedAt)
+	if err != nil {
+		return nil, fmt.Errorf("create review run ID: %w", err)
+	}
+	if strings.TrimSpace(runID) == "" {
+		return nil, fmt.Errorf("create review run ID: empty ID")
+	}
+
+	run := &domain.ReviewRun{
+		ID:                       runID,
+		Target:                   request.Target.Clone(),
+		Trigger:                  request.Trigger,
+		Engine:                   request.Engine,
+		StartedAt:                startedAt,
+		Configuration:            request.Configuration,
+		ConfigurationSource:      request.ConfigurationSource,
+		ConfigurationFingerprint: request.Configuration.Fingerprint(),
+	}
+	emitter := newEventEmitter(request.Events, s.dependencies.now, runID)
+	emitter.emit(Event{Kind: EventRunStarted})
+
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseInitialization, err, emitter), nil
+	}
+
+	values := request.Configuration.Values()
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseInitialization})
+	reviewAgents, summarizerAgent, err := s.initializeAgents(values)
+	if err != nil {
+		return s.fail(run, domain.ReviewPhaseInitialization, err, emitter), nil
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseInitialization})
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseInitialization, err, emitter), nil
+	}
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseRevisions})
+	revision, err := s.dependencies.revisions(ctx, run.Target)
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseRevisions, err, ctx, emitter), nil
+	}
+	if err := validateResolvedRevision(run.Target.Revision, revision); err != nil {
+		return s.fail(run, domain.ReviewPhaseRevisions, err, emitter), nil
+	}
+	run.Target.Revision = revision
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseRevisions})
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseRevisions, err, emitter), nil
+	}
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseDiff})
+	diff, err := s.dependencies.diff(ctx, run.Target)
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseDiff, err, ctx, emitter), nil
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseDiff})
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseDiff, err, emitter), nil
+	}
+	if diff == "" {
+		return s.complete(run, domain.ReviewConclusionNoChanges, emitter), nil
+	}
+
+	feedbackTask := s.startPriorFeedback(ctx, run.Target, values, emitter)
+	if feedbackTask != nil {
+		defer feedbackTask.stop()
+	}
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseReviewers})
+	reviewerEvents := runner.Events{
+		ReviewerStarted: func(reviewerID int, agentName string) {
+			emitter.emit(Event{Kind: EventReviewerStarted, Phase: domain.ReviewPhaseReviewers, ReviewerID: reviewerID, AgentName: agentName})
+		},
+		ReviewerOutput: func(reviewerID int, output string) {
+			emitter.emit(Event{Kind: EventReviewerOutput, Phase: domain.ReviewPhaseReviewers, ReviewerID: reviewerID, Message: output})
+		},
+		ReviewerRetrying: func(reviewerID int, reason string, attempt, retries int, delay time.Duration) {
+			message := fmt.Sprintf("%s; retry %d/%d in %s", reason, attempt, retries, delay)
+			emitter.emit(Event{Kind: EventReviewerRetrying, Phase: domain.ReviewPhaseReviewers, ReviewerID: reviewerID, Message: message})
+		},
+		ReviewerCompleted: func(result domain.ReviewerResult) {
+			for _, warning := range result.Warnings {
+				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, ReviewerID: result.ReviewerID, AgentName: result.AgentName, Message: warning.Message})
+			}
+			emitter.emit(Event{Kind: EventReviewerCompleted, Phase: domain.ReviewPhaseReviewers, ReviewerID: result.ReviewerID, AgentName: result.AgentName, ReviewerResult: cloneReviewerResult(result)})
+		},
+	}
+	reviewRunner, err := runner.NewHeadless(runner.Config{
+		Reviewers:       values.Reviewers,
+		Concurrency:     values.Concurrency,
+		BaseRef:         run.Target.Revision.ResolvedBaseRef,
+		Timeout:         values.Timeout,
+		Retries:         values.Retries,
+		WorkDir:         run.Target.WorktreeRoot,
+		Guidance:        values.Guidance,
+		UseRefFile:      values.UseRefFile,
+		Diff:            diff,
+		DiffPrecomputed: agent.AgentsNeedDiff(reviewAgents),
+		Events:          reviewerEvents,
+	}, reviewAgents)
+	if err != nil {
+		return s.fail(run, domain.ReviewPhaseReviewers, err, emitter), nil
+	}
+	results, wallClock, err := reviewRunner.Run(ctx)
+	run.ReviewerResults = cloneReviewerResults(results)
+	run.Stats = runner.BuildStats(results, values.Reviewers, wallClock)
+	run.RawFindings = cloneFindings(runner.CollectFindings(results))
+	run.AggregatedFindings = cloneAggregatedFindings(domain.AggregateFindings(run.RawFindings))
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseReviewers})
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseReviewers, err, ctx, emitter), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseReviewers, err, emitter), nil
+	}
+	if run.Stats.AllFailed() {
+		return s.fail(run, domain.ReviewPhaseReviewers, fmt.Errorf("all reviewers failed"), emitter), nil
+	}
+	s.emitReviewerWarnings(run.Stats, emitter)
+
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseSummarization})
+	summaryCtx, summaryCancel := context.WithTimeout(ctx, values.SummarizerTimeout)
+	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings)
+	summaryCancel()
+	if summaryResult != nil {
+		run.Stats.SummarizerDuration = summaryResult.Duration
+		run.Summarizer = domain.SummarizerOutcome{
+			ExitCode: summaryResult.ExitCode,
+			Stderr:   boundedSummaryEvidence(summaryResult.Stderr),
+			Duration: summaryResult.Duration,
+		}
+		if summaryResult.ExitCode != 0 {
+			run.Summarizer.DiagnosticOutput = boundedSummaryEvidence(summaryResult.RawOut)
+		}
+		run.PreFilterSummary = cloneGroupedFindings(summaryResult.Grouped)
+		initializeRunFindingRecords(run)
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseSummarization})
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseSummarization, err, ctx, emitter), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseSummarization, err, emitter), nil
+	}
+	if summaryResult == nil {
+		return s.fail(run, domain.ReviewPhaseSummarization, fmt.Errorf("summarizer returned no result"), emitter), nil
+	}
+	if summaryResult.ExitCode != 0 {
+		message := strings.TrimSpace(run.Summarizer.Stderr)
+		if message == "" {
+			message = fmt.Sprintf("summarizer exited with code %d", summaryResult.ExitCode)
+		}
+		if ctx.Err() != nil {
+			return s.interrupt(run, domain.ReviewPhaseSummarization, ctx.Err(), emitter), nil
+		}
+		return s.fail(run, domain.ReviewPhaseSummarization, errors.New(message), emitter), nil
+	}
+
+	priorFeedback, err := feedbackTask.receive(ctx, emitter)
+	if err != nil {
+		return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
+	}
+	finalGrouped := cloneGroupedFindings(run.PreFilterSummary)
+	var fpRemoved []domain.FPRemovedInfo
+	var fpRemovedGroups []domain.FindingGroup
+	run.FalsePositiveFilter.Enabled = values.FPFilterEnabled
+	if values.FPFilterEnabled && len(finalGrouped.Findings) > 0 {
+		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
+		fpCtx, fpCancel := context.WithTimeout(ctx, values.FPFilterTimeout)
+		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
+		fpCancel()
+		if fpResult != nil {
+			finalGrouped = cloneGroupedFindings(fpResult.Grouped)
+			run.FalsePositiveFilter.Applied = !fpResult.Skipped
+			run.FalsePositiveFilter.Skipped = fpResult.Skipped
+			run.FalsePositiveFilter.SkipReason = fpResult.SkipReason
+			run.FalsePositiveFilter.EvalErrors = fpResult.EvalErrors
+			run.FalsePositiveFilter.Duration = fpResult.Duration
+			run.Stats.FPFilterDuration = fpResult.Duration
+			run.Stats.FPFilteredCount = fpResult.RemovedCount
+			for _, removed := range fpResult.Removed {
+				fpRemovedGroups = append(fpRemovedGroups, cloneFindingGroup(removed.Finding))
+				fpRemoved = append(fpRemoved, domain.FPRemovedInfo{
+					Sources:   slices.Clone(removed.Finding.Sources),
+					FPScore:   removed.FPScore,
+					Reasoning: removed.Reasoning,
+					Title:     removed.Finding.Title,
+				})
+			}
+			if fpResult.Skipped {
+				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFalsePositiveFilter, Message: "false-positive filter skipped: " + fpResult.SkipReason})
+			}
+		}
+		emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFalsePositiveFilter})
+		if err := ctx.Err(); err != nil {
+			run.Dispositions = domain.BuildDispositions(
+				len(run.AggregatedFindings),
+				run.PreFilterSummary.Info,
+				fpRemoved,
+				nil,
+				finalGrouped.Findings,
+			)
+			populateRunFindings(run, finalGrouped, fpRemovedGroups, nil, fpRemoved)
+			return s.interrupt(run, domain.ReviewPhaseFalsePositiveFilter, err, emitter), nil
+		}
+	}
+
+	var excludeRemoved []domain.FindingGroup
+	run.ExcludeFilter.Patterns = slices.Clone(values.ExcludePatterns)
+	if len(values.ExcludePatterns) > 0 {
+		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseExcludeFilter})
+		exclude, err := filter.New(values.ExcludePatterns)
+		if err != nil {
+			return s.fail(run, domain.ReviewPhaseExcludeFilter, err, emitter), nil
+		}
+		before := cloneGroupedFindings(finalGrouped)
+		finalGrouped = exclude.Apply(finalGrouped)
+		excludeRemoved = diffFindingGroups(before.Findings, finalGrouped.Findings)
+		emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseExcludeFilter})
+		if err := ctx.Err(); err != nil {
+			run.Dispositions = domain.BuildDispositions(
+				len(run.AggregatedFindings),
+				run.PreFilterSummary.Info,
+				fpRemoved,
+				excludeRemoved,
+				finalGrouped.Findings,
+			)
+			populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+			return s.interrupt(run, domain.ReviewPhaseExcludeFilter, err, emitter), nil
+		}
+	}
+
+	run.Dispositions = domain.BuildDispositions(
+		len(run.AggregatedFindings),
+		run.PreFilterSummary.Info,
+		fpRemoved,
+		excludeRemoved,
+		finalGrouped.Findings,
+	)
+	populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+	if err := ctx.Err(); err != nil {
+		return s.interrupt(run, domain.ReviewPhaseComplete, err, emitter), nil
+	}
+
+	if len(run.Findings) == 0 {
+		return s.complete(run, domain.ReviewConclusionClean, emitter), nil
+	}
+	return s.complete(run, domain.ReviewConclusionFindings, emitter), nil
+}
+
+func validateRequest(request Request) error {
+	var invalid []string
+	if err := request.Target.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.Trigger.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.Engine.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.Configuration.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if err := request.ConfigurationSource.Validate(); err != nil {
+		invalid = append(invalid, err.Error())
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid review request: %s", strings.Join(invalid, "; "))
+	}
+	return nil
+}
+
+func (s *Service) initializeAgents(values domain.ReviewConfigurationValues) ([]agent.Agent, agent.Agent, error) {
+	reviewAgents := make([]agent.Agent, 0, len(values.ReviewerAgents))
+	seen := make(map[string]agent.Agent)
+	for _, name := range values.ReviewerAgents {
+		reviewAgent, ok := seen[name]
+		if !ok {
+			var err error
+			reviewAgent, err = s.dependencies.newAgent(name, values.ReviewerModel)
+			if err != nil {
+				return nil, nil, fmt.Errorf("create reviewer agent %q: %w", name, err)
+			}
+			if reviewAgent == nil {
+				return nil, nil, fmt.Errorf("create reviewer agent %q: no agent returned", name)
+			}
+			if err := reviewAgent.IsAvailable(); err != nil {
+				return nil, nil, fmt.Errorf("reviewer agent %q unavailable: %w", name, err)
+			}
+			seen[name] = reviewAgent
+		}
+		reviewAgents = append(reviewAgents, reviewAgent)
+	}
+
+	summarizerAgent, err := s.dependencies.newAgent(values.SummarizerAgent, values.SummarizerModel)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create summarizer agent %q: %w", values.SummarizerAgent, err)
+	}
+	if summarizerAgent == nil {
+		return nil, nil, fmt.Errorf("create summarizer agent %q: no agent returned", values.SummarizerAgent)
+	}
+	if err := summarizerAgent.IsAvailable(); err != nil {
+		return nil, nil, fmt.Errorf("summarizer agent %q unavailable: %w", values.SummarizerAgent, err)
+	}
+	return reviewAgents, summarizerAgent, nil
+}
+
+type priorFeedbackResult struct {
+	summary string
+	err     error
+}
+
+type priorFeedbackTask struct {
+	result <-chan priorFeedbackResult
+	done   <-chan struct{}
+	cancel context.CancelFunc
+}
+
+func (s *Service) startPriorFeedback(ctx context.Context, target domain.ReviewTarget, values domain.ReviewConfigurationValues, emitter *eventEmitter) *priorFeedbackTask {
+	if !values.PRFeedbackEnabled || !values.FPFilterEnabled || target.PullRequest == nil {
+		return nil
+	}
+	result := make(chan priorFeedbackResult, 1)
+	done := make(chan struct{})
+	feedbackCtx, cancel := context.WithTimeout(ctx, values.SummarizerTimeout)
+	task := &priorFeedbackTask{result: result, done: done, cancel: cancel}
+	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFeedback})
+	go func() {
+		defer close(done)
+		feedbackAgent := values.PRFeedbackAgent
+		if feedbackAgent == "" {
+			feedbackAgent = values.SummarizerAgent
+		}
+		summary, err := s.dependencies.priorFeedback(feedbackCtx, target, feedbackAgent, values.SummarizerModel)
+		result <- priorFeedbackResult{summary: summary, err: err}
+	}()
+	return task
+}
+
+func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) (string, error) {
+	if t == nil {
+		return "", nil
+	}
+	var feedbackResult priorFeedbackResult
+	select {
+	case feedbackResult = <-t.result:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback})
+	if feedbackResult.err != nil {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFeedback, Message: "prior feedback unavailable: " + feedbackResult.err.Error()})
+		return "", nil
+	}
+	return feedbackResult.summary, nil
+}
+
+func (t *priorFeedbackTask) stop() {
+	if t == nil {
+		return
+	}
+	t.cancel()
+	<-t.done
+}
+
+func (s *Service) emitReviewerWarnings(stats domain.ReviewStats, emitter *eventEmitter) {
+	if stats.ParseErrors > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("reviewer parse errors: %d", stats.ParseErrors)})
+	}
+	if len(stats.FailedReviewers) > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("failed reviewers: %v", stats.FailedReviewers)})
+	}
+	if len(stats.TimedOutReviewers) > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("timed out reviewers: %v", stats.TimedOutReviewers)})
+	}
+	if len(stats.AuthFailedReviewers) > 0 {
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseReviewers, Message: fmt.Sprintf("authentication failed reviewers: %v", stats.AuthFailedReviewers)})
+	}
+}
+
+func (s *Service) complete(run *domain.ReviewRun, conclusion domain.ReviewConclusion, emitter *eventEmitter) *domain.ReviewRun {
+	run.Status = domain.ReviewStatusCompleted
+	run.Conclusion = conclusion
+	run.CompletedAt = s.dependencies.now()
+	emitter.emit(Event{Kind: EventRunCompleted, Phase: domain.ReviewPhaseComplete, Status: run.Status, Conclusion: run.Conclusion})
+	emitter.close()
+	return run
+}
+
+func (s *Service) fail(run *domain.ReviewRun, phase domain.ReviewPhase, err error, emitter *eventEmitter) *domain.ReviewRun {
+	run.Status = domain.ReviewStatusFailed
+	run.Conclusion = domain.ReviewConclusionNone
+	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	run.CompletedAt = s.dependencies.now()
+	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
+	emitter.close()
+	return run
+}
+
+func (s *Service) interrupt(run *domain.ReviewRun, phase domain.ReviewPhase, err error, emitter *eventEmitter) *domain.ReviewRun {
+	run.Status = domain.ReviewStatusInterrupted
+	run.Conclusion = domain.ReviewConclusionNone
+	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	run.CompletedAt = s.dependencies.now()
+	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
+	emitter.close()
+	return run
+}
+
+func (s *Service) finishFromError(run *domain.ReviewRun, phase domain.ReviewPhase, err error, ctx context.Context, emitter *eventEmitter) *domain.ReviewRun {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return s.interrupt(run, phase, err, emitter)
+	}
+	return s.fail(run, phase, err, emitter)
+}
+
+func validateResolvedRevision(expected, actual domain.RevisionEvidence) error {
+	if strings.TrimSpace(actual.RequestedBaseRef) == "" || strings.TrimSpace(actual.ResolvedBaseRef) == "" || strings.TrimSpace(actual.HeadObjectID) == "" || strings.TrimSpace(actual.BaseObjectID) == "" {
+		return fmt.Errorf("revision provider returned incomplete evidence")
+	}
+	if actual.RequestedBaseRef != expected.RequestedBaseRef {
+		return fmt.Errorf("requested base ref changed from %q to %q", expected.RequestedBaseRef, actual.RequestedBaseRef)
+	}
+	if actual.ResolvedBaseRef != expected.ResolvedBaseRef {
+		return fmt.Errorf("resolved base ref changed from %q to %q", expected.ResolvedBaseRef, actual.ResolvedBaseRef)
+	}
+	if expected.HeadObjectID != "" && expected.HeadObjectID != actual.HeadObjectID {
+		return fmt.Errorf("review head changed from %s to %s", expected.HeadObjectID, actual.HeadObjectID)
+	}
+	if expected.BaseObjectID != "" && expected.BaseObjectID != actual.BaseObjectID {
+		return fmt.Errorf("review base changed from %s to %s", expected.BaseObjectID, actual.BaseObjectID)
+	}
+	return nil
+}
+
+func resolveRevisions(ctx context.Context, target domain.ReviewTarget) (domain.RevisionEvidence, error) {
+	revision := target.Revision
+	headObjectID, err := git.ResolveCommit(ctx, target.WorktreeRoot, "HEAD")
+	if err != nil {
+		return domain.RevisionEvidence{}, err
+	}
+	baseObjectID, err := git.ResolveCommit(ctx, target.WorktreeRoot, revision.ResolvedBaseRef)
+	if err != nil {
+		return domain.RevisionEvidence{}, err
+	}
+	revision.HeadObjectID = headObjectID
+	revision.BaseObjectID = baseObjectID
+	return revision, nil
+}
+
+func loadDiff(ctx context.Context, target domain.ReviewTarget) (string, error) {
+	return git.GetDiff(ctx, target.Revision.ResolvedBaseRef, target.WorktreeRoot)
+}
+
+func summarizePriorFeedback(ctx context.Context, target domain.ReviewTarget, agentName, model string) (string, error) {
+	if target.PullRequest == nil {
+		return "", nil
+	}
+	summary := feedback.NewSummarizer(agentName, model, false, nil)
+	return summary.SummarizePullRequest(ctx, *target.PullRequest, target.WorktreeRoot)
+}
+
+func defaultRunID(startedAt time.Time) (string, error) {
+	var random [8]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", err
+	}
+	return startedAt.UTC().Format("20060102T150405.000000000Z") + "-" + hex.EncodeToString(random[:]), nil
+}
+
+const (
+	summaryDiagnosticMaxLines         = 10
+	summaryDiagnosticMaxBytes         = 4096
+	summaryDiagnosticTruncationMarker = "\n[truncated]"
+)
+
+func boundedSummaryEvidence(output string) string {
+	lines := strings.Split(output, "\n")
+	truncated := len(lines) > summaryDiagnosticMaxLines
+	if truncated {
+		lines = lines[:summaryDiagnosticMaxLines]
+	}
+	diagnostic := strings.Join(lines, "\n")
+	if len(diagnostic) > summaryDiagnosticMaxBytes {
+		truncated = true
+	}
+	if truncated {
+		limit := summaryDiagnosticMaxBytes - len(summaryDiagnosticTruncationMarker)
+		if len(diagnostic) > limit {
+			for limit > 0 && !utf8.RuneStart(diagnostic[limit]) {
+				limit--
+			}
+			diagnostic = diagnostic[:limit]
+		}
+		return diagnostic + summaryDiagnosticTruncationMarker
+	}
+	return diagnostic
+}
+
+func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fpRemovedGroups, excludeRemoved []domain.FindingGroup, fpRemoved []domain.FPRemovedInfo) {
+	if len(run.FindingRecords) == 0 && run.PreFilterSummary.TotalGroups() > 0 {
+		initializeRunFindingRecords(run)
+	}
+	run.Findings = nil
+	run.Info = nil
+	run.FalsePositiveFilter.Removed = nil
+	run.ExcludeFilter.Removed = nil
+	for i, finding := range run.FindingRecords {
+		if finding.Kind == domain.ReviewFindingActionable {
+			finding.Disposition = dispositionForGroup(finding.Group, final.Findings, fpRemovedGroups, excludeRemoved, fpRemoved)
+			run.FindingRecords[i] = finding
+		}
+		switch finding.Disposition.Kind {
+		case domain.DispositionSurvived:
+			run.Findings = append(run.Findings, finding)
+		case domain.DispositionInfo:
+			run.Info = append(run.Info, finding)
+		case domain.DispositionFilteredFP:
+			run.FalsePositiveFilter.Removed = append(run.FalsePositiveFilter.Removed, finding)
+		case domain.DispositionFilteredExclude:
+			run.ExcludeFilter.Removed = append(run.ExcludeFilter.Removed, finding)
+		}
+	}
+}
+
+func initializeRunFindingRecords(run *domain.ReviewRun) {
+	records := make([]domain.ReviewFinding, 0, run.PreFilterSummary.TotalGroups())
+	for i, group := range run.PreFilterSummary.Findings {
+		records = append(records, domain.ReviewFinding{
+			ID:    fmt.Sprintf("finding-%03d", i+1),
+			Kind:  domain.ReviewFindingActionable,
+			Group: cloneFindingGroup(group),
+			Disposition: domain.Disposition{
+				GroupTitle: group.Title,
+			},
+		})
+	}
+	for i, group := range run.PreFilterSummary.Info {
+		records = append(records, domain.ReviewFinding{
+			ID:    fmt.Sprintf("info-%03d", i+1),
+			Kind:  domain.ReviewFindingInformational,
+			Group: cloneFindingGroup(group),
+			Disposition: domain.Disposition{
+				Kind:       domain.DispositionInfo,
+				GroupTitle: group.Title,
+			},
+		})
+	}
+	run.FindingRecords = records
+}
+
+func dispositionForGroup(group domain.FindingGroup, final, fpRemoved, excludeRemoved []domain.FindingGroup, fpInfo []domain.FPRemovedInfo) domain.Disposition {
+	if containsFindingGroup(final, group) {
+		return domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: group.Title}
+	}
+	if containsFindingGroup(fpRemoved, group) {
+		disposition := domain.Disposition{Kind: domain.DispositionFilteredFP, GroupTitle: group.Title}
+		for _, info := range fpInfo {
+			if info.Title == group.Title && slices.Equal(info.Sources, group.Sources) {
+				disposition.FPScore = info.FPScore
+				disposition.Reasoning = info.Reasoning
+				break
+			}
+		}
+		return disposition
+	}
+	if containsFindingGroup(excludeRemoved, group) {
+		return domain.Disposition{Kind: domain.DispositionFilteredExclude, GroupTitle: group.Title}
+	}
+	return domain.Disposition{GroupTitle: group.Title}
+}
+
+func containsFindingGroup(groups []domain.FindingGroup, candidate domain.FindingGroup) bool {
+	for _, group := range groups {
+		if sameFindingGroup(group, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func diffFindingGroups(before, after []domain.FindingGroup) []domain.FindingGroup {
+	j := 0
+	var removed []domain.FindingGroup
+	for i := range before {
+		if j < len(after) && sameFindingGroup(before[i], after[j]) {
+			j++
+		} else {
+			removed = append(removed, cloneFindingGroup(before[i]))
+		}
+	}
+	return removed
+}
+
+func sameFindingGroup(left, right domain.FindingGroup) bool {
+	return left.Title == right.Title &&
+		left.Summary == right.Summary &&
+		left.ReviewerCount == right.ReviewerCount &&
+		slices.Equal(left.Messages, right.Messages) &&
+		slices.Equal(left.Sources, right.Sources)
+}
+
+func cloneReviewerResults(results []domain.ReviewerResult) []domain.ReviewerResult {
+	cloned := make([]domain.ReviewerResult, len(results))
+	for i, result := range results {
+		cloned[i] = cloneReviewerResult(result)
+	}
+	return cloned
+}
+
+func cloneReviewerResult(result domain.ReviewerResult) domain.ReviewerResult {
+	result.Findings = cloneFindings(result.Findings)
+	result.Warnings = slices.Clone(result.Warnings)
+	if result.Failure != nil {
+		failure := *result.Failure
+		result.Failure = &failure
+	}
+	return result
+}
+
+func cloneFindings(findings []domain.Finding) []domain.Finding {
+	return slices.Clone(findings)
+}
+
+func cloneAggregatedFindings(findings []domain.AggregatedFinding) []domain.AggregatedFinding {
+	cloned := make([]domain.AggregatedFinding, len(findings))
+	for i, finding := range findings {
+		cloned[i] = finding
+		cloned[i].Reviewers = slices.Clone(finding.Reviewers)
+	}
+	return cloned
+}
+
+func cloneGroupedFindings(grouped domain.GroupedFindings) domain.GroupedFindings {
+	cloned := domain.GroupedFindings{
+		Findings: make([]domain.FindingGroup, len(grouped.Findings)),
+		Info:     make([]domain.FindingGroup, len(grouped.Info)),
+	}
+	for i, finding := range grouped.Findings {
+		cloned.Findings[i] = cloneFindingGroup(finding)
+	}
+	for i, finding := range grouped.Info {
+		cloned.Info[i] = cloneFindingGroup(finding)
+	}
+	return cloned
+}
+
+func cloneFindingGroup(group domain.FindingGroup) domain.FindingGroup {
+	group.Messages = slices.Clone(group.Messages)
+	group.Sources = slices.Clone(group.Sources)
+	return group
+}

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -179,6 +179,13 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if err != nil {
 		return s.finishFromError(run, domain.ReviewPhaseDiff, err, ctx, emitter), nil
 	}
+	confirmedRevision, err := s.dependencies.revisions(ctx, run.Target)
+	if err != nil {
+		return s.finishFromError(run, domain.ReviewPhaseDiff, err, ctx, emitter), nil
+	}
+	if err := validateResolvedRevision(run.Target.Revision, confirmedRevision); err != nil {
+		return s.fail(run, domain.ReviewPhaseDiff, err, emitter), nil
+	}
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseDiff})
 	if err := ctx.Err(); err != nil {
 		return s.interrupt(run, domain.ReviewPhaseDiff, err, emitter), nil
@@ -189,7 +196,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 
 	feedbackTask := s.startPriorFeedback(ctx, run.Target, values, emitter)
 	if feedbackTask != nil {
-		defer feedbackTask.stop()
+		emitter.setBeforeCompletion(feedbackTask.stop)
 	}
 
 	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseReviewers})
@@ -254,6 +261,11 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 			ExitCode: summaryResult.ExitCode,
 			Stderr:   boundedSummaryEvidence(summaryResult.Stderr),
 			Duration: summaryResult.Duration,
+		}
+		for _, warning := range summaryResult.Warnings {
+			message := boundedSummaryEvidence(warning)
+			run.Summarizer.Warnings = append(run.Summarizer.Warnings, message)
+			emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseSummarization, Message: message})
 		}
 		if summaryResult.ExitCode != 0 {
 			run.Summarizer.DiagnosticOutput = boundedSummaryEvidence(summaryResult.RawOut)

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -214,14 +214,14 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	reviewRunner, err := runner.NewHeadless(runner.Config{
 		Reviewers:       values.Reviewers,
 		Concurrency:     values.Concurrency,
-		BaseRef:         run.Target.Revision.ResolvedBaseRef,
+		BaseRef:         run.Target.Revision.BaseObjectID,
 		Timeout:         values.Timeout,
 		Retries:         values.Retries,
 		WorkDir:         run.Target.WorktreeRoot,
 		Guidance:        values.Guidance,
 		UseRefFile:      values.UseRefFile,
 		Diff:            diff,
-		DiffPrecomputed: agent.AgentsNeedDiff(reviewAgents),
+		DiffPrecomputed: true,
 		Events:          reviewerEvents,
 	}, reviewAgents)
 	if err != nil {
@@ -291,7 +291,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	}
 	finalGrouped := cloneGroupedFindings(run.PreFilterSummary)
 	var fpRemoved []domain.FPRemovedInfo
-	var fpRemovedGroups []domain.FindingGroup
+	fpRemovedByIndex := make(map[int]domain.FPRemovedInfo)
 	run.FalsePositiveFilter.Enabled = values.FPFilterEnabled
 	if values.FPFilterEnabled && len(finalGrouped.Findings) > 0 {
 		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
@@ -308,13 +308,14 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 			run.Stats.FPFilterDuration = fpResult.Duration
 			run.Stats.FPFilteredCount = fpResult.RemovedCount
 			for _, removed := range fpResult.Removed {
-				fpRemovedGroups = append(fpRemovedGroups, cloneFindingGroup(removed.Finding))
-				fpRemoved = append(fpRemoved, domain.FPRemovedInfo{
+				info := domain.FPRemovedInfo{
 					Sources:   slices.Clone(removed.Finding.Sources),
 					FPScore:   removed.FPScore,
 					Reasoning: removed.Reasoning,
 					Title:     removed.Finding.Title,
-				})
+				}
+				fpRemovedByIndex[removed.Index] = info
+				fpRemoved = append(fpRemoved, info)
 			}
 			if fpResult.Skipped {
 				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFalsePositiveFilter, Message: "false-positive filter skipped: " + fpResult.SkipReason})
@@ -329,7 +330,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 				nil,
 				finalGrouped.Findings,
 			)
-			populateRunFindings(run, finalGrouped, fpRemovedGroups, nil, fpRemoved)
+			populateRunFindings(run, finalGrouped, fpRemovedByIndex, nil)
 			return s.interrupt(run, domain.ReviewPhaseFalsePositiveFilter, err, emitter), nil
 		}
 	}
@@ -354,7 +355,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 				excludeRemoved,
 				finalGrouped.Findings,
 			)
-			populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+			populateRunFindings(run, finalGrouped, fpRemovedByIndex, excludeRemoved)
 			return s.interrupt(run, domain.ReviewPhaseExcludeFilter, err, emitter), nil
 		}
 	}
@@ -366,7 +367,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 		excludeRemoved,
 		finalGrouped.Findings,
 	)
-	populateRunFindings(run, finalGrouped, fpRemovedGroups, excludeRemoved, fpRemoved)
+	populateRunFindings(run, finalGrouped, fpRemovedByIndex, excludeRemoved)
 	if err := ctx.Err(); err != nil {
 		return s.interrupt(run, domain.ReviewPhaseComplete, err, emitter), nil
 	}
@@ -579,7 +580,7 @@ func resolveRevisions(ctx context.Context, target domain.ReviewTarget) (domain.R
 }
 
 func loadDiff(ctx context.Context, target domain.ReviewTarget) (string, error) {
-	return git.GetDiff(ctx, target.Revision.ResolvedBaseRef, target.WorktreeRoot)
+	return git.GetDiff(ctx, target.Revision.BaseObjectID, target.WorktreeRoot)
 }
 
 func summarizePriorFeedback(ctx context.Context, target domain.ReviewTarget, agentName, model string) (string, error) {
@@ -627,7 +628,7 @@ func boundedSummaryEvidence(output string) string {
 	return diagnostic
 }
 
-func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fpRemovedGroups, excludeRemoved []domain.FindingGroup, fpRemoved []domain.FPRemovedInfo) {
+func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fpRemovedByIndex map[int]domain.FPRemovedInfo, excludeRemoved []domain.FindingGroup) {
 	if len(run.FindingRecords) == 0 && run.PreFilterSummary.TotalGroups() > 0 {
 		initializeRunFindingRecords(run)
 	}
@@ -635,10 +636,14 @@ func populateRunFindings(run *domain.ReviewRun, final domain.GroupedFindings, fp
 	run.Info = nil
 	run.FalsePositiveFilter.Removed = nil
 	run.ExcludeFilter.Removed = nil
+	finalRemaining := cloneFindingGroups(final.Findings)
+	excludeRemaining := cloneFindingGroups(excludeRemoved)
+	actionableIndex := 0
 	for i, finding := range run.FindingRecords {
 		if finding.Kind == domain.ReviewFindingActionable {
-			finding.Disposition = dispositionForGroup(finding.Group, final.Findings, fpRemovedGroups, excludeRemoved, fpRemoved)
+			finding.Disposition = dispositionForFinding(actionableIndex, finding.Group, &finalRemaining, fpRemovedByIndex, &excludeRemaining)
 			run.FindingRecords[i] = finding
+			actionableIndex++
 		}
 		switch finding.Disposition.Kind {
 		case domain.DispositionSurvived:
@@ -679,34 +684,35 @@ func initializeRunFindingRecords(run *domain.ReviewRun) {
 	run.FindingRecords = records
 }
 
-func dispositionForGroup(group domain.FindingGroup, final, fpRemoved, excludeRemoved []domain.FindingGroup, fpInfo []domain.FPRemovedInfo) domain.Disposition {
-	if containsFindingGroup(final, group) {
+func dispositionForFinding(index int, group domain.FindingGroup, final *[]domain.FindingGroup, fpRemoved map[int]domain.FPRemovedInfo, excludeRemoved *[]domain.FindingGroup) domain.Disposition {
+	if info, ok := fpRemoved[index]; ok {
+		return domain.Disposition{Kind: domain.DispositionFilteredFP, GroupTitle: group.Title, FPScore: info.FPScore, Reasoning: info.Reasoning}
+	}
+	if consumeFindingGroup(final, group) {
 		return domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: group.Title}
 	}
-	if containsFindingGroup(fpRemoved, group) {
-		disposition := domain.Disposition{Kind: domain.DispositionFilteredFP, GroupTitle: group.Title}
-		for _, info := range fpInfo {
-			if info.Title == group.Title && slices.Equal(info.Sources, group.Sources) {
-				disposition.FPScore = info.FPScore
-				disposition.Reasoning = info.Reasoning
-				break
-			}
-		}
-		return disposition
-	}
-	if containsFindingGroup(excludeRemoved, group) {
+	if consumeFindingGroup(excludeRemoved, group) {
 		return domain.Disposition{Kind: domain.DispositionFilteredExclude, GroupTitle: group.Title}
 	}
 	return domain.Disposition{GroupTitle: group.Title}
 }
 
-func containsFindingGroup(groups []domain.FindingGroup, candidate domain.FindingGroup) bool {
-	for _, group := range groups {
+func consumeFindingGroup(groups *[]domain.FindingGroup, candidate domain.FindingGroup) bool {
+	for i, group := range *groups {
 		if sameFindingGroup(group, candidate) {
+			*groups = append((*groups)[:i], (*groups)[i+1:]...)
 			return true
 		}
 	}
 	return false
+}
+
+func cloneFindingGroups(groups []domain.FindingGroup) []domain.FindingGroup {
+	cloned := make([]domain.FindingGroup, len(groups))
+	for i, group := range groups {
+		cloned[i] = cloneFindingGroup(group)
+	}
+	return cloned
 }
 
 func diffFindingGroups(before, after []domain.FindingGroup) []domain.FindingGroup {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -253,7 +253,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 
 	emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseSummarization})
 	summaryCtx, summaryCancel := context.WithTimeout(ctx, values.SummarizerTimeout)
-	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings)
+	summaryResult, err := summarizer.SummarizeWithAgent(summaryCtx, summarizerAgent, run.AggregatedFindings, run.Target.WorktreeRoot)
 	summaryCancel()
 	if summaryResult != nil {
 		run.Stats.SummarizerDuration = summaryResult.Duration
@@ -308,7 +308,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if values.FPFilterEnabled && len(finalGrouped.Findings) > 0 {
 		emitter.emit(Event{Kind: EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
 		fpCtx, fpCancel := context.WithTimeout(ctx, values.FPFilterTimeout)
-		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
+		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold, run.Target.WorktreeRoot).Apply(fpCtx, finalGrouped, priorFeedback, run.Stats.SuccessfulReviewers)
 		fpCancel()
 		if fpResult != nil {
 			finalGrouped = cloneGroupedFindings(fpResult.Grouped)
@@ -317,6 +317,11 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 			run.FalsePositiveFilter.SkipReason = fpResult.SkipReason
 			run.FalsePositiveFilter.EvalErrors = fpResult.EvalErrors
 			run.FalsePositiveFilter.Duration = fpResult.Duration
+			for _, warning := range fpResult.Warnings {
+				message := boundedSummaryEvidence(warning)
+				run.FalsePositiveFilter.Warnings = append(run.FalsePositiveFilter.Warnings, message)
+				emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFalsePositiveFilter, Message: message})
+			}
 			run.Stats.FPFilterDuration = fpResult.Duration
 			run.Stats.FPFilteredCount = fpResult.RemovedCount
 			for _, removed := range fpResult.Removed {
@@ -492,8 +497,12 @@ func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) 
 	}
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback})
 	if feedbackResult.err != nil {
-		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFeedback, Message: "prior feedback unavailable: " + feedbackResult.err.Error()})
-		return "", nil
+		message := "prior feedback unavailable: " + feedbackResult.err.Error()
+		if feedbackResult.summary != "" {
+			message = "prior feedback warning: " + feedbackResult.err.Error()
+		}
+		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFeedback, Message: message})
+		return feedbackResult.summary, nil
 	}
 	return feedbackResult.summary, nil
 }
@@ -524,6 +533,7 @@ func (s *Service) emitReviewerWarnings(stats domain.ReviewStats, emitter *eventE
 func (s *Service) complete(run *domain.ReviewRun, conclusion domain.ReviewConclusion, emitter *eventEmitter) *domain.ReviewRun {
 	run.Status = domain.ReviewStatusCompleted
 	run.Conclusion = conclusion
+	emitter.runBeforeCompletion()
 	run.CompletedAt = s.dependencies.now()
 	emitter.emit(Event{Kind: EventRunCompleted, Phase: domain.ReviewPhaseComplete, Status: run.Status, Conclusion: run.Conclusion})
 	emitter.close()
@@ -534,6 +544,7 @@ func (s *Service) fail(run *domain.ReviewRun, phase domain.ReviewPhase, err erro
 	run.Status = domain.ReviewStatusFailed
 	run.Conclusion = domain.ReviewConclusionNone
 	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	emitter.runBeforeCompletion()
 	run.CompletedAt = s.dependencies.now()
 	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
 	emitter.close()
@@ -544,6 +555,7 @@ func (s *Service) interrupt(run *domain.ReviewRun, phase domain.ReviewPhase, err
 	run.Status = domain.ReviewStatusInterrupted
 	run.Conclusion = domain.ReviewConclusionNone
 	run.Failure = &domain.ReviewFailure{Phase: phase, Message: err.Error()}
+	emitter.runBeforeCompletion()
 	run.CompletedAt = s.dependencies.now()
 	emitter.emit(Event{Kind: EventRunCompleted, Phase: phase, Message: err.Error(), Status: run.Status})
 	emitter.close()

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -275,6 +275,32 @@ func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
 	}
 }
 
+func TestServicePinsEveryReviewerToCapturedRevisionAndDiff(t *testing.T) {
+	configs := make(chan agent.ReviewConfig, 2)
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(_ context.Context, config *agent.ReviewConfig) (string, int, string, error) {
+			configs <- *config
+			return codexReviewOutput("src/service.go:10: missing validation"), 0, "", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "captured diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewStatusCompleted {
+		t.Fatalf("run status = %q", run.Status)
+	}
+	for range 2 {
+		config := <-configs
+		if config.BaseRef != "base-object" || !config.DiffPrecomputed || config.Diff != "captured diff" {
+			t.Fatalf("reviewer received mutable review input: %#v", config)
+		}
+	}
+}
+
 func TestServiceEmitsReviewerCleanupWarningsHeadlessly(t *testing.T) {
 	reviewAgent := &mockReviewAgent{name: "codex", reviewClose: errors.New("temporary file cleanup failed")}
 	service := serviceForTest(t, reviewAgent, "diff --git a/file b/file")
@@ -667,6 +693,8 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	request.Configuration = configuration
 	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
 	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
 
 	run, err := service.Run(context.Background(), request)
@@ -678,6 +706,23 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if !feedbackStopped.Load() {
 		t.Fatal("prior-feedback worker remained active after service return")
+	}
+	feedbackStarted := -1
+	feedbackCompleted := -1
+	runCompleted := -1
+	for i, event := range events {
+		if event.Kind == EventPhaseStarted && event.Phase == domain.ReviewPhaseFeedback {
+			feedbackStarted = i
+		}
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseFeedback {
+			feedbackCompleted = i
+		}
+		if event.Kind == EventRunCompleted {
+			runCompleted = i
+		}
+	}
+	if feedbackStarted < 0 || feedbackCompleted <= feedbackStarted || runCompleted <= feedbackCompleted {
+		t.Fatalf("feedback phase lifecycle is unbalanced: %#v", events)
 	}
 }
 
@@ -881,6 +926,42 @@ func TestServiceRecordsFalsePositiveDisposition(t *testing.T) {
 	removed := run.FalsePositiveFilter.Removed[0]
 	if removed.ID != "finding-001" || removed.Disposition.FPScore != 95 || removed.Disposition.Reasoning != "not actionable" {
 		t.Fatalf("false-positive disposition incomplete: %#v", removed)
+	}
+}
+
+func TestServiceTracksDuplicateFindingGroupsByFilterIdentity(t *testing.T) {
+	duplicate := `{"title":"Duplicate","summary":"Same.","messages":["src/service.go:10: issue"],"reviewer_count":2,"sources":[0]}`
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[` + duplicate + `,` + duplicate + `],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":95,"reasoning":"first removed"},{"id":1,"fp_score":0,"reasoning":"second kept"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(run.Findings) != 1 || run.Findings[0].ID != "finding-002" {
+		t.Fatalf("surviving duplicate identity = %#v", run.Findings)
+	}
+	if len(run.FalsePositiveFilter.Removed) != 1 || run.FalsePositiveFilter.Removed[0].ID != "finding-001" {
+		t.Fatalf("removed duplicate identity = %#v", run.FalsePositiveFilter.Removed)
+	}
+	if run.Stats.FPFilteredCount != 1 {
+		t.Fatalf("FP filtered count = %d", run.Stats.FPFilteredCount)
 	}
 }
 

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -19,12 +19,14 @@ import (
 )
 
 type mockReviewAgent struct {
-	name         string
-	review       func(context.Context, *agent.ReviewConfig) (string, int, string, error)
-	summary      func(context.Context, int64, string, []byte) (string, int, string, error)
-	reviewClose  error
-	summaryClose error
-	summaryCalls atomic.Int64
+	name                string
+	review              func(context.Context, *agent.ReviewConfig) (string, int, string, error)
+	summary             func(context.Context, int64, string, []byte) (string, int, string, error)
+	reviewClose         error
+	summaryClose        error
+	summaryCloseForCall func(int64) error
+	summaryConfigs      chan agent.SummaryConfig
+	summaryCalls        atomic.Int64
 }
 
 type reviewErrorReadCloser struct {
@@ -62,20 +64,27 @@ func (m *mockReviewAgent) ExecuteReview(ctx context.Context, config *agent.Revie
 	return executionResult(output, exitCode, stderr), nil
 }
 
-func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*agent.ExecutionResult, error) {
+func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, config *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	call := m.summaryCalls.Add(1)
+	if m.summaryConfigs != nil {
+		m.summaryConfigs <- *config
+	}
 	output := codexSummaryOutput(`{"findings":[{"title":"Missing validation","summary":"Input is not checked.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`)
 	exitCode := 0
 	stderr := ""
 	if m.summary != nil {
 		var err error
-		output, exitCode, stderr, err = m.summary(ctx, call, prompt, input)
+		output, exitCode, stderr, err = m.summary(ctx, call, config.Prompt, config.Input)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if m.summaryClose != nil {
-		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: m.summaryClose}
+	closeErr := m.summaryClose
+	if m.summaryCloseForCall != nil {
+		closeErr = m.summaryCloseForCall(call)
+	}
+	if closeErr != nil {
+		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: closeErr}
 		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
 	}
 	return executionResult(output, exitCode, stderr), nil
@@ -302,6 +311,47 @@ func TestServicePinsEveryReviewerToCapturedRevisionAndDiff(t *testing.T) {
 		config := <-configs
 		if config.BaseRef != "base-object" || !config.DiffPrecomputed || config.Diff != "captured diff" {
 			t.Fatalf("reviewer received mutable review input: %#v", config)
+		}
+	}
+}
+
+func TestServiceScopesSummaryAndFalsePositiveExecutionToReviewTarget(t *testing.T) {
+	root := t.TempDir()
+	summaryConfigs := make(chan agent.SummaryConfig, 2)
+	reviewAgent := &mockReviewAgent{
+		name:           "codex",
+		summaryConfigs: summaryConfigs,
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":0,"reasoning":"actionable"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, root)
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewStatusCompleted {
+		t.Fatalf("run status = %q", run.Status)
+	}
+	if len(summaryConfigs) != 2 {
+		t.Fatalf("summary calls = %d, want 2", len(summaryConfigs))
+	}
+	for range 2 {
+		config := <-summaryConfigs
+		if config.WorkDir != root {
+			t.Fatalf("summary workdir = %q, want %q", config.WorkDir, root)
 		}
 	}
 }
@@ -740,9 +790,11 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 		},
 	}
 	var feedbackStopped atomic.Bool
+	var completionClock atomic.Int64
 	feedbackProvider := func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (string, error) {
 		<-ctx.Done()
 		feedbackStopped.Store(true)
+		completionClock.Store(2)
 		return "", ctx.Err()
 	}
 	request := validRequest(t, t.TempDir())
@@ -763,7 +815,13 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 			completionBeforeFeedbackStopped.Store(true)
 		}
 	})
-	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
+	service := serviceForTest(
+		t,
+		reviewAgent,
+		"diff",
+		WithPriorFeedbackProvider(feedbackProvider),
+		WithClock(func() time.Time { return time.Unix(completionClock.Load(), 0) }),
+	)
 
 	run, err := service.Run(context.Background(), request)
 	if err != nil {
@@ -777,6 +835,9 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if completionBeforeFeedbackStopped.Load() {
 		t.Fatal("run completion was emitted before prior-feedback worker stopped")
+	}
+	if run.CompletedAt.Before(time.Unix(2, 0)) {
+		t.Fatalf("run completed at %s before feedback joined", run.CompletedAt)
 	}
 	feedbackStarted := -1
 	feedbackCompleted := -1
@@ -794,6 +855,59 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if feedbackStarted < 0 || feedbackCompleted <= feedbackStarted || runCompleted <= feedbackCompleted {
 		t.Fatalf("feedback phase lifecycle is unbalanced: %#v", events)
+	}
+}
+
+func TestServiceRetainsPriorFeedbackWhenCleanupWarns(t *testing.T) {
+	var feedbackUsed atomic.Bool
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, prompt string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			if strings.Contains(prompt, "trusted prior feedback") {
+				feedbackUsed.Store(true)
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":0,"reasoning":"actionable"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	values.PRFeedbackEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	service := serviceForTest(
+		t,
+		reviewAgent,
+		"diff",
+		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (string, error) {
+			return "trusted prior feedback", errors.New("feedback cleanup failed")
+		}),
+	)
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || !feedbackUsed.Load() {
+		t.Fatalf("prior feedback was discarded: status=%q used=%v", run.Status, feedbackUsed.Load())
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseFeedback && strings.Contains(event.Message, "feedback cleanup failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("feedback cleanup warning event was not emitted")
 	}
 }
 
@@ -997,6 +1111,52 @@ func TestServiceRecordsFalsePositiveDisposition(t *testing.T) {
 	removed := run.FalsePositiveFilter.Removed[0]
 	if removed.ID != "finding-001" || removed.Disposition.FPScore != 95 || removed.Disposition.Reasoning != "not actionable" {
 		t.Fatalf("false-positive disposition incomplete: %#v", removed)
+	}
+}
+
+func TestServiceRetainsFalsePositiveCleanupWarningsHeadlessly(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":0,"reasoning":"actionable"}]}`), 0, "", nil
+		},
+		summaryCloseForCall: func(call int64) error {
+			if call == 2 {
+				return errors.New("FP temp cleanup failed")
+			}
+			return nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(run.FalsePositiveFilter.Warnings) != 1 || !strings.Contains(run.FalsePositiveFilter.Warnings[0], "FP temp cleanup failed") {
+		t.Fatalf("FP cleanup warnings = %#v", run.FalsePositiveFilter.Warnings)
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseFalsePositiveFilter && strings.Contains(event.Message, "FP temp cleanup failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("FP cleanup warning event was not emitted")
 	}
 }
 

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -1,0 +1,1034 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type mockReviewAgent struct {
+	name         string
+	review       func(context.Context, *agent.ReviewConfig) (string, int, string, error)
+	summary      func(context.Context, int64, string, []byte) (string, int, string, error)
+	reviewClose  error
+	summaryCalls atomic.Int64
+}
+
+type reviewErrorReadCloser struct {
+	io.Reader
+	err error
+}
+
+func (r *reviewErrorReadCloser) Close() error {
+	return r.err
+}
+
+func (m *mockReviewAgent) Name() string {
+	return m.name
+}
+
+func (m *mockReviewAgent) IsAvailable() error {
+	return nil
+}
+
+func (m *mockReviewAgent) ExecuteReview(ctx context.Context, config *agent.ReviewConfig) (*agent.ExecutionResult, error) {
+	output := codexReviewOutput("src/service.go:10: missing validation")
+	exitCode := 0
+	stderr := ""
+	if m.review != nil {
+		var err error
+		output, exitCode, stderr, err = m.review(ctx, config)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if m.reviewClose != nil {
+		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: m.reviewClose}
+		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
+	}
+	return executionResult(output, exitCode, stderr), nil
+}
+
+func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*agent.ExecutionResult, error) {
+	call := m.summaryCalls.Add(1)
+	output := codexSummaryOutput(`{"findings":[{"title":"Missing validation","summary":"Input is not checked.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`)
+	exitCode := 0
+	stderr := ""
+	if m.summary != nil {
+		var err error
+		output, exitCode, stderr, err = m.summary(ctx, call, prompt, input)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return executionResult(output, exitCode, stderr), nil
+}
+
+func executionResult(output string, exitCode int, stderr string) *agent.ExecutionResult {
+	return agent.NewExecutionResult(io.NopCloser(strings.NewReader(output)), func() int { return exitCode }, func() string { return stderr })
+}
+
+func codexReviewOutput(findings ...string) string {
+	var lines []string
+	for _, finding := range findings {
+		payload, _ := json.Marshal(map[string]any{
+			"item": map[string]string{
+				"type": "agent_message",
+				"text": finding,
+			},
+		})
+		lines = append(lines, string(payload))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func codexSummaryOutput(content string) string {
+	return `{"type":"item.completed","item":{"type":"agent_message","text":` + strconv.Quote(content) + `}}`
+}
+
+func validRequest(t *testing.T, root string) Request {
+	t.Helper()
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         2,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		Retries:           0,
+		ReviewerAgents:    []string{"codex"},
+		ReviewerModel:     "review-model",
+		SummarizerAgent:   "codex",
+		SummarizerModel:   "summary-model",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPFilterEnabled:   false,
+		FPThreshold:       75,
+		PRFeedbackEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("create configuration: %v", err)
+	}
+	return Request{
+		Target: domain.ReviewTarget{
+			RepositoryRoot: root,
+			WorktreeRoot:   root,
+			Revision: domain.RevisionEvidence{
+				RequestedBaseRef: "main",
+				ResolvedBaseRef:  "origin/main",
+			},
+		},
+		Trigger:       domain.ReviewTriggerManual,
+		Engine:        domain.ReviewEngine{Name: "acr", Version: "test"},
+		Configuration: configuration,
+		ConfigurationSource: domain.ConfigurationSourceIdentity{
+			Kind:          "test",
+			Locator:       "test-fixture",
+			ConfigPresent: true,
+			ConfigDigest:  "test-digest",
+		},
+	}
+}
+
+func serviceForTest(t *testing.T, reviewAgent agent.Agent, diff string, options ...Option) *Service {
+	t.Helper()
+	fixedTime := time.Date(2026, time.July, 21, 8, 0, 0, 0, time.UTC)
+	baseOptions := []Option{
+		WithClock(func() time.Time { return fixedTime }),
+		WithRunIDGenerator(func(time.Time) (string, error) { return "run-test", nil }),
+		WithAgentFactory(func(string, string) (agent.Agent, error) { return reviewAgent, nil }),
+		WithRevisionProvider(func(_ context.Context, target domain.ReviewTarget) (domain.RevisionEvidence, error) {
+			revision := target.Revision
+			revision.HeadObjectID = "head-object"
+			revision.BaseObjectID = "base-object"
+			return revision, nil
+		}),
+		WithDiffProvider(func(context.Context, domain.ReviewTarget) (string, error) { return diff, nil }),
+		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (string, error) { return "", nil }),
+	}
+	service, err := NewService(append(baseOptions, options...)...)
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	return service
+}
+
+func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
+	root := t.TempDir()
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff --git a/file b/file")
+	request := validRequest(t, root)
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+	})
+
+	beforeCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	stdoutPath := filepath.Join(t.TempDir(), "stdout")
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout capture: %v", err)
+	}
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	os.Stdout = stdout
+	os.Stderr = stderr
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	})
+
+	run, runErr := service.Run(context.Background(), request)
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+	if err := stdout.Close(); err != nil {
+		t.Fatalf("close stdout capture: %v", err)
+	}
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+	if runErr != nil {
+		t.Fatalf("run review: %v", runErr)
+	}
+
+	assertEmptyFile(t, stdoutPath)
+	assertEmptyFile(t, stderrPath)
+	afterCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd after review: %v", err)
+	}
+	if afterCWD != beforeCWD {
+		t.Fatalf("process cwd changed from %q to %q", beforeCWD, afterCWD)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read target directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("headless service created files: %v", entries)
+	}
+
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("unexpected outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.ID != "run-test" || run.ConfigurationFingerprint == "" {
+		t.Fatalf("run identity not populated: %#v", run)
+	}
+	if run.ConfigurationSource != request.ConfigurationSource || run.ConfigurationSource.ConfigDigest == run.ConfigurationFingerprint {
+		t.Fatalf("configuration source evidence was lost or conflated: source=%#v fingerprint=%q", run.ConfigurationSource, run.ConfigurationFingerprint)
+	}
+	if run.Target.PullRequest != nil {
+		t.Fatalf("local review unexpectedly acquired PR identity: %#v", run.Target.PullRequest)
+	}
+	if run.Target.Revision.HeadObjectID != "head-object" || run.Target.Revision.BaseObjectID != "base-object" {
+		t.Fatalf("revision evidence not populated: %#v", run.Target.Revision)
+	}
+	if len(run.ReviewerResults) != 2 || run.Stats.SuccessfulReviewers != 2 {
+		t.Fatalf("reviewer evidence incomplete: results=%d stats=%#v", len(run.ReviewerResults), run.Stats)
+	}
+	if len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("finding evidence incomplete: raw=%d aggregated=%d", len(run.RawFindings), len(run.AggregatedFindings))
+	}
+	if !slicesEqual(run.AggregatedFindings[0].Reviewers, []int{1, 2}) {
+		t.Fatalf("aggregate reviewer evidence = %v", run.AggregatedFindings[0].Reviewers)
+	}
+	if len(run.PreFilterSummary.Findings) != 1 || len(run.Findings) != 1 {
+		t.Fatalf("summary evidence incomplete: pre=%#v final=%#v", run.PreFilterSummary, run.Findings)
+	}
+	if run.Findings[0].ID != "finding-001" || run.Findings[0].Disposition.Kind != domain.DispositionSurvived {
+		t.Fatalf("run-local finding identity or disposition missing: %#v", run.Findings[0])
+	}
+	if run.Dispositions[0].Kind != domain.DispositionSurvived {
+		t.Fatalf("raw finding disposition missing: %#v", run.Dispositions)
+	}
+	if len(events) == 0 || events[0].Kind != EventRunStarted || events[len(events)-1].Kind != EventRunCompleted {
+		t.Fatalf("unexpected event boundaries: %#v", events)
+	}
+	foundReviewerOutput := false
+	for i, event := range events {
+		if event.Sequence != uint64(i+1) {
+			t.Fatalf("event %d has sequence %d", i, event.Sequence)
+		}
+		if event.Kind == EventReviewerOutput {
+			foundReviewerOutput = true
+		}
+	}
+	if !foundReviewerOutput {
+		t.Fatal("reviewer output event was not emitted")
+	}
+}
+
+func TestServiceEmitsReviewerCleanupWarningsHeadlessly(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex", reviewClose: errors.New("temporary file cleanup failed")}
+	service := serviceForTest(t, reviewAgent, "diff --git a/file b/file")
+	request := validRequest(t, t.TempDir())
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+	})
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = originalStderr })
+
+	run, err := service.Run(context.Background(), request)
+	os.Stderr = originalStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("cleanup warning changed run outcome: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 {
+		t.Fatalf("reviewer results = %d, want 2", len(run.ReviewerResults))
+	}
+	for _, result := range run.ReviewerResults {
+		if len(result.Warnings) != 1 || result.Warnings[0].Kind != domain.ReviewerWarningCleanup {
+			t.Fatalf("reviewer cleanup warning missing: %#v", result)
+		}
+	}
+	warningEvents := 0
+	completedWithWarning := 0
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseReviewers && strings.Contains(event.Message, "reviewer cleanup failed") {
+			warningEvents++
+		}
+		if event.Kind == EventReviewerCompleted && len(event.ReviewerResult.Warnings) == 1 {
+			completedWithWarning++
+		}
+	}
+	if warningEvents != 2 || completedWithWarning != 2 {
+		t.Fatalf("cleanup warning events incomplete: warnings=%d completed=%d events=%#v", warningEvents, completedWithWarning, events)
+	}
+	captured, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	if len(captured) != 0 {
+		t.Fatalf("headless service wrote stderr for cleanup warnings: %q", captured)
+	}
+}
+
+func TestServiceDefaultDiffIncludesStagedAndUnstagedChanges(t *testing.T) {
+	root := t.TempDir()
+	runGitForServiceTest(t, root, "init")
+	runGitForServiceTest(t, root, "config", "user.email", "test@example.com")
+	runGitForServiceTest(t, root, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(root, "staged.txt"), []byte("initial staged"), 0o600); err != nil {
+		t.Fatalf("write staged fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "unstaged.txt"), []byte("initial unstaged"), 0o600); err != nil {
+		t.Fatalf("write unstaged fixture: %v", err)
+	}
+	runGitForServiceTest(t, root, "add", ".")
+	runGitForServiceTest(t, root, "commit", "-m", "initial")
+	if err := os.WriteFile(filepath.Join(root, "staged.txt"), []byte("changed staged"), 0o600); err != nil {
+		t.Fatalf("modify staged fixture: %v", err)
+	}
+	runGitForServiceTest(t, root, "add", "staged.txt")
+	if err := os.WriteFile(filepath.Join(root, "unstaged.txt"), []byte("changed unstaged"), 0o600); err != nil {
+		t.Fatalf("modify unstaged fixture: %v", err)
+	}
+
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	fixedTime := time.Date(2026, time.July, 21, 8, 0, 0, 0, time.UTC)
+	service, err := NewService(
+		WithClock(func() time.Time { return fixedTime }),
+		WithRunIDGenerator(func(time.Time) (string, error) { return "run-local-diff", nil }),
+		WithAgentFactory(func(string, string) (agent.Agent, error) { return reviewAgent, nil }),
+	)
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	request := validRequest(t, root)
+	request.Target.Revision.RequestedBaseRef = "HEAD"
+	request.Target.Revision.ResolvedBaseRef = "HEAD"
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run local review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("staged and unstaged changes were not reviewed: status=%q conclusion=%q failure=%#v", run.Status, run.Conclusion, run.Failure)
+	}
+}
+
+func TestServiceReturnsNoChangesWithoutReviewExecution(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "")
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionNoChanges {
+		t.Fatalf("unexpected no-change outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if len(run.ReviewerResults) != 0 || reviewAgent.summaryCalls.Load() != 0 {
+		t.Fatalf("review work ran for empty diff: results=%d summaries=%d", len(run.ReviewerResults), reviewAgent.summaryCalls.Load())
+	}
+}
+
+func TestServiceInterruptsNoChangesRunCanceledAtDiffBoundary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "")
+	request := validRequest(t, t.TempDir())
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseDiff {
+			cancel()
+		}
+	})
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("canceled no-change run completed: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseDiff {
+		t.Fatalf("diff-boundary interruption evidence missing: %#v", run.Failure)
+	}
+	if len(run.ReviewerResults) != 0 || reviewAgent.summaryCalls.Load() != 0 {
+		t.Fatalf("review work ran after diff cancellation: results=%d summaries=%d", len(run.ReviewerResults), reviewAgent.summaryCalls.Load())
+	}
+}
+
+func TestServiceReturnsCleanRunWithoutFindings(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return codexReviewOutput("No issues found."), 0, "", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionClean {
+		t.Fatalf("unexpected clean outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if len(run.ReviewerResults) != 2 || run.Stats.SuccessfulReviewers != 2 || len(run.RawFindings) != 0 {
+		t.Fatalf("clean run evidence incomplete: results=%d stats=%#v raw=%d", len(run.ReviewerResults), run.Stats, len(run.RawFindings))
+	}
+}
+
+func TestServiceCompletesWithPartialReviewerFailures(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(ctx context.Context, config *agent.ReviewConfig) (string, int, string, error) {
+			switch config.ReviewerID {
+			case "2":
+				return codexReviewOutput("src/service.go:10: missing validation"), 1, "failed", nil
+			case "3":
+				<-ctx.Done()
+				return "", 0, "", ctx.Err()
+			default:
+				return codexReviewOutput("src/service.go:10: missing validation"), 0, "", nil
+			}
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.Reviewers = 3
+	values.Concurrency = 3
+	values.Timeout = 20 * time.Millisecond
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create partial-failure configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("partial failure did not complete: status=%q conclusion=%q failure=%#v", run.Status, run.Conclusion, run.Failure)
+	}
+	if run.Stats.SuccessfulReviewers != 1 || !slicesEqual(run.Stats.FailedReviewers, []int{2}) || !slicesEqual(run.Stats.TimedOutReviewers, []int{3}) {
+		t.Fatalf("partial failures not classified: %#v", run.Stats)
+	}
+	results := make(map[int]domain.ReviewerResult)
+	for _, result := range run.ReviewerResults {
+		results[result.ReviewerID] = result
+	}
+	if results[2].Failure == nil || results[2].Failure.Kind != domain.ReviewerFailureExit {
+		t.Fatalf("ordinary failure missing: %#v", results[2])
+	}
+	if results[3].Failure == nil || results[3].Failure.Kind != domain.ReviewerFailureTimeout {
+		t.Fatalf("timeout failure missing: %#v", results[3])
+	}
+	if len(run.RawFindings) != 2 || !slicesEqual(run.AggregatedFindings[0].Reviewers, []int{1, 2}) {
+		t.Fatalf("failed reviewer findings were not retained: raw=%#v aggregated=%#v", run.RawFindings, run.AggregatedFindings)
+	}
+}
+
+func TestServiceReturnsPopulatedFailedRunAfterAcceptance(t *testing.T) {
+	root := t.TempDir()
+	request := validRequest(t, root)
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	fixedTime := time.Date(2026, time.July, 21, 8, 0, 0, 0, time.UTC)
+	service, err := NewService(
+		WithClock(func() time.Time { return fixedTime }),
+		WithRunIDGenerator(func(time.Time) (string, error) { return "run-failed", nil }),
+		WithAgentFactory(func(string, string) (agent.Agent, error) { return nil, errors.New("backend unavailable") }),
+	)
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+
+	run, runErr := service.Run(context.Background(), request)
+	if runErr != nil {
+		t.Fatalf("accepted execution returned Go error: %v", runErr)
+	}
+	if run == nil || run.ID != "run-failed" || run.Target.WorktreeRoot != root {
+		t.Fatalf("failed run lost request evidence: %#v", run)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("unexpected failed outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseInitialization || !strings.Contains(run.Failure.Message, "backend unavailable") {
+		t.Fatalf("failure evidence missing: %#v", run.Failure)
+	}
+	if run.StartedAt.IsZero() || run.CompletedAt.IsZero() || run.ConfigurationFingerprint == "" {
+		t.Fatalf("failed run is not persistence-ready: %#v", run)
+	}
+	assertOrderedEventBoundaries(t, events, domain.ReviewStatusFailed)
+}
+
+func TestServiceReturnsPopulatedInterruptedRunAfterAcceptance(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request := validRequest(t, t.TempDir())
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("unexpected interrupted outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || !errors.Is(ctx.Err(), context.Canceled) || !strings.Contains(run.Failure.Message, "canceled") {
+		t.Fatalf("interruption evidence missing: %#v", run.Failure)
+	}
+	if run.ID == "" || run.ConfigurationFingerprint == "" || run.CompletedAt.IsZero() {
+		t.Fatalf("interrupted run is not persistence-ready: %#v", run)
+	}
+	assertOrderedEventBoundaries(t, events, domain.ReviewStatusInterrupted)
+}
+
+func TestServiceInterruptDuringReviewersRetainsCompletedWork(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(reviewCtx context.Context, config *agent.ReviewConfig) (string, int, string, error) {
+			if config.ReviewerID == "2" {
+				<-reviewCtx.Done()
+				return "", 0, "", reviewCtx.Err()
+			}
+			return codexReviewOutput("src/service.go:10: missing validation"), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.Concurrency = 2
+	configuration, configurationErr := domain.NewReviewConfiguration(values)
+	if configurationErr != nil {
+		t.Fatalf("create interrupt configuration: %v", configurationErr)
+	}
+	request.Configuration = configuration
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+		if event.Kind == EventReviewerCompleted && event.ReviewerID == 1 {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseReviewers {
+		t.Fatalf("unexpected interrupted run: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 || len(run.RawFindings) != 1 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("completed reviewer state was lost: results=%#v raw=%#v aggregated=%#v", run.ReviewerResults, run.RawFindings, run.AggregatedFindings)
+	}
+	results := make(map[int]domain.ReviewerResult)
+	for _, result := range run.ReviewerResults {
+		results[result.ReviewerID] = result
+	}
+	if results[2].Failure == nil || results[2].Failure.Kind != domain.ReviewerFailureInterrupted {
+		t.Fatalf("canceled reviewer was not retained as interrupted: %#v", results[2])
+	}
+	completedReviewers := 0
+	reviewerPhaseCompleted := false
+	for _, event := range events {
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseReviewers {
+			reviewerPhaseCompleted = true
+		}
+		if event.Kind == EventReviewerCompleted {
+			if reviewerPhaseCompleted {
+				t.Fatalf("reviewer completion emitted after reviewer phase completion: %#v", event)
+			}
+			completedReviewers++
+		}
+		if event.Kind == EventRunCompleted && completedReviewers != 2 {
+			t.Fatalf("run completed after only %d reviewer completions", completedReviewers)
+		}
+	}
+	if completedReviewers != 2 || !reviewerPhaseCompleted {
+		t.Fatalf("reviewer event lifecycle incomplete: completions=%d phaseCompleted=%v", completedReviewers, reviewerPhaseCompleted)
+	}
+}
+
+func TestServiceReturnsPopulatedReviewerFailure(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return codexReviewOutput("partial finding"), 1, "review failed", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted reviewer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseReviewers {
+		t.Fatalf("unexpected failed run: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 || len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("failed reviewer evidence was lost: results=%d raw=%d aggregated=%d", len(run.ReviewerResults), len(run.RawFindings), len(run.AggregatedFindings))
+	}
+	for _, result := range run.ReviewerResults {
+		if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureExit || result.Attempts != 1 {
+			t.Fatalf("typed reviewer failure missing: %#v", result)
+		}
+	}
+}
+
+func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return "", 1, "review failed", nil
+		},
+	}
+	var feedbackStopped atomic.Bool
+	feedbackProvider := func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (string, error) {
+		<-ctx.Done()
+		feedbackStopped.Store(true)
+		return "", ctx.Err()
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	values.PRFeedbackEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create feedback configuration: %v", err)
+	}
+	request.Configuration = configuration
+	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed {
+		t.Fatalf("unexpected run status %q", run.Status)
+	}
+	if !feedbackStopped.Load() {
+		t.Fatal("prior-feedback worker remained active after service return")
+	}
+}
+
+func TestServiceSummarizerFailureRetainsReviewerEvidence(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(context.Context, int64, string, []byte) (string, int, string, error) {
+			return codexSummaryOutput(`{"findings":[],"info":[]}`), 1, "summary failed", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted summarizer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer failure: %#v", run)
+	}
+	if len(run.ReviewerResults) != 2 || len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("summarizer failure lost reviewer evidence: %#v", run)
+	}
+	if run.Summarizer.ExitCode != 1 || run.Summarizer.Stderr != "summary failed" || run.Summarizer.DiagnosticOutput == "" {
+		t.Fatalf("summarizer diagnostic evidence missing: %#v", run.Summarizer)
+	}
+}
+
+func TestServiceBoundsOneLineSummarizerFailureEvidence(t *testing.T) {
+	rawOutput := strings.Repeat("x", summaryDiagnosticMaxBytes*4)
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(context.Context, int64, string, []byte) (string, int, string, error) {
+			return rawOutput, 1, "summary failed", nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted summarizer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer failure: %#v", run)
+	}
+	if len(run.Summarizer.DiagnosticOutput) > summaryDiagnosticMaxBytes {
+		t.Fatalf("diagnostic output has %d bytes, want at most %d", len(run.Summarizer.DiagnosticOutput), summaryDiagnosticMaxBytes)
+	}
+	if !strings.HasSuffix(run.Summarizer.DiagnosticOutput, summaryDiagnosticTruncationMarker) {
+		t.Fatalf("bounded diagnostic output is not marked as truncated: %q", run.Summarizer.DiagnosticOutput)
+	}
+	if run.Summarizer.DiagnosticOutput == rawOutput {
+		t.Fatal("raw summarizer transcript was retained")
+	}
+}
+
+func TestServiceBoundsSummarizerStderrAndFailureMessage(t *testing.T) {
+	stderr := strings.Repeat("failure detail ", summaryDiagnosticMaxBytes)
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(context.Context, int64, string, []byte) (string, int, string, error) {
+			return codexSummaryOutput(`{"findings":[],"info":[]}`), 1, stderr, nil
+		},
+	}
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("accepted summarizer failure returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected summarizer failure: %#v", run)
+	}
+	if len(run.Summarizer.Stderr) > summaryDiagnosticMaxBytes {
+		t.Fatalf("summarizer stderr has %d bytes, want at most %d", len(run.Summarizer.Stderr), summaryDiagnosticMaxBytes)
+	}
+	if !strings.HasSuffix(run.Summarizer.Stderr, summaryDiagnosticTruncationMarker) {
+		t.Fatalf("bounded summarizer stderr is not marked as truncated: %q", run.Summarizer.Stderr)
+	}
+	if run.Failure.Message != strings.TrimSpace(run.Summarizer.Stderr) {
+		t.Fatalf("failure message was not derived from bounded stderr: message=%q stderr=%q", run.Failure.Message, run.Summarizer.Stderr)
+	}
+	if strings.Contains(run.Failure.Message, stderr) {
+		t.Fatal("run failure retained full summarizer stderr")
+	}
+}
+
+func TestServiceInterruptDuringSummarizationRetainsReviewerEvidence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	request := validRequest(t, t.TempDir())
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseStarted && event.Phase == domain.ReviewPhaseSummarization {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("unexpected interrupted run: %#v", run)
+	}
+	if len(run.RawFindings) != 2 || len(run.AggregatedFindings) != 1 {
+		t.Fatalf("summarization interruption lost reviewer evidence: %#v", run)
+	}
+}
+
+func TestServiceInterruptsRunCanceledAtSummarizationBoundary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	request := validRequest(t, t.TempDir())
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseSummarization {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Conclusion != domain.ReviewConclusionNone {
+		t.Fatalf("canceled summarized run completed: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseSummarization {
+		t.Fatalf("summarization-boundary interruption evidence missing: %#v", run.Failure)
+	}
+	if len(run.PreFilterSummary.Findings) != 1 || len(run.FindingRecords) != 1 {
+		t.Fatalf("summarization-boundary interruption lost evidence: %#v", run)
+	}
+}
+
+func TestServicePreservesPreFilterEvidenceAndExcludeDisposition(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		review: func(context.Context, *agent.ReviewConfig) (string, int, string, error) {
+			return codexReviewOutput("src/main.go:1: bug", "generated/file.go:2: generated bug"), 0, "", nil
+		},
+		summary: func(_ context.Context, _ int64, _ string, _ []byte) (string, int, string, error) {
+			return codexSummaryOutput(`{"findings":[{"title":"Real bug","summary":"Real.","messages":["src/main.go:1: bug"],"reviewer_count":2,"sources":[0]},{"title":"Generated bug","summary":"Generated.","messages":["generated/file.go:2: generated bug"],"reviewer_count":2,"sources":[1]}],"info":[]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.ExcludePatterns = []string{"generated/"}
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create filtered configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if len(run.PreFilterSummary.Findings) != 2 || len(run.Findings) != 1 || len(run.ExcludeFilter.Removed) != 1 {
+		t.Fatalf("filter evidence incomplete: pre=%d final=%d removed=%d", len(run.PreFilterSummary.Findings), len(run.Findings), len(run.ExcludeFilter.Removed))
+	}
+	if run.Findings[0].ID != "finding-001" || run.ExcludeFilter.Removed[0].ID != "finding-002" {
+		t.Fatalf("finding identities did not follow observed summary order: final=%#v removed=%#v", run.Findings, run.ExcludeFilter.Removed)
+	}
+	if run.ExcludeFilter.Removed[0].Disposition.Kind != domain.DispositionFilteredExclude {
+		t.Fatalf("exclude disposition missing: %#v", run.ExcludeFilter.Removed[0])
+	}
+}
+
+func TestServiceRecordsFalsePositiveDisposition(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return codexSummaryOutput(`{"evaluations":[{"id":0,"fp_score":95,"reasoning":"not actionable"}]}`), 0, "", nil
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create FP configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionClean {
+		t.Fatalf("unexpected filtered outcome: status=%q conclusion=%q", run.Status, run.Conclusion)
+	}
+	if !run.FalsePositiveFilter.Applied || len(run.FalsePositiveFilter.Removed) != 1 {
+		t.Fatalf("false-positive outcome missing: %#v", run.FalsePositiveFilter)
+	}
+	removed := run.FalsePositiveFilter.Removed[0]
+	if removed.ID != "finding-001" || removed.Disposition.FPScore != 95 || removed.Disposition.Reasoning != "not actionable" {
+		t.Fatalf("false-positive disposition incomplete: %#v", removed)
+	}
+}
+
+func TestServiceFalsePositiveFailureIsExplicitAndFailOpen(t *testing.T) {
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(_ context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return "", 0, "", errors.New("FP backend unavailable")
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create FP configuration: %v", err)
+	}
+	request.Configuration = configuration
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings || len(run.Findings) != 1 {
+		t.Fatalf("FP failure did not fail open: %#v", run)
+	}
+	if !run.FalsePositiveFilter.Skipped || !strings.Contains(run.FalsePositiveFilter.SkipReason, "FP backend unavailable") {
+		t.Fatalf("FP skip evidence missing: %#v", run.FalsePositiveFilter)
+	}
+}
+
+func TestServiceInterruptDuringFalsePositiveFilterRetainsIntermediateState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reviewAgent := &mockReviewAgent{
+		name: "codex",
+		summary: func(summaryCtx context.Context, call int64, _ string, _ []byte) (string, int, string, error) {
+			if call == 1 {
+				return codexSummaryOutput(`{"findings":[{"title":"Maybe bug","summary":"Maybe.","messages":["src/service.go:10: missing validation"],"reviewer_count":2,"sources":[0]}],"info":[]}`), 0, "", nil
+			}
+			return "", 0, "", summaryCtx.Err()
+		},
+	}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatalf("create FP configuration: %v", err)
+	}
+	request.Configuration = configuration
+	request.Events = EventSinkFunc(func(event Event) {
+		if event.Kind == EventPhaseStarted && event.Phase == domain.ReviewPhaseFalsePositiveFilter {
+			cancel()
+		}
+	})
+	service := serviceForTest(t, reviewAgent, "diff")
+
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		t.Fatalf("accepted interruption returned Go error: %v", err)
+	}
+	if run.Status != domain.ReviewStatusInterrupted || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseFalsePositiveFilter {
+		t.Fatalf("unexpected interrupted run: %#v", run)
+	}
+	if len(run.PreFilterSummary.Findings) != 1 || len(run.FindingRecords) != 1 || run.FindingRecords[0].ID != "finding-001" {
+		t.Fatalf("FP interruption lost intermediate finding identity: %#v", run)
+	}
+}
+
+func TestServiceRejectsInvalidRequestBeforeAcceptance(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff")
+	request := validRequest(t, t.TempDir())
+	request.Target.WorktreeRoot = "relative"
+
+	run, err := service.Run(context.Background(), request)
+	if err == nil {
+		t.Fatal("expected invalid request error")
+	}
+	if run != nil {
+		t.Fatalf("invalid request was accepted: %#v", run)
+	}
+}
+
+func TestServiceRejectsMissingConfigurationSourceBeforeAcceptance(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, reviewAgent, "diff")
+	request := validRequest(t, t.TempDir())
+	request.ConfigurationSource = domain.ConfigurationSourceIdentity{}
+
+	run, err := service.Run(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "configuration source") {
+		t.Fatalf("expected configuration source error, got %v", err)
+	}
+	if run != nil {
+		t.Fatalf("request without source evidence was accepted: %#v", run)
+	}
+}
+
+func assertEmptyFile(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read capture %q: %v", path, err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("unexpected process output in %q: %q", path, data)
+	}
+}
+
+func slicesEqual(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func runGitForServiceTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+	return string(output)
+}
+
+func assertOrderedEventBoundaries(t *testing.T, events []Event, status domain.ReviewStatus) {
+	t.Helper()
+	if len(events) < 2 || events[0].Kind != EventRunStarted || events[len(events)-1].Kind != EventRunCompleted {
+		t.Fatalf("unexpected event boundaries: %#v", events)
+	}
+	for i, event := range events {
+		if event.Sequence != uint64(i+1) {
+			t.Fatalf("event %d has sequence %d", i, event.Sequence)
+		}
+	}
+	if events[len(events)-1].Status != status {
+		t.Fatalf("last event status = %q, want %q", events[len(events)-1].Status, status)
+	}
+}

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -23,6 +23,7 @@ type mockReviewAgent struct {
 	review       func(context.Context, *agent.ReviewConfig) (string, int, string, error)
 	summary      func(context.Context, int64, string, []byte) (string, int, string, error)
 	reviewClose  error
+	summaryClose error
 	summaryCalls atomic.Int64
 }
 
@@ -72,6 +73,10 @@ func (m *mockReviewAgent) ExecuteSummary(ctx context.Context, prompt string, inp
 		if err != nil {
 			return nil, err
 		}
+	}
+	if m.summaryClose != nil {
+		reader := &reviewErrorReadCloser{Reader: strings.NewReader(output), err: m.summaryClose}
+		return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
 	}
 	return executionResult(output, exitCode, stderr), nil
 }
@@ -360,6 +365,34 @@ func TestServiceEmitsReviewerCleanupWarningsHeadlessly(t *testing.T) {
 	}
 }
 
+func TestServiceRetainsSummarizerCleanupWarningsHeadlessly(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex", summaryClose: errors.New("temporary summary cleanup failed")}
+	service := serviceForTest(t, reviewAgent, "diff")
+	request := validRequest(t, t.TempDir())
+	var events []Event
+	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
+		t.Fatalf("cleanup warning changed run outcome: %#v", run)
+	}
+	if len(run.Summarizer.Warnings) != 1 || !strings.Contains(run.Summarizer.Warnings[0], "summary cleanup failed") {
+		t.Fatalf("summarizer cleanup warning missing: %#v", run.Summarizer)
+	}
+	warningEvents := 0
+	for _, event := range events {
+		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseSummarization && event.Message == run.Summarizer.Warnings[0] {
+			warningEvents++
+		}
+	}
+	if warningEvents != 1 {
+		t.Fatalf("summarizer cleanup warning events = %d, events=%#v", warningEvents, events)
+	}
+}
+
 func TestServiceDefaultDiffIncludesStagedAndUnstagedChanges(t *testing.T) {
 	root := t.TempDir()
 	runGitForServiceTest(t, root, "init")
@@ -401,6 +434,35 @@ func TestServiceDefaultDiffIncludesStagedAndUnstagedChanges(t *testing.T) {
 	}
 	if run.Status != domain.ReviewStatusCompleted || run.Conclusion != domain.ReviewConclusionFindings {
 		t.Fatalf("staged and unstaged changes were not reviewed: status=%q conclusion=%q failure=%#v", run.Status, run.Conclusion, run.Failure)
+	}
+}
+
+func TestServiceFailsWhenHeadMovesDuringDiffCapture(t *testing.T) {
+	reviewAgent := &mockReviewAgent{name: "codex"}
+	var revisionCalls atomic.Int32
+	service := serviceForTest(t, reviewAgent, "diff", WithRevisionProvider(func(_ context.Context, target domain.ReviewTarget) (domain.RevisionEvidence, error) {
+		revision := target.Revision
+		revision.BaseObjectID = "base-object"
+		if revisionCalls.Add(1) == 1 {
+			revision.HeadObjectID = "head-a"
+		} else {
+			revision.HeadObjectID = "head-b"
+		}
+		return revision, nil
+	}))
+
+	run, err := service.Run(context.Background(), validRequest(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("run review: %v", err)
+	}
+	if run.Status != domain.ReviewStatusFailed || run.Failure == nil || run.Failure.Phase != domain.ReviewPhaseDiff {
+		t.Fatalf("moving head was accepted: %#v", run)
+	}
+	if !strings.Contains(run.Failure.Message, "review head changed") {
+		t.Fatalf("failure = %#v", run.Failure)
+	}
+	if len(run.ReviewerResults) != 0 || reviewAgent.summaryCalls.Load() != 0 {
+		t.Fatalf("review continued after head movement: %#v", run)
 	}
 }
 
@@ -694,7 +756,13 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	request.Configuration = configuration
 	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
 	var events []Event
-	request.Events = EventSinkFunc(func(event Event) { events = append(events, event) })
+	var completionBeforeFeedbackStopped atomic.Bool
+	request.Events = EventSinkFunc(func(event Event) {
+		events = append(events, event)
+		if event.Kind == EventRunCompleted && !feedbackStopped.Load() {
+			completionBeforeFeedbackStopped.Store(true)
+		}
+	})
 	service := serviceForTest(t, reviewAgent, "diff", WithPriorFeedbackProvider(feedbackProvider))
 
 	run, err := service.Run(context.Background(), request)
@@ -706,6 +774,9 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	if !feedbackStopped.Load() {
 		t.Fatal("prior-feedback worker remained active after service return")
+	}
+	if completionBeforeFeedbackStopped.Load() {
+		t.Fatal("run completion was emitted before prior-feedback worker stopped")
 	}
 	feedbackStarted := -1
 	feedbackCompleted := -1

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -128,12 +128,14 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 
 	for i := 1; i <= r.config.Reviewers; i++ {
 		go func(id int) {
+			agentName := r.reviewerAgentName(id)
 
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():
 				result := domain.ReviewerResult{
 					ReviewerID: id,
+					AgentName:  agentName,
 					ExitCode:   -1,
 					Failure: &domain.ReviewerFailure{
 						Kind:    domain.ReviewerFailureInterrupted,
@@ -189,12 +191,14 @@ func finishRun(ctx context.Context, results []domain.ReviewerResult, startedAt t
 func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domain.ReviewerResult {
 	var result domain.ReviewerResult
 	var warnings []domain.ReviewerWarning
+	agentName := r.reviewerAgentName(reviewerID)
 
 	for attempt := 0; attempt <= r.config.Retries; attempt++ {
 		select {
 		case <-ctx.Done():
 			return domain.ReviewerResult{
 				ReviewerID: reviewerID,
+				AgentName:  agentName,
 				ExitCode:   -1,
 				Attempts:   attempt,
 				Failure: &domain.ReviewerFailure{
@@ -394,6 +398,10 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) (result domain
 	result.ExitCode = execResult.ExitCode()
 	result.Duration = time.Since(start)
 
+	if result.ExitCode == 0 {
+		return result
+	}
+
 	if ctx.Err() != nil {
 		result.TimedOut = false
 		result.AuthFailed = false
@@ -421,6 +429,14 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) (result domain
 	}
 
 	return result
+}
+
+func (r *Runner) reviewerAgentName(reviewerID int) string {
+	selectedAgent := agent.AgentForReviewer(r.agents, reviewerID)
+	if selectedAgent == nil {
+		return ""
+	}
+	return selectedAgent.Name()
 }
 
 func (r *Runner) verbose() bool {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -246,6 +246,10 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 			select {
 			case <-time.After(delay):
 			case <-ctx.Done():
+				result.ExitCode = -1
+				result.TimedOut = false
+				result.AuthFailed = false
+				result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
 				return result
 			}
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -57,37 +57,63 @@ type Config struct {
 	UseRefFile      bool
 	Diff            string
 	DiffPrecomputed bool
+	Events          Events
+}
+
+type Events struct {
+	ReviewerStarted   func(int, string)
+	ReviewerOutput    func(int, string)
+	ReviewerRetrying  func(int, string, int, int, time.Duration)
+	ReviewerCompleted func(domain.ReviewerResult)
 }
 
 type Runner struct {
-	config    Config
-	agents    []agent.Agent
-	logger    *terminal.Logger
-	completed *atomic.Int32
+	config       Config
+	agents       []agent.Agent
+	logger       *terminal.Logger
+	completed    *atomic.Int32
+	showProgress bool
 }
 
 func New(config Config, agents []agent.Agent, logger *terminal.Logger) (*Runner, error) {
+	return newRunner(config, agents, logger, true)
+}
+
+func NewHeadless(config Config, agents []agent.Agent) (*Runner, error) {
+	return newRunner(config, agents, nil, false)
+}
+
+func newRunner(config Config, agents []agent.Agent, logger *terminal.Logger, showProgress bool) (*Runner, error) {
 	if len(agents) == 0 {
 		return nil, fmt.Errorf("at least one agent is required")
 	}
 	return &Runner{
-		config:    config,
-		agents:    agents,
-		logger:    logger,
-		completed: &atomic.Int32{},
+		config:       config,
+		agents:       agents,
+		logger:       logger,
+		completed:    &atomic.Int32{},
+		showProgress: showProgress,
 	}, nil
 }
 
 func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duration, error) {
-	spinner := terminal.NewSpinner(r.config.Reviewers)
-	r.completed = spinner.Completed()
-
-	spinnerCtx, spinnerCancel := context.WithCancel(context.Background())
-	spinnerDone := make(chan struct{})
-	go func() {
-		spinner.Run(spinnerCtx)
-		close(spinnerDone)
-	}()
+	stopProgress := func() {}
+	if r.showProgress {
+		spinner := terminal.NewSpinner(r.config.Reviewers)
+		r.completed = spinner.Completed()
+		spinnerCtx, spinnerCancel := context.WithCancel(context.Background())
+		spinnerDone := make(chan struct{})
+		go func() {
+			spinner.Run(spinnerCtx)
+			close(spinnerDone)
+		}()
+		stopProgress = func() {
+			spinnerCancel()
+			<-spinnerDone
+		}
+	} else {
+		r.completed = &atomic.Int32{}
+	}
 
 	start := time.Now()
 
@@ -106,10 +132,16 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():
-				resultCh <- domain.ReviewerResult{
+				result := domain.ReviewerResult{
 					ReviewerID: id,
 					ExitCode:   -1,
+					Failure: &domain.ReviewerFailure{
+						Kind:    domain.ReviewerFailureInterrupted,
+						Message: ctx.Err().Error(),
+					},
 				}
+				r.reviewerCompleted(result)
+				resultCh <- result
 				return
 			}
 
@@ -118,30 +150,45 @@ func (r *Runner) Run(ctx context.Context) ([]domain.ReviewerResult, time.Duratio
 			<-sem
 
 			r.completed.Add(1)
+			r.reviewerCompleted(result)
 			resultCh <- result
 		}(i)
 	}
 
 	results := make([]domain.ReviewerResult, 0, r.config.Reviewers)
-	for i := 0; i < r.config.Reviewers; i++ {
+	var runErr error
+	for len(results) < r.config.Reviewers {
+		if runErr != nil {
+			results = append(results, <-resultCh)
+			continue
+		}
 		select {
 		case result := <-resultCh:
 			results = append(results, result)
 		case <-ctx.Done():
-			spinnerCancel()
-			<-spinnerDone
-			return nil, time.Since(start), ctx.Err()
+			runErr = ctx.Err()
 		}
 	}
 
-	spinnerCancel()
-	<-spinnerDone
+	stopProgress()
+	if runErr != nil {
+		return results, time.Since(start), runErr
+	}
 
-	return results, time.Since(start), nil
+	return finishRun(ctx, results, start)
+}
+
+func finishRun(ctx context.Context, results []domain.ReviewerResult, startedAt time.Time) ([]domain.ReviewerResult, time.Duration, error) {
+	duration := time.Since(startedAt)
+	if err := ctx.Err(); err != nil {
+		return results, duration, err
+	}
+	return results, duration, nil
 }
 
 func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domain.ReviewerResult {
 	var result domain.ReviewerResult
+	var warnings []domain.ReviewerWarning
 
 	for attempt := 0; attempt <= r.config.Retries; attempt++ {
 		select {
@@ -149,19 +196,30 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 			return domain.ReviewerResult{
 				ReviewerID: reviewerID,
 				ExitCode:   -1,
+				Attempts:   attempt,
+				Failure: &domain.ReviewerFailure{
+					Kind:    domain.ReviewerFailureInterrupted,
+					Message: ctx.Err().Error(),
+				},
+				Warnings: append([]domain.ReviewerWarning(nil), warnings...),
 			}
 		default:
 		}
 
 		result = r.runReviewer(ctx, reviewerID)
+		warnings = append(warnings, result.Warnings...)
+		result.Warnings = append([]domain.ReviewerWarning(nil), warnings...)
+		result.Attempts = attempt + 1
 
 		if result.ExitCode == 0 {
 			return result
 		}
 
 		if result.AuthFailed {
-			r.logger.Logf(terminal.StyleError, "Reviewer #%d (%s) authentication failed: %s",
-				reviewerID, result.AgentName, agent.AuthHint(result.AgentName))
+			if r.logger != nil {
+				r.logger.Logf(terminal.StyleError, "Reviewer #%d (%s) authentication failed: %s",
+					reviewerID, result.AgentName, agent.AuthHint(result.AgentName))
+			}
 			return result
 		}
 
@@ -173,8 +231,13 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 			if result.TimedOut {
 				reason = "timed out"
 			}
-			r.logger.Logf(terminal.StyleWarning, "Reviewer #%d %s (exit %d), retry %d/%d in %v",
-				reviewerID, reason, result.ExitCode, attempt+1, r.config.Retries, delay)
+			if r.logger != nil {
+				r.logger.Logf(terminal.StyleWarning, "Reviewer #%d %s (exit %d), retry %d/%d in %v",
+					reviewerID, reason, result.ExitCode, attempt+1, r.config.Retries, delay)
+			}
+			if r.config.Events.ReviewerRetrying != nil {
+				r.config.Events.ReviewerRetrying(reviewerID, reason, attempt+1, r.config.Retries, delay)
+			}
 
 			select {
 			case <-time.After(delay):
@@ -187,7 +250,7 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 	return result
 }
 
-func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.ReviewerResult {
+func (r *Runner) runReviewer(ctx context.Context, reviewerID int) (result domain.ReviewerResult) {
 	start := time.Now()
 
 	selectedAgent := agent.AgentForReviewer(r.agents, reviewerID)
@@ -197,12 +260,19 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 			ReviewerID: reviewerID,
 			ExitCode:   -1,
 			Duration:   time.Since(start),
+			Failure: &domain.ReviewerFailure{
+				Kind:    domain.ReviewerFailureExecution,
+				Message: "no reviewer agent available",
+			},
 		}
 	}
 
-	result := domain.ReviewerResult{
+	result = domain.ReviewerResult{
 		ReviewerID: reviewerID,
 		AgentName:  selectedAgent.Name(),
+	}
+	if r.config.Events.ReviewerStarted != nil {
+		r.config.Events.ReviewerStarted(reviewerID, selectedAgent.Name())
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, r.config.Timeout)
@@ -224,19 +294,40 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 	if err != nil {
 		result.ExitCode = -1
 		result.Duration = time.Since(start)
+		if ctx.Err() != nil {
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+		} else if timeoutCtx.Err() == context.DeadlineExceeded {
+			result.TimedOut = true
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureTimeout, Message: timeoutCtx.Err().Error()}
+		} else {
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureExecution, Message: err.Error()}
+		}
 		return result
 	}
 
-	defer func() {
-		if closeErr := execResult.Close(); closeErr != nil && r.verbose() {
-			r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: close error (non-fatal): %v", reviewerID, closeErr)
+	closed := false
+	closeExecution := func() {
+		if closed {
+			return
 		}
-	}()
+		closed = true
+		if closeErr := execResult.Close(); closeErr != nil {
+			result.Warnings = append(result.Warnings, domain.ReviewerWarning{
+				Kind:    domain.ReviewerWarningCleanup,
+				Message: fmt.Sprintf("reviewer cleanup failed: %v", closeErr),
+			})
+			if r.verbose() {
+				r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: close error (non-fatal): %v", reviewerID, closeErr)
+			}
+		}
+	}
+	defer closeExecution()
 
 	parser, err := agent.NewReviewParser(selectedAgent.Name(), reviewerID)
 	if err != nil {
 		result.ExitCode = -1
 		result.Duration = time.Since(start)
+		result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureParser, Message: err.Error()}
 		return result
 	}
 
@@ -246,11 +337,19 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 
 	for {
 
+		if ctx.Err() != nil {
+			result.ParseErrors += parser.ParseErrors()
+			result.ExitCode = -1
+			result.Duration = time.Since(start)
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+			return result
+		}
 		if timeoutCtx.Err() == context.DeadlineExceeded {
 			result.ParseErrors += parser.ParseErrors()
 			result.TimedOut = true
 			result.ExitCode = -1
 			result.Duration = time.Since(start)
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureTimeout, Message: timeoutCtx.Err().Error()}
 			return result
 		}
 
@@ -274,6 +373,9 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		}
 
 		result.Findings = append(result.Findings, *finding)
+		if r.config.Events.ReviewerOutput != nil {
+			r.config.Events.ReviewerOutput(reviewerID, finding.Text)
+		}
 
 		if r.verbose() {
 			text := finding.Text
@@ -288,32 +390,47 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 
 	result.ParseErrors += parser.ParseErrors()
 
-	if closeErr := execResult.Close(); closeErr != nil && r.verbose() {
-		r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: close error (non-fatal): %v", reviewerID, closeErr)
-	}
+	closeExecution()
 	result.ExitCode = execResult.ExitCode()
-
-	if result.ExitCode != 0 {
-		result.AuthFailed = agent.IsAuthFailure(selectedAgent.Name(), result.ExitCode, execResult.Stderr(), stdoutCapture.String())
-		if result.AuthFailed {
-			result.Findings = nil
-		}
-	}
-
 	result.Duration = time.Since(start)
+
+	if ctx.Err() != nil {
+		result.TimedOut = false
+		result.AuthFailed = false
+		result.ExitCode = -1
+		result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+		return result
+	}
 
 	if timeoutCtx.Err() == context.DeadlineExceeded {
 		result.TimedOut = true
 		result.AuthFailed = false
 		result.ExitCode = -1
+		result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureTimeout, Message: timeoutCtx.Err().Error()}
 		return result
+	}
+
+	if result.ExitCode != 0 {
+		result.AuthFailed = agent.IsAuthFailure(selectedAgent.Name(), result.ExitCode, execResult.Stderr(), stdoutCapture.String())
+		if result.AuthFailed {
+			result.Findings = nil
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureAuth, Message: selectedAgent.Name() + " authentication failed"}
+		} else if result.Failure == nil {
+			result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureExit, Message: fmt.Sprintf("reviewer exited with code %d", result.ExitCode)}
+		}
 	}
 
 	return result
 }
 
 func (r *Runner) verbose() bool {
-	return r.config.Verbose
+	return r.config.Verbose && r.logger != nil
+}
+
+func (r *Runner) reviewerCompleted(result domain.ReviewerResult) {
+	if r.config.Events.ReviewerCompleted != nil {
+		r.config.Events.ReviewerCompleted(result)
+	}
 }
 
 func BuildStats(results []domain.ReviewerResult, totalReviewers int, wallClock time.Duration) domain.ReviewStats {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -218,6 +218,15 @@ func (r *Runner) runReviewerWithRetry(ctx context.Context, reviewerID int) domai
 		if result.ExitCode == 0 {
 			return result
 		}
+		if ctx.Err() != nil || (result.Failure != nil && result.Failure.Kind == domain.ReviewerFailureInterrupted) {
+			if ctx.Err() != nil {
+				result.ExitCode = -1
+				result.TimedOut = false
+				result.AuthFailed = false
+				result.Failure = &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: ctx.Err().Error()}
+			}
+			return result
+		}
 
 		if result.AuthFailed {
 			if r.logger != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -290,7 +290,7 @@ func (m *mockAgent) ExecuteReview(_ context.Context, _ *agent.ReviewConfig) (*ag
 	return nil, nil
 }
 
-func (m *mockAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
+func (m *mockAgent) ExecuteSummary(_ context.Context, _ *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -319,7 +319,7 @@ func (a *cleanupWarningAgent) ExecuteReview(context.Context, *agent.ReviewConfig
 	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
 }
 
-func (a *cleanupWarningAgent) ExecuteSummary(context.Context, string, []byte) (*agent.ExecutionResult, error) {
+func (a *cleanupWarningAgent) ExecuteSummary(context.Context, *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -339,7 +339,7 @@ func (m *mockStreamingAgent) ExecuteReview(_ context.Context, _ *agent.ReviewCon
 	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
 }
 
-func (m *mockStreamingAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
+func (m *mockStreamingAgent) ExecuteSummary(_ context.Context, _ *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -619,6 +619,7 @@ type mockAuthFailAgent struct {
 	exitCode  int
 	stdout    string
 	stderr    string
+	onReview  func()
 	callCount atomic.Int32
 }
 
@@ -627,13 +628,16 @@ func (m *mockAuthFailAgent) IsAvailable() error { return nil }
 
 func (m *mockAuthFailAgent) ExecuteReview(_ context.Context, _ *agent.ReviewConfig) (*agent.ExecutionResult, error) {
 	m.callCount.Add(1)
+	if m.onReview != nil {
+		m.onReview()
+	}
 	reader := &stringReadCloser{strings.NewReader(m.stdout)}
 	exitCode := m.exitCode
 	stderr := m.stderr
 	return agent.NewExecutionResult(reader, func() int { return exitCode }, func() string { return stderr }), nil
 }
 
-func (m *mockAuthFailAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
+func (m *mockAuthFailAgent) ExecuteSummary(_ context.Context, _ *agent.SummaryConfig) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
 
@@ -733,5 +737,32 @@ func TestRunReviewerWithRetryMarksBackoffCancellationInterrupted(t *testing.T) {
 	}
 	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
 		t.Fatalf("backoff cancellation was misclassified: %#v", result)
+	}
+}
+
+func TestRunReviewerWithRetrySkipsRetryEventAfterInterruption(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	retryEvents := 0
+	mock := &mockAuthFailAgent{name: "codex", exitCode: 1, stderr: "some error", onReview: cancel}
+	r := &Runner{
+		config: Config{
+			Reviewers: 1,
+			Retries:   1,
+			Timeout:   10 * time.Second,
+			Events: Events{
+				ReviewerRetrying: func(int, string, int, int, time.Duration) { retryEvents++ },
+			},
+		},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewerWithRetry(ctx, 1)
+
+	if mock.callCount.Load() != 1 || retryEvents != 0 {
+		t.Fatalf("interrupted review retried: calls=%d retry-events=%d", mock.callCount.Load(), retryEvents)
+	}
+	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted || result.ExitCode != -1 {
+		t.Fatalf("interrupted result = %#v", result)
 	}
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -706,3 +706,32 @@ func TestRunReviewerWithRetry_RetriesNonAuthFailure(t *testing.T) {
 		t.Error("expected AuthFailed to be false for non-auth failure")
 	}
 }
+
+func TestRunReviewerWithRetryMarksBackoffCancellationInterrupted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockAuthFailAgent{name: "codex", exitCode: 1, stderr: "some error"}
+	r := &Runner{
+		config: Config{
+			Reviewers: 1,
+			Retries:   1,
+			Timeout:   10 * time.Second,
+			Events: Events{
+				ReviewerRetrying: func(int, string, int, int, time.Duration) { cancel() },
+			},
+		},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewerWithRetry(ctx, 1)
+
+	if mock.callCount.Load() != 1 || result.Attempts != 1 {
+		t.Fatalf("retry started after cancellation: calls=%d result=%#v", mock.callCount.Load(), result)
+	}
+	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted {
+		t.Fatalf("backoff cancellation was not interrupted: %#v", result)
+	}
+	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
+		t.Fatalf("backoff cancellation was misclassified: %#v", result)
+	}
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -25,10 +25,14 @@ func (s *stringReadCloser) Close() error {
 
 type errorReadCloser struct {
 	*strings.Reader
-	err error
+	err     error
+	onClose func()
 }
 
 func (r *errorReadCloser) Close() error {
+	if r.onClose != nil {
+		r.onClose()
+	}
 	return r.err
 }
 
@@ -299,6 +303,7 @@ type cleanupWarningAgent struct {
 	name     string
 	output   string
 	closeErr error
+	onClose  func()
 }
 
 func (a *cleanupWarningAgent) Name() string {
@@ -310,7 +315,7 @@ func (a *cleanupWarningAgent) IsAvailable() error {
 }
 
 func (a *cleanupWarningAgent) ExecuteReview(context.Context, *agent.ReviewConfig) (*agent.ExecutionResult, error) {
-	reader := &errorReadCloser{Reader: strings.NewReader(a.output), err: a.closeErr}
+	reader := &errorReadCloser{Reader: strings.NewReader(a.output), err: a.closeErr, onClose: a.onClose}
 	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
 }
 
@@ -504,6 +509,54 @@ func TestRunReviewerParentCancellationTakesPriority(t *testing.T) {
 	}
 	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
 		t.Fatalf("reviewer cancellation was misclassified: %#v", result)
+	}
+}
+
+func TestRunReviewerKeepsSuccessfulResultWhenCancellationArrivesAfterCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &cleanupWarningAgent{
+		name:    "codex",
+		output:  `{"item":{"type":"agent_message","text":"finding"}}`,
+		onClose: cancel,
+	}
+	r := &Runner{
+		config:    Config{Reviewers: 1, Timeout: time.Minute},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(ctx, 1)
+
+	if result.ExitCode != 0 || result.Failure != nil || len(result.Findings) != 1 {
+		t.Fatalf("completed reviewer was reclassified after cancellation: %#v", result)
+	}
+}
+
+func TestCanceledReviewersRetainAssignedAgentNames(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r, err := NewHeadless(Config{Reviewers: 2, Concurrency: 1, Timeout: time.Minute}, []agent.Agent{
+		&mockStreamingAgent{name: "codex"},
+		&mockStreamingAgent{name: "claude"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, _, runErr := r.Run(ctx)
+	if !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("Run() error = %v", runErr)
+	}
+	byID := make(map[int]domain.ReviewerResult)
+	for _, result := range results {
+		byID[result.ReviewerID] = result
+	}
+	if byID[1].AgentName != "codex" || byID[2].AgentName != "claude" {
+		t.Fatalf("canceled reviewer identities = %#v", byID)
+	}
+	stats := BuildStats(results, 2, 0)
+	if stats.ReviewerAgentNames[1] != "codex" || stats.ReviewerAgentNames[2] != "claude" {
+		t.Fatalf("canceled reviewer stats identities = %#v", stats.ReviewerAgentNames)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,6 +2,9 @@ package runner
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -18,6 +21,15 @@ type stringReadCloser struct {
 
 func (s *stringReadCloser) Close() error {
 	return nil
+}
+
+type errorReadCloser struct {
+	*strings.Reader
+	err error
+}
+
+func (r *errorReadCloser) Close() error {
+	return r.err
 }
 
 func TestBuildStats_CategorizesResults(t *testing.T) {
@@ -41,6 +53,21 @@ func TestBuildStats_CategorizesResults(t *testing.T) {
 	}
 	if stats.ParseErrors != 2 {
 		t.Errorf("expected 2 parse errors, got %d", stats.ParseErrors)
+	}
+}
+
+func TestFinishRunReportsCancellationAfterResultsWereCollected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	want := []domain.ReviewerResult{{ReviewerID: 1, ExitCode: 0}}
+
+	got, _, err := finishRun(ctx, want, time.Now())
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("finishRun error = %v, want context cancellation", err)
+	}
+	if len(got) != 1 || got[0].ReviewerID != 1 {
+		t.Fatalf("collected reviewer results were lost: %#v", got)
 	}
 }
 
@@ -268,6 +295,29 @@ type mockStreamingAgent struct {
 	output string
 }
 
+type cleanupWarningAgent struct {
+	name     string
+	output   string
+	closeErr error
+}
+
+func (a *cleanupWarningAgent) Name() string {
+	return a.name
+}
+
+func (a *cleanupWarningAgent) IsAvailable() error {
+	return nil
+}
+
+func (a *cleanupWarningAgent) ExecuteReview(context.Context, *agent.ReviewConfig) (*agent.ExecutionResult, error) {
+	reader := &errorReadCloser{Reader: strings.NewReader(a.output), err: a.closeErr}
+	return agent.NewExecutionResult(reader, func() int { return 0 }, func() string { return "" }), nil
+}
+
+func (a *cleanupWarningAgent) ExecuteSummary(context.Context, string, []byte) (*agent.ExecutionResult, error) {
+	return nil, nil
+}
+
 func (m *mockStreamingAgent) Name() string {
 	if m.name == "" {
 		return "codex"
@@ -310,6 +360,150 @@ invalid json line here
 	}
 	if result.ParseErrors != 1 {
 		t.Errorf("expected 1 parse error, got %d", result.ParseErrors)
+	}
+}
+
+func TestRunReviewerCleanupFailureIsNonfatalWarning(t *testing.T) {
+	mock := &cleanupWarningAgent{
+		name:     "codex",
+		output:   `{"item":{"type":"agent_message","text":"finding"}}`,
+		closeErr: errors.New("temporary file cleanup failed"),
+	}
+	r := &Runner{
+		config:    Config{Reviewers: 1, Timeout: time.Second},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(context.Background(), 1)
+
+	if result.ExitCode != 0 || result.Failure != nil || len(result.Findings) != 1 {
+		t.Fatalf("cleanup failure changed reviewer outcome: %#v", result)
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0].Kind != domain.ReviewerWarningCleanup {
+		t.Fatalf("cleanup warning missing: %#v", result.Warnings)
+	}
+}
+
+func TestHeadlessRunnerEmitsEarlyReturnCleanupWarningWithoutStderr(t *testing.T) {
+	mock := &cleanupWarningAgent{
+		name:     "unsupported",
+		output:   "ignored",
+		closeErr: errors.New("temporary file cleanup failed"),
+	}
+	var completed domain.ReviewerResult
+	r, err := NewHeadless(Config{
+		Reviewers:   1,
+		Concurrency: 1,
+		Timeout:     time.Second,
+		Events: Events{
+			ReviewerCompleted: func(result domain.ReviewerResult) {
+				completed = result
+			},
+		},
+	}, []agent.Agent{mock})
+	if err != nil {
+		t.Fatalf("create headless runner: %v", err)
+	}
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = originalStderr })
+
+	results, _, runErr := r.Run(context.Background())
+	os.Stderr = originalStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+
+	if runErr != nil {
+		t.Fatalf("run headless reviewer: %v", runErr)
+	}
+	if len(results) != 1 || results[0].Failure == nil || results[0].Failure.Kind != domain.ReviewerFailureParser {
+		t.Fatalf("early return outcome missing: %#v", results)
+	}
+	if len(results[0].Warnings) != 1 || results[0].Warnings[0].Kind != domain.ReviewerWarningCleanup {
+		t.Fatalf("early-return cleanup warning missing: %#v", results[0])
+	}
+	if len(completed.Warnings) != 1 || completed.Warnings[0] != results[0].Warnings[0] {
+		t.Fatalf("ReviewerCompleted did not receive cleanup warning: completed=%#v result=%#v", completed, results[0])
+	}
+	captured, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	if len(captured) != 0 {
+		t.Fatalf("headless cleanup failure wrote stderr: %q", captured)
+	}
+}
+
+func TestVerboseRunnerLogsCleanupWarningOnce(t *testing.T) {
+	mock := &cleanupWarningAgent{
+		name:     "codex",
+		output:   `{"item":{"type":"agent_message","text":"finding"}}`,
+		closeErr: errors.New("temporary file cleanup failed"),
+	}
+	stderrPath := filepath.Join(t.TempDir(), "stderr")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	originalStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = originalStderr })
+	r := &Runner{
+		config:    Config{Reviewers: 1, Timeout: time.Second, Verbose: true},
+		agents:    []agent.Agent{mock},
+		logger:    terminal.NewLogger(),
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(context.Background(), 1)
+	os.Stderr = originalStderr
+	if err := stderr.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+
+	if len(result.Warnings) != 1 || result.Warnings[0].Kind != domain.ReviewerWarningCleanup {
+		t.Fatalf("typed cleanup warning missing: %#v", result.Warnings)
+	}
+	captured, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	if strings.Count(string(captured), "close error (non-fatal)") != 1 {
+		t.Fatalf("verbose cleanup warning output = %q", captured)
+	}
+}
+
+func TestRunReviewerParentCancellationTakesPriority(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockStreamingAgent{
+		output: `{"item":{"type":"agent_message","text":"finding"}}`,
+	}
+	r := &Runner{
+		config: Config{
+			Reviewers: 1,
+			Timeout:   time.Minute,
+			Events: Events{
+				ReviewerStarted: func(int, string) { cancel() },
+			},
+		},
+		agents:    []agent.Agent{mock},
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(ctx, 1)
+
+	if result.Failure == nil || result.Failure.Kind != domain.ReviewerFailureInterrupted {
+		t.Fatalf("reviewer cancellation was not classified as interrupted: %#v", result)
+	}
+	if result.TimedOut || result.AuthFailed || result.ExitCode != -1 {
+		t.Fatalf("reviewer cancellation was misclassified: %#v", result)
 	}
 }
 

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -74,7 +74,7 @@ type inputItem struct {
 	Reviewers []int  `json:"reviewers"`
 }
 
-func Summarize(ctx context.Context, agentName, model string, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
+func Summarize(ctx context.Context, agentName, model string, aggregated []domain.AggregatedFinding, workDir string, verbose bool, logger *terminal.Logger) (*Result, error) {
 	start := time.Now()
 	if len(aggregated) == 0 {
 		return &Result{
@@ -87,10 +87,10 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 	if err != nil {
 		return nil, err
 	}
-	return summarize(ctx, ag, aggregated, verbose, logger)
+	return summarize(ctx, ag, aggregated, workDir, verbose, logger)
 }
 
-func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding) (*Result, error) {
+func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, workDir string) (*Result, error) {
 	start := time.Now()
 	if len(aggregated) == 0 {
 		return &Result{Grouped: domain.GroupedFindings{}, Duration: time.Since(start)}, nil
@@ -98,10 +98,10 @@ func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain
 	if ag == nil {
 		return nil, fmt.Errorf("summarizer agent is required")
 	}
-	return summarize(ctx, ag, aggregated, false, nil)
+	return summarize(ctx, ag, aggregated, workDir, false, nil)
 }
 
-func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
+func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, workDir string, verbose bool, logger *terminal.Logger) (*Result, error) {
 	start := time.Now()
 	agentName := ag.Name()
 
@@ -127,7 +127,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 		}, nil
 	}
 
-	execResult, err := ag.ExecuteSummary(ctx, groupPrompt, payload)
+	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: groupPrompt, Input: payload, WorkDir: workDir})
 	if err != nil {
 
 		if ctx.Err() != nil {
@@ -168,7 +168,10 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 				Warnings: append([]string(nil), warnings...),
 			}, nil
 		}
-		return nil, err
+		return &Result{
+			Duration: time.Since(start),
+			Warnings: append([]string(nil), warnings...),
+		}, err
 	}
 
 	closeExecution()

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -65,6 +65,7 @@ type Result struct {
 	Stderr   string
 	RawOut   string
 	Duration time.Duration
+	Warnings []string
 }
 
 type inputItem struct {
@@ -139,28 +140,38 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 		return nil, err
 	}
 
-	defer func() {
-		if err := execResult.Close(); err != nil && verbose && logger != nil {
-			logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
+	closed := false
+	var warnings []string
+	closeExecution := func() {
+		if closed {
+			return
 		}
-	}()
+		closed = true
+		if err := execResult.Close(); err != nil {
+			warnings = append(warnings, fmt.Sprintf("summarizer cleanup failed: %v", err))
+			if verbose && logger != nil {
+				logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
+			}
+		}
+	}
+	defer closeExecution()
 
 	output, err := io.ReadAll(execResult)
 	if err != nil {
+		closeExecution()
 
 		if ctx.Err() != nil {
 			return &Result{
 				ExitCode: -1,
 				Stderr:   "context canceled",
 				Duration: time.Since(start),
+				Warnings: append([]string(nil), warnings...),
 			}, nil
 		}
 		return nil, err
 	}
 
-	if err := execResult.Close(); err != nil && verbose && logger != nil {
-		logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
-	}
+	closeExecution()
 	exitCode := execResult.ExitCode()
 	stderr := execResult.Stderr()
 	duration := time.Since(start)
@@ -173,6 +184,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 			Stderr:   fmt.Sprintf("%s authentication failed: %s", agentName, agent.AuthHint(agentName)),
 			RawOut:   rawOut,
 			Duration: duration,
+			Warnings: append([]string(nil), warnings...),
 		}, nil
 	}
 
@@ -182,6 +194,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 			ExitCode: exitCode,
 			Stderr:   stderr,
 			Duration: duration,
+			Warnings: append([]string(nil), warnings...),
 		}, nil
 	}
 
@@ -202,6 +215,7 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 			Stderr:   parseErr,
 			RawOut:   rawOut,
 			Duration: duration,
+			Warnings: append([]string(nil), warnings...),
 		}, nil
 	}
 
@@ -211,5 +225,6 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 		Stderr:   stderr,
 		RawOut:   rawOut,
 		Duration: duration,
+		Warnings: append([]string(nil), warnings...),
 	}, nil
 }

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -75,7 +75,6 @@ type inputItem struct {
 
 func Summarize(ctx context.Context, agentName, model string, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
 	start := time.Now()
-
 	if len(aggregated) == 0 {
 		return &Result{
 			Grouped:  domain.GroupedFindings{},
@@ -87,6 +86,23 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 	if err != nil {
 		return nil, err
 	}
+	return summarize(ctx, ag, aggregated, verbose, logger)
+}
+
+func SummarizeWithAgent(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding) (*Result, error) {
+	start := time.Now()
+	if len(aggregated) == 0 {
+		return &Result{Grouped: domain.GroupedFindings{}, Duration: time.Since(start)}, nil
+	}
+	if ag == nil {
+		return nil, fmt.Errorf("summarizer agent is required")
+	}
+	return summarize(ctx, ag, aggregated, false, nil)
+}
+
+func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.AggregatedFinding, verbose bool, logger *terminal.Logger) (*Result, error) {
+	start := time.Now()
+	agentName := ag.Name()
 
 	items := make([]inputItem, len(aggregated))
 	for i, a := range aggregated {
@@ -124,7 +140,7 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 	}
 
 	defer func() {
-		if err := execResult.Close(); err != nil && verbose {
+		if err := execResult.Close(); err != nil && verbose && logger != nil {
 			logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
 		}
 	}()
@@ -142,7 +158,7 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 		return nil, err
 	}
 
-	if err := execResult.Close(); err != nil && verbose {
+	if err := execResult.Close(); err != nil && verbose && logger != nil {
 		logger.Logf(terminal.StyleDim, "summarizer close error (non-fatal): %v", err)
 	}
 	exitCode := execResult.ExitCode()

--- a/internal/summarizer/summarizer_test.go
+++ b/internal/summarizer/summarizer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestSummarize_EmptyInput(t *testing.T) {
-	result, err := Summarize(context.Background(), "codex", "", nil, false, terminal.NewLogger())
+	result, err := Summarize(context.Background(), "codex", "", nil, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestSummarize_EmptyInput(t *testing.T) {
 }
 
 func TestSummarize_EmptySlice(t *testing.T) {
-	result, err := Summarize(context.Background(), "codex", "", []domain.AggregatedFinding{}, false, terminal.NewLogger())
+	result, err := Summarize(context.Background(), "codex", "", []domain.AggregatedFinding{}, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestSummarize_ContextCanceled(t *testing.T) {
 		{Text: "Test finding", Reviewers: []int{1}},
 	}
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -105,7 +105,7 @@ EOF
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -148,7 +148,7 @@ exit 1
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "claude", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "claude", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ echo "this is not valid JSON"
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestSummarize_EmptyOutput(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -264,7 +264,7 @@ exit 42
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -305,7 +305,7 @@ EOF
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", "", findings, "", false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- introduce the typed `PullRequestKey`, `ReviewTarget`, immutable review configuration, source identity, request, and complete in-memory `ReviewRun` contracts
- extract semantic orchestration behind a headless `review.Service` with ordered ephemeral events and no terminal, prompt, posting, worktree-lifecycle, or process-CWD ownership
- separate execution status from review conclusion and retain populated evidence for completed, failed, and interrupted accepted runs
- preserve exact aggregation, filtering dispositions, reviewer outcomes, bounded diagnostics, stable run-local finding identities, and revision evidence
- scope PR feedback reads with the complete repository identity rather than ambient git state
- drain and join reviewer/feedback work on cancellation and expose cleanup failures as typed warnings without headless stderr output

This PR is intentionally stacked on #220 because the service consumes #220's immutable configuration-source identity and shared revision resolver.

Closes #193
Part of #191

## Validation

- `go test ./cmd/acr ./internal/...`
- `go test -race ./cmd/acr ./internal/agent ./internal/config ./internal/domain ./internal/feedback ./internal/git ./internal/review ./internal/runner`
- `make vet`
- `make staticcheck`
- `make lint`
- `git diff --check`
- independent implementation review found no remaining findings after cleanup-warning handling was corrected

`make check` reaches the repository's pre-existing unrelated `integration/TestVersion` fixture mismatch: the development binary reports `acr dev` while the fixture expects `acr v`. All other packages pass.