### PR TITLE
[P1] Preserve ordinary acr behavior on typed review service

### DIFF
--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -157,6 +157,7 @@ func registerSharedReviewFlags(cmd *cobra.Command) {
 
 type worktreeResult struct {
 	workDir          string
+	repositoryRoot   string
 	detectedBase     string
 	baseAutoDetected bool
 	prRemote         string
@@ -207,6 +208,7 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 			return result, exitCode(domain.ExitError)
 		}
 		result.prRepoRoot = repoRoot
+		result.repositoryRoot = repoRoot
 
 		remote, err := github.FindRepoRemote(ctx, repoRoot)
 		if err != nil {
@@ -251,6 +253,7 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 				logger.Logf(terminal.StyleError, "Error getting repo root: %v", err)
 				return result, exitCode(domain.ExitError)
 			}
+			result.repositoryRoot = repoRoot
 
 			if err := git.AddRemote(repoRoot, forkRef.RemoteName, forkRef.RepoURL); err != nil {
 				logger.Logf(terminal.StyleError, "Error adding remote: %v", err)
@@ -498,6 +501,19 @@ func runReview(cmd *cobra.Command, _ []string) error {
 		return contextualExit(ctx, err)
 	}
 
+	repositoryRoot := wt.repositoryRoot
+	if repositoryRoot == "" {
+		repositoryRoot, err = git.GetRoot()
+		if err != nil {
+			logger.Logf(terminal.StyleError, "%v", err)
+			return contextualExit(ctx, exitCode(domain.ExitError))
+		}
+	}
+	reviewWorktreeRoot := wt.workDir
+	if reviewWorktreeRoot == "" {
+		reviewWorktreeRoot = repositoryRoot
+	}
+
 	detectedPR := prNumber
 	if detectedPR == "" && !local && cfgResult.resolved.PRFeedbackEnabled && github.IsGHAvailable() {
 		if detected, err := github.GetCurrentPRNumber(ctx, worktreeBranch); err == nil {
@@ -518,7 +534,9 @@ func runReview(cmd *cobra.Command, _ []string) error {
 		WorktreeBranch:  worktreeBranch,
 		UseRefFile:      refFile,
 		ExcludePatterns: cfgResult.excludePatterns,
-		WorkDir:         wt.workDir,
+		RepositoryRoot:  repositoryRoot,
+		WorkDir:         reviewWorktreeRoot,
+		ConfigSource:    cfgResult.source,
 	}
 	code := executeReview(ctx, opts, logger)
 	return exitCode(code)

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -20,7 +20,7 @@ import (
 
 const geminiDeprecationWarning = "Gemini CLI is deprecated for consumer use. ACR still supports gemini for enterprise Gemini CLI users, but use agy for new or non-enterprise Google-agent usage. Google says individual Gemini CLI requests stop serving on June 18, 2026: https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/"
 
-func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger) domain.ExitCode {
+func executeLegacyReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger) domain.ExitCode {
 	if opts.Concurrency < opts.Reviewers {
 		logger.Logf(terminal.StyleInfo, "Starting review %s(%d reviewers, %d concurrent, base=%s)%s",
 			terminal.Color(terminal.Dim), opts.Reviewers, opts.Concurrency, opts.Base, terminal.Color(terminal.Reset))

--- a/cmd/acr/review_events.go
+++ b/cmd/acr/review_events.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	reviewpkg "github.com/richhaase/agentic-code-reviewer/internal/review"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+)
+
+const reviewerOutputPreviewLength = 120
+
+type runningReviewSpinner struct {
+	cancel    context.CancelFunc
+	done      chan struct{}
+	completed func()
+}
+
+func (s *runningReviewSpinner) Stop() {
+	if s == nil || s.cancel == nil {
+		return
+	}
+	s.cancel()
+	<-s.done
+	s.cancel = nil
+}
+
+type cliReviewEvents struct {
+	opts              ReviewOpts
+	logger            *terminal.Logger
+	reviewers         *runningReviewSpinner
+	summarization     *runningReviewSpinner
+	falsePositivePass *runningReviewSpinner
+}
+
+func newCLIReviewEvents(opts ReviewOpts, logger *terminal.Logger) *cliReviewEvents {
+	return &cliReviewEvents{opts: opts, logger: logger}
+}
+
+func (e *cliReviewEvents) HandleReviewEvent(event reviewpkg.Event) {
+	switch event.Kind {
+	case reviewpkg.EventPhaseStarted:
+		e.startPhase(event.Phase)
+	case reviewpkg.EventPhaseCompleted:
+		e.completePhase(event)
+	case reviewpkg.EventReviewerOutput:
+		e.reviewerOutput(event)
+	case reviewpkg.EventReviewerRetrying:
+		e.logger.Logf(terminal.StyleWarning, "Reviewer #%d %s", event.ReviewerID, event.Message)
+	case reviewpkg.EventReviewerCompleted:
+		if e.reviewers != nil && e.reviewers.completed != nil {
+			e.reviewers.completed()
+		}
+	case reviewpkg.EventWarning:
+		e.warning(event)
+	case reviewpkg.EventRunCompleted:
+		e.Close()
+	}
+}
+
+func (e *cliReviewEvents) startPhase(phase domain.ReviewPhase) {
+	switch phase {
+	case domain.ReviewPhaseFeedback:
+		if e.opts.DetectedPR != "" {
+			e.logger.Logf(terminal.StyleInfo, "Summarizing PR #%s feedback %s(in parallel)%s",
+				e.opts.DetectedPR, terminal.Color(terminal.Dim), terminal.Color(terminal.Reset))
+		}
+	case domain.ReviewPhaseReviewers:
+		spinner := terminal.NewSpinner(e.opts.Reviewers)
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		e.reviewers = &runningReviewSpinner{
+			cancel: cancel,
+			done:   done,
+			completed: func() {
+				spinner.Completed().Add(1)
+			},
+		}
+		go func() {
+			spinner.Run(ctx)
+			close(done)
+		}()
+	case domain.ReviewPhaseSummarization:
+		e.summarization = startPhaseSpinner("Summarizing")
+	case domain.ReviewPhaseFalsePositiveFilter:
+		e.falsePositivePass = startPhaseSpinner("Filtering false positives")
+	}
+}
+
+func (e *cliReviewEvents) completePhase(event reviewpkg.Event) {
+	switch event.Phase {
+	case domain.ReviewPhaseFeedback:
+		switch event.Message {
+		case "summarized":
+			e.logger.Log("PR feedback summarized", terminal.StyleSuccess)
+		case "empty":
+			e.logger.Log("No relevant PR feedback found", terminal.StyleDim)
+		}
+	case domain.ReviewPhaseReviewers:
+		e.reviewers.Stop()
+	case domain.ReviewPhaseSummarization:
+		e.summarization.Stop()
+	case domain.ReviewPhaseFalsePositiveFilter:
+		e.falsePositivePass.Stop()
+	}
+}
+
+func (e *cliReviewEvents) reviewerOutput(event reviewpkg.Event) {
+	if !e.opts.Verbose {
+		return
+	}
+	message := event.Message
+	if len(message) > reviewerOutputPreviewLength {
+		message = message[:reviewerOutputPreviewLength] + "..."
+	}
+	e.logger.Logf(terminal.StyleDim, "%s#%d:%s %s%s%s",
+		terminal.Color(terminal.Dim), event.ReviewerID, terminal.Color(terminal.Reset),
+		terminal.Color(terminal.Dim), message, terminal.Color(terminal.Reset))
+}
+
+func (e *cliReviewEvents) warning(event reviewpkg.Event) {
+	switch event.Phase {
+	case domain.ReviewPhaseReviewers:
+		if event.ReviewerID != 0 {
+			e.logger.Logf(terminal.StyleWarning, "Reviewer #%d: %s", event.ReviewerID, event.Message)
+		}
+	case domain.ReviewPhaseFeedback:
+		message := strings.TrimPrefix(event.Message, "prior feedback unavailable: ")
+		message = strings.TrimPrefix(message, "prior feedback warning: ")
+		if strings.Contains(message, context.DeadlineExceeded.Error()) {
+			e.logger.Logf(terminal.StyleWarning, "PR feedback summarizer timed out after %s", e.opts.SummarizerTimeout)
+			return
+		}
+		e.logger.Logf(terminal.StyleWarning, "PR feedback summarizer failed: %s", message)
+	case domain.ReviewPhaseFalsePositiveFilter:
+		if strings.HasPrefix(event.Message, "false-positive filter skipped: ") {
+			reason := strings.TrimPrefix(event.Message, "false-positive filter skipped: ")
+			e.logger.Logf(terminal.StyleWarning, "FP filter skipped (%s): showing all findings", reason)
+			return
+		}
+		e.logger.Log(event.Message, terminal.StyleWarning)
+	case domain.ReviewPhaseSummarization:
+		e.logger.Log(event.Message, terminal.StyleWarning)
+	}
+}
+
+func (e *cliReviewEvents) Close() {
+	if e == nil {
+		return
+	}
+	e.reviewers.Stop()
+	e.summarization.Stop()
+	e.falsePositivePass.Stop()
+}
+
+func startPhaseSpinner(label string) *runningReviewSpinner {
+	spinner := terminal.NewPhaseSpinner(label)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		spinner.Run(ctx)
+		close(done)
+	}()
+	return &runningReviewSpinner{cancel: cancel, done: done}
+}

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/richhaase/agentic-code-reviewer/internal/config"
+import (
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
 
 type ReviewOpts struct {
 	config.ResolvedConfig
@@ -13,7 +16,10 @@ type ReviewOpts struct {
 	WorktreeBranch  string
 	UseRefFile      bool
 	ExcludePatterns []string
+	RepositoryRoot  string
 	WorkDir         string
+	PullRequest     *domain.PullRequestKey
+	ConfigSource    config.SourceIdentity
 
 	ForcePostComment bool
 	ExpectedHeadSHA  string

--- a/cmd/acr/review_typed.go
+++ b/cmd/acr/review_typed.go
@@ -245,12 +245,16 @@ func handleTypedReviewFailure(run *domain.ReviewRun, logger *terminal.Logger) do
 		logger.Logf(terminal.StyleError, "Failed to get diff: %s", run.Failure.Message)
 	case domain.ReviewPhaseReviewers:
 		if strings.Contains(run.Failure.Message, "all reviewers failed") {
+			logAuthenticationFailures(run.Stats, logger)
 			logger.Log("All reviewers failed", terminal.StyleError)
 		} else {
 			logger.Logf(terminal.StyleError, "Review failed: %s", run.Failure.Message)
 		}
 	case domain.ReviewPhaseSummarization:
 		if strings.Contains(run.Failure.Message, "summarizer timed out") {
+			if diagnostic := retainedSummarizerTimeoutDiagnostic(run.Summarizer.Stderr, run.Failure.Message); diagnostic != "" {
+				logger.Logf(terminal.StyleError, "Summarizer stderr: %s", diagnostic)
+			}
 			logger.Logf(terminal.StyleError, "Summarizer timed out after %s", run.Configuration.Values().SummarizerTimeout)
 		} else {
 			logger.Logf(terminal.StyleError, "Summarizer error: %s", run.Failure.Message)
@@ -261,6 +265,42 @@ func handleTypedReviewFailure(run *domain.ReviewRun, logger *terminal.Logger) do
 		logger.Logf(terminal.StyleError, "Review failed: %s", run.Failure.Message)
 	}
 	return domain.ExitError
+}
+
+func logAuthenticationFailures(stats domain.ReviewStats, logger *terminal.Logger) {
+	if len(stats.AuthFailedReviewers) == 0 {
+		return
+	}
+	reviewers := make([]string, 0, len(stats.AuthFailedReviewers))
+	hints := make([]string, 0, len(stats.AuthFailedReviewers))
+	seenHints := make(map[string]struct{})
+	for _, reviewerID := range stats.AuthFailedReviewers {
+		agentName := stats.ReviewerAgentNames[reviewerID]
+		if agentName == "" {
+			reviewers = append(reviewers, fmt.Sprintf("#%d", reviewerID))
+			continue
+		}
+		reviewers = append(reviewers, fmt.Sprintf("#%d (%s)", reviewerID, agentName))
+		hint := agent.AuthHint(agentName)
+		if _, seen := seenHints[hint]; seen {
+			continue
+		}
+		seenHints[hint] = struct{}{}
+		hints = append(hints, fmt.Sprintf("Authentication hint (%s): %s", agentName, hint))
+	}
+	logger.Logf(terminal.StyleError, "Auth failed reviewers: %s", strings.Join(reviewers, ", "))
+	for _, hint := range hints {
+		logger.Log(hint, terminal.StyleError)
+	}
+}
+
+func retainedSummarizerTimeoutDiagnostic(stderr, timeoutEvidence string) string {
+	stderr = strings.TrimSpace(stderr)
+	timeoutEvidence = strings.TrimSpace(timeoutEvidence)
+	if stderr == timeoutEvidence {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimSuffix(stderr, "\n"+timeoutEvidence))
 }
 
 func configurationSourceIdentity(source config.SourceIdentity) domain.ConfigurationSourceIdentity {

--- a/cmd/acr/review_typed.go
+++ b/cmd/acr/review_typed.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/git"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	reviewpkg "github.com/richhaase/agentic-code-reviewer/internal/review"
+	"github.com/richhaase/agentic-code-reviewer/internal/runner"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+)
+
+type semanticReviewService interface {
+	Run(context.Context, reviewpkg.Request) (*domain.ReviewRun, error)
+}
+
+func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger) domain.ExitCode {
+	logReviewStart(opts, logger)
+
+	if usesGeminiAgent(opts) {
+		logger.Logf(terminal.StyleWarning, "%s", geminiDeprecationWarning)
+	}
+
+	reviewAgents, ready := prepareReviewAgents(opts, logger)
+	if !ready {
+		return domain.ExitError
+	}
+	logAgentDistribution(opts, reviewAgents, logger)
+
+	resolvedBaseRef := resolveReviewBase(ctx, opts, logger)
+	if opts.PullRequest == nil && opts.DetectedPR != "" {
+		pullRequest, err := github.GetPullRequestKey(ctx, opts.RepositoryRoot, opts.DetectedPR)
+		if err != nil {
+			logger.Logf(terminal.StyleWarning, "PR feedback summarizer failed: could not resolve PR identity: %v", err)
+		} else {
+			opts.PullRequest = &pullRequest
+		}
+	}
+	events := newCLIReviewEvents(opts, logger)
+	defer events.Close()
+
+	service, err := reviewpkg.NewService(reviewpkg.WithDiffProvider(func(ctx context.Context, target domain.ReviewTarget) (string, error) {
+		diff, err := git.GetDiff(ctx, target.Revision.BaseObjectID, target.WorktreeRoot)
+		if err != nil {
+			return "", err
+		}
+		if diff != "" && opts.Verbose {
+			logger.Logf(terminal.StyleDim, "Diff size: %d bytes", len(diff))
+			if opts.UseRefFile {
+				logger.Logf(terminal.StyleDim, "Ref-file mode enabled")
+			}
+		}
+		return diff, nil
+	}))
+	if err != nil {
+		logger.Logf(terminal.StyleError, "Review failed: %v", err)
+		return domain.ExitError
+	}
+
+	return executeTypedReview(ctx, opts, resolvedBaseRef, service, events, logger)
+}
+
+func logReviewStart(opts ReviewOpts, logger *terminal.Logger) {
+	if opts.Concurrency < opts.Reviewers {
+		logger.Logf(terminal.StyleInfo, "Starting review %s(%d reviewers, %d concurrent, base=%s)%s",
+			terminal.Color(terminal.Dim), opts.Reviewers, opts.Concurrency, opts.Base, terminal.Color(terminal.Reset))
+		return
+	}
+	logger.Logf(terminal.StyleInfo, "Starting review %s(%d reviewers, base=%s)%s",
+		terminal.Color(terminal.Dim), opts.Reviewers, opts.Base, terminal.Color(terminal.Reset))
+}
+
+func prepareReviewAgents(opts ReviewOpts, logger *terminal.Logger) ([]agent.Agent, bool) {
+	if err := agent.ValidateAgentNames(opts.ReviewerAgents); err != nil {
+		logger.Logf(terminal.StyleError, "Invalid agent: %v", err)
+		return nil, false
+	}
+	reviewAgents, err := agent.CreateAgentsWithModel(opts.ReviewerAgents, opts.ReviewerModel)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "%v", err)
+		return nil, false
+	}
+	summarizerAgent, err := agent.NewAgentWithModel(opts.SummarizerAgent, opts.SummarizerModel)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "Invalid summarizer agent: %v", err)
+		return nil, false
+	}
+	if err := summarizerAgent.IsAvailable(); err != nil {
+		logger.Logf(terminal.StyleError, "%s CLI not found (summarizer): %v", opts.SummarizerAgent, err)
+		return nil, false
+	}
+	return reviewAgents, true
+}
+
+func logAgentDistribution(opts ReviewOpts, reviewAgents []agent.Agent, logger *terminal.Logger) {
+	if len(reviewAgents) > 1 {
+		distribution := agent.FormatDistribution(reviewAgents, opts.Reviewers)
+		logger.Logf(terminal.StyleInfo, "Agent distribution: %s%s%s",
+			terminal.Color(terminal.Dim), distribution, terminal.Color(terminal.Reset))
+	} else if opts.Verbose && len(opts.ReviewerAgents) > 0 {
+		logger.Logf(terminal.StyleDim, "%sUsing agent: %s%s",
+			terminal.Color(terminal.Dim), opts.ReviewerAgents[0], terminal.Color(terminal.Reset))
+	}
+}
+
+func resolveReviewBase(ctx context.Context, opts ReviewOpts, logger *terminal.Logger) string {
+	resolvedBaseRef := opts.Base
+	if !opts.Fetch {
+		return resolvedBaseRef
+	}
+	if !git.IsRelativeRef(opts.Base) {
+		branchResult := git.UpdateCurrentBranch(ctx, opts.WorkDir)
+		if branchResult.Updated && opts.Verbose {
+			logger.Logf(terminal.StyleDim, "Updated branch %s from origin", branchResult.BranchName)
+		}
+		if branchResult.Error != nil {
+			logger.Logf(terminal.StyleWarning, "Could not update %s from origin: %v (reviewing local state)", branchResult.BranchName, branchResult.Error)
+		}
+	}
+	result := git.FetchRemoteRef(ctx, opts.Base, opts.WorkDir)
+	resolvedBaseRef = result.ResolvedRef
+	if result.FetchAttempted && !result.RefResolved {
+		logger.Logf(terminal.StyleWarning, "Failed to fetch %s from origin, comparing against local %s (may be stale)", opts.Base, resolvedBaseRef)
+	} else if opts.Verbose && result.FetchAttempted && result.RefResolved {
+		logger.Logf(terminal.StyleDim, "Comparing against %s (fetched from origin)", resolvedBaseRef)
+	}
+	return resolvedBaseRef
+}
+
+func executeTypedReview(ctx context.Context, opts ReviewOpts, resolvedBaseRef string, service semanticReviewService, events reviewpkg.EventSink, logger *terminal.Logger) domain.ExitCode {
+	request, err := newReviewRequest(opts, resolvedBaseRef, events)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "Review failed: %v", err)
+		return domain.ExitError
+	}
+	run, err := service.Run(ctx, request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return domain.ExitInterrupted
+		}
+		logger.Logf(terminal.StyleError, "Review failed: %v", err)
+		return domain.ExitError
+	}
+	return handleTypedReviewRun(ctx, opts, run, logger)
+}
+
+func newReviewRequest(opts ReviewOpts, resolvedBaseRef string, events reviewpkg.EventSink) (reviewpkg.Request, error) {
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         opts.Reviewers,
+		Concurrency:       opts.Concurrency,
+		Timeout:           opts.Timeout,
+		Retries:           opts.Retries,
+		ReviewerAgents:    opts.ReviewerAgents,
+		ReviewerModel:     opts.ReviewerModel,
+		SummarizerAgent:   opts.SummarizerAgent,
+		SummarizerModel:   opts.SummarizerModel,
+		SummarizerTimeout: opts.SummarizerTimeout,
+		FPFilterTimeout:   opts.FPFilterTimeout,
+		Guidance:          opts.Guidance,
+		UseRefFile:        opts.UseRefFile,
+		FPFilterEnabled:   opts.FPFilterEnabled,
+		FPThreshold:       opts.FPThreshold,
+		PRFeedbackEnabled: opts.PRFeedbackEnabled,
+		PRFeedbackAgent:   opts.PRFeedbackAgent,
+		ExcludePatterns:   opts.ExcludePatterns,
+	})
+	if err != nil {
+		return reviewpkg.Request{}, err
+	}
+	engineVersion, _, _ := getVersionInfo()
+	return reviewpkg.Request{
+		Target: domain.ReviewTarget{
+			RepositoryRoot: opts.RepositoryRoot,
+			WorktreeRoot:   opts.WorkDir,
+			Revision: domain.RevisionEvidence{
+				RequestedBaseRef: opts.Base,
+				ResolvedBaseRef:  resolvedBaseRef,
+			},
+			PullRequest: opts.PullRequest,
+		},
+		Trigger:             domain.ReviewTriggerManual,
+		Engine:              domain.ReviewEngine{Name: "acr", Version: engineVersion},
+		Configuration:       configuration,
+		ConfigurationSource: configurationSourceIdentity(opts.ConfigSource),
+		Events:              events,
+	}, nil
+}
+
+func handleTypedReviewRun(ctx context.Context, opts ReviewOpts, run *domain.ReviewRun, logger *terminal.Logger) domain.ExitCode {
+	if run == nil {
+		logger.Log("Review failed: no review result returned", terminal.StyleError)
+		return domain.ExitError
+	}
+	if run.Status == domain.ReviewStatusInterrupted {
+		return domain.ExitInterrupted
+	}
+	if run.Status == domain.ReviewStatusFailed {
+		return handleTypedReviewFailure(run, logger)
+	}
+	if run.Status != domain.ReviewStatusCompleted {
+		logger.Logf(terminal.StyleError, "Review failed: unexpected review status %q", run.Status)
+		return domain.ExitError
+	}
+	if run.Conclusion == domain.ReviewConclusionNoChanges {
+		logger.Logf(terminal.StyleSuccess, "No changes detected between HEAD and %s. Nothing to review.", run.Target.Revision.ResolvedBaseRef)
+		opts.record(OutcomeNoChanges)
+		return domain.ExitNoFindings
+	}
+	if run.Conclusion != domain.ReviewConclusionClean && run.Conclusion != domain.ReviewConclusionFindings {
+		logger.Logf(terminal.StyleError, "Review failed: unexpected review conclusion %q", run.Conclusion)
+		return domain.ExitError
+	}
+
+	fmt.Println(runner.RenderReviewRun(*run))
+	grouped := run.FinalGroupedFindings()
+	if run.Conclusion == domain.ReviewConclusionClean {
+		return handleLGTM(ctx, opts, run.RawFindings, run.AggregatedFindings, run.Dispositions, run.Stats, logger)
+	}
+	return handleFindings(ctx, opts, grouped, run.AggregatedFindings, run.Stats, logger)
+}
+
+func handleTypedReviewFailure(run *domain.ReviewRun, logger *terminal.Logger) domain.ExitCode {
+	if run.Failure == nil {
+		logger.Log("Review failed without failure evidence", terminal.StyleError)
+		return domain.ExitError
+	}
+	if run.Failure.Phase == domain.ReviewPhaseSummarization && run.Summarizer.ExitCode != 0 && !strings.Contains(run.Failure.Message, "summarizer timed out") && !strings.Contains(run.Failure.Message, "read summarizer output") {
+		fmt.Println(runner.RenderReviewRun(*run))
+		return domain.ExitError
+	}
+	switch run.Failure.Phase {
+	case domain.ReviewPhaseInitialization:
+		message := run.Failure.Message
+		if strings.Contains(message, "isolated post-processing workspace") {
+			logger.Logf(terminal.StyleError, "Failed to create isolated post-processing workspace: %s", strings.TrimPrefix(message, "create isolated post-processing workspace: "))
+		} else {
+			logger.Logf(terminal.StyleError, "Review failed: %s", message)
+		}
+	case domain.ReviewPhaseRevisions, domain.ReviewPhaseDiff:
+		logger.Logf(terminal.StyleError, "Failed to get diff: %s", run.Failure.Message)
+	case domain.ReviewPhaseReviewers:
+		if strings.Contains(run.Failure.Message, "all reviewers failed") {
+			logger.Log("All reviewers failed", terminal.StyleError)
+		} else {
+			logger.Logf(terminal.StyleError, "Review failed: %s", run.Failure.Message)
+		}
+	case domain.ReviewPhaseSummarization:
+		if strings.Contains(run.Failure.Message, "summarizer timed out") {
+			logger.Logf(terminal.StyleError, "Summarizer timed out after %s", run.Configuration.Values().SummarizerTimeout)
+		} else {
+			logger.Logf(terminal.StyleError, "Summarizer error: %s", run.Failure.Message)
+		}
+	case domain.ReviewPhaseExcludeFilter:
+		logger.Logf(terminal.StyleError, "Invalid exclude pattern: %s", run.Failure.Message)
+	default:
+		logger.Logf(terminal.StyleError, "Review failed: %s", run.Failure.Message)
+	}
+	return domain.ExitError
+}
+
+func configurationSourceIdentity(source config.SourceIdentity) domain.ConfigurationSourceIdentity {
+	return domain.ConfigurationSourceIdentity{
+		Kind:          source.Kind,
+		Locator:       source.Locator,
+		Ref:           source.Ref,
+		Revision:      source.Revision,
+		ConfigPresent: source.ConfigPresent,
+		ConfigDigest:  source.ConfigDigest,
+	}
+}

--- a/cmd/acr/review_typed_test.go
+++ b/cmd/acr/review_typed_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	reviewpkg "github.com/richhaase/agentic-code-reviewer/internal/review"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+)
+
+type capturedReviewService struct {
+	request reviewpkg.Request
+	run     *domain.ReviewRun
+	err     error
+}
+
+type noopReviewEventSink struct{}
+
+func (*noopReviewEventSink) HandleReviewEvent(reviewpkg.Event) {}
+
+func (s *capturedReviewService) Run(_ context.Context, request reviewpkg.Request) (*domain.ReviewRun, error) {
+	s.request = request
+	return s.run, s.err
+}
+
+func typedReviewOpts() ReviewOpts {
+	return ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			Reviewers:         3,
+			Concurrency:       2,
+			Base:              "main",
+			Timeout:           2 * time.Minute,
+			Retries:           2,
+			ReviewerAgents:    []string{"codex", "claude"},
+			ReviewerModel:     "review-model",
+			SummarizerAgent:   "codex",
+			SummarizerModel:   "summary-model",
+			SummarizerTimeout: 3 * time.Minute,
+			FPFilterTimeout:   4 * time.Minute,
+			Guidance:          "trusted guidance",
+			FPFilterEnabled:   true,
+			FPThreshold:       81,
+			PRFeedbackEnabled: true,
+			PRFeedbackAgent:   "claude",
+		},
+		Local:           true,
+		DetectedPR:      "195",
+		UseRefFile:      true,
+		ExcludePatterns: []string{"generated"},
+		RepositoryRoot:  "/tmp/repository",
+		WorkDir:         "/tmp/repository/worktree",
+		PullRequest: &domain.PullRequestKey{
+			Host:       "github.com",
+			Owner:      "richhaase",
+			Repository: "agentic-code-reviewer",
+			Number:     195,
+		},
+		ConfigSource: config.SourceIdentity{
+			Kind:          config.SourceKindRepositoryRevision,
+			Locator:       "/tmp/repository",
+			Ref:           "refs/acr/trusted-config/origin/main",
+			Revision:      "trusted-revision",
+			ConfigPresent: true,
+			ConfigDigest:  "trusted-digest",
+		},
+	}
+}
+
+func TestNewReviewRequestMapsOrdinaryCLIInputs(t *testing.T) {
+	opts := typedReviewOpts()
+	sink := &noopReviewEventSink{}
+	request, err := newReviewRequest(opts, "origin/main", sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Trigger != domain.ReviewTriggerManual {
+		t.Fatalf("trigger = %q", request.Trigger)
+	}
+	if request.Target.RepositoryRoot != opts.RepositoryRoot || request.Target.WorktreeRoot != opts.WorkDir {
+		t.Fatalf("target roots = %#v", request.Target)
+	}
+	if request.Target.Revision.RequestedBaseRef != "main" || request.Target.Revision.ResolvedBaseRef != "origin/main" {
+		t.Fatalf("target revision = %#v", request.Target.Revision)
+	}
+	if request.Target.PullRequest == nil || *request.Target.PullRequest != *opts.PullRequest {
+		t.Fatalf("pull request = %#v", request.Target.PullRequest)
+	}
+	if request.Engine.Name != "acr" || request.Engine.Version == "" {
+		t.Fatalf("engine = %#v", request.Engine)
+	}
+	if request.Events != sink {
+		t.Fatal("event sink was not preserved")
+	}
+	wantSource := configurationSourceIdentity(opts.ConfigSource)
+	if request.ConfigurationSource != wantSource {
+		t.Fatalf("configuration source = %#v, want %#v", request.ConfigurationSource, wantSource)
+	}
+	values := request.Configuration.Values()
+	wantValues := domain.ReviewConfigurationValues{
+		Reviewers:         opts.Reviewers,
+		Concurrency:       opts.Concurrency,
+		Timeout:           opts.Timeout,
+		Retries:           opts.Retries,
+		ReviewerAgents:    opts.ReviewerAgents,
+		ReviewerModel:     opts.ReviewerModel,
+		SummarizerAgent:   opts.SummarizerAgent,
+		SummarizerModel:   opts.SummarizerModel,
+		SummarizerTimeout: opts.SummarizerTimeout,
+		FPFilterTimeout:   opts.FPFilterTimeout,
+		Guidance:          opts.Guidance,
+		UseRefFile:        opts.UseRefFile,
+		FPFilterEnabled:   opts.FPFilterEnabled,
+		FPThreshold:       opts.FPThreshold,
+		PRFeedbackEnabled: opts.PRFeedbackEnabled,
+		PRFeedbackAgent:   opts.PRFeedbackAgent,
+		ExcludePatterns:   opts.ExcludePatterns,
+	}
+	if !reflect.DeepEqual(values, wantValues) {
+		t.Fatalf("configuration values = %#v, want %#v", values, wantValues)
+	}
+}
+
+func TestExecuteTypedReviewPassesRequestAndHandlesNoChanges(t *testing.T) {
+	opts := typedReviewOpts()
+	outcome := &CycleOutcome{}
+	opts.Outcome = outcome
+	service := &capturedReviewService{run: &domain.ReviewRun{
+		Status:     domain.ReviewStatusCompleted,
+		Conclusion: domain.ReviewConclusionNoChanges,
+		Target: domain.ReviewTarget{Revision: domain.RevisionEvidence{
+			ResolvedBaseRef: "origin/main",
+		}},
+	}}
+	sink := &noopReviewEventSink{}
+	code := executeTypedReview(context.Background(), opts, "origin/main", service, sink, terminal.NewLogger())
+	if code != domain.ExitNoFindings || outcome.Kind != OutcomeNoChanges {
+		t.Fatalf("code = %d, outcome = %d", code, outcome.Kind)
+	}
+	if service.request.Trigger != domain.ReviewTriggerManual || service.request.Events != sink {
+		t.Fatalf("request = %#v", service.request)
+	}
+}
+
+func TestHandleTypedReviewRunPreservesCompletedOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		conclusion domain.ReviewConclusion
+		want       domain.ExitCode
+	}{
+		{name: "clean", conclusion: domain.ReviewConclusionClean, want: domain.ExitNoFindings},
+		{name: "findings", conclusion: domain.ReviewConclusionFindings, want: domain.ExitFindings},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := typedReviewOpts()
+			group := domain.FindingGroup{Title: "Finding", Summary: "Evidence", Sources: []int{0}}
+			run := &domain.ReviewRun{
+				Status:     domain.ReviewStatusCompleted,
+				Conclusion: tt.conclusion,
+				Stats:      domain.ReviewStats{TotalReviewers: 3, SuccessfulReviewers: 2, FailedReviewers: []int{3}},
+				Summarizer: domain.SummarizerOutcome{ExitCode: 0},
+			}
+			if tt.conclusion == domain.ReviewConclusionFindings {
+				run.Findings = []domain.ReviewFinding{{ID: "finding-001", Kind: domain.ReviewFindingActionable, Group: group}}
+			}
+			if got := handleTypedReviewRun(context.Background(), opts, run, terminal.NewLogger()); got != tt.want {
+				t.Fatalf("exit = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleTypedReviewRunPreservesFailuresAndInterruptions(t *testing.T) {
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"codex"},
+		SummarizerAgent:   "codex",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		run  *domain.ReviewRun
+		want domain.ExitCode
+	}{
+		{
+			name: "interrupted",
+			run:  &domain.ReviewRun{Status: domain.ReviewStatusInterrupted},
+			want: domain.ExitInterrupted,
+		},
+		{
+			name: "all reviewers failed",
+			run: &domain.ReviewRun{
+				Status:  domain.ReviewStatusFailed,
+				Failure: &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: "all reviewers failed"},
+			},
+			want: domain.ExitError,
+		},
+		{
+			name: "summarizer timeout",
+			run: &domain.ReviewRun{
+				Status:        domain.ReviewStatusFailed,
+				Configuration: configuration,
+				Failure:       &domain.ReviewFailure{Phase: domain.ReviewPhaseSummarization, Message: "summarizer timed out after 1m0s"},
+			},
+			want: domain.ExitError,
+		},
+		{
+			name: "summarizer read failure",
+			run: &domain.ReviewRun{
+				Status:     domain.ReviewStatusFailed,
+				Summarizer: domain.SummarizerOutcome{ExitCode: -1, DiagnosticOutput: "partial output"},
+				Failure:    &domain.ReviewFailure{Phase: domain.ReviewPhaseSummarization, Message: "read summarizer output: stream failed"},
+			},
+			want: domain.ExitError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := handleTypedReviewRun(context.Background(), typedReviewOpts(), tt.run, terminal.NewLogger()); got != tt.want {
+				t.Fatalf("exit = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteTypedReviewPreservesServiceErrors(t *testing.T) {
+	service := &capturedReviewService{err: errors.New("service unavailable")}
+	code := executeTypedReview(context.Background(), typedReviewOpts(), "origin/main", service, nil, terminal.NewLogger())
+	if code != domain.ExitError {
+		t.Fatalf("exit = %d", code)
+	}
+}
+
+func TestCLIReviewEventsCompletesEveryProgressPhase(t *testing.T) {
+	events := newCLIReviewEvents(ReviewOpts{ResolvedConfig: config.ResolvedConfig{Reviewers: 2}}, terminal.NewLogger())
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventPhaseStarted, Phase: domain.ReviewPhaseReviewers})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventReviewerCompleted})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventReviewerCompleted})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventPhaseCompleted, Phase: domain.ReviewPhaseReviewers})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventPhaseStarted, Phase: domain.ReviewPhaseSummarization})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventPhaseCompleted, Phase: domain.ReviewPhaseSummarization})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventPhaseStarted, Phase: domain.ReviewPhaseFalsePositiveFilter})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventPhaseCompleted, Phase: domain.ReviewPhaseFalsePositiveFilter})
+	events.HandleReviewEvent(reviewpkg.Event{Kind: reviewpkg.EventRunCompleted})
+	events.Close()
+}

--- a/cmd/acr/review_typed_test.go
+++ b/cmd/acr/review_typed_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	reviewpkg "github.com/richhaase/agentic-code-reviewer/internal/review"
@@ -232,6 +234,75 @@ func TestHandleTypedReviewRunPreservesFailuresAndInterruptions(t *testing.T) {
 				t.Fatalf("exit = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestHandleTypedReviewFailureRendersDeduplicatedAuthenticationGuidance(t *testing.T) {
+	run := &domain.ReviewRun{
+		Status:  domain.ReviewStatusFailed,
+		Failure: &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: "all reviewers failed"},
+		Stats: domain.ReviewStats{
+			AuthFailedReviewers: []int{1, 2, 3},
+			ReviewerAgentNames: map[int]string{
+				1: "codex",
+				2: "codex",
+				3: "claude",
+			},
+		},
+	}
+	output := captureWatchStderr(t, func() {
+		if got := handleTypedReviewFailure(run, terminal.NewLogger()); got != domain.ExitError {
+			t.Fatalf("exit = %d", got)
+		}
+	})
+	if !strings.Contains(output, "Auth failed reviewers: #1 (codex), #2 (codex), #3 (claude)") {
+		t.Fatalf("auth failed reviewers missing: %q", output)
+	}
+	if strings.Count(output, agent.AuthHint("codex")) != 1 {
+		t.Fatalf("codex authentication hint was not rendered once: %q", output)
+	}
+	if strings.Count(output, agent.AuthHint("claude")) != 1 {
+		t.Fatalf("claude authentication hint was not rendered once: %q", output)
+	}
+	if !strings.Contains(output, "All reviewers failed") {
+		t.Fatalf("generic failure missing: %q", output)
+	}
+}
+
+func TestHandleTypedReviewFailureRendersRetainedSummarizerTimeoutDiagnosticOnce(t *testing.T) {
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"codex"},
+		SummarizerAgent:   "codex",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	timeoutEvidence := "summarizer timed out after 1m0s"
+	run := &domain.ReviewRun{
+		Status:        domain.ReviewStatusFailed,
+		Configuration: configuration,
+		Summarizer: domain.SummarizerOutcome{
+			ExitCode: -1,
+			Stderr:   "partial child diagnostic\n" + timeoutEvidence,
+		},
+		Failure: &domain.ReviewFailure{Phase: domain.ReviewPhaseSummarization, Message: timeoutEvidence},
+	}
+	output := captureWatchStderr(t, func() {
+		if got := handleTypedReviewFailure(run, terminal.NewLogger()); got != domain.ExitError {
+			t.Fatalf("exit = %d", got)
+		}
+	})
+	if !strings.Contains(output, "Summarizer stderr: partial child diagnostic") {
+		t.Fatalf("retained summarizer diagnostic missing: %q", output)
+	}
+	if strings.Count(strings.ToLower(output), timeoutEvidence) != 1 {
+		t.Fatalf("timeout evidence was rendered more than once: %q", output)
 	}
 }
 

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -295,7 +295,7 @@ func runWatchCycle(ctx context.Context, cmd *cobra.Command, watchPR string, mode
 		Outcome:          outcome,
 	}
 
-	code := executeReview(ctx, opts, logger)
+	code := executeLegacyReview(ctx, opts, logger)
 	if code == domain.ExitInterrupted {
 		return watch.Cycle{Result: watch.CycleError}, ctx.Err()
 	}

--- a/internal/github/pr_identity.go
+++ b/internal/github/pr_identity.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type pullRequestIdentityResponse struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+func GetPullRequestKey(ctx context.Context, repositoryRoot, prNumber string) (domain.PullRequestKey, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "number,url")
+	cmd.Dir = repositoryRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return domain.PullRequestKey{}, classifyGHError(err)
+	}
+	return parsePullRequestKey(out)
+}
+
+func parsePullRequestKey(data []byte) (domain.PullRequestKey, error) {
+	var response pullRequestIdentityResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return domain.PullRequestKey{}, fmt.Errorf("failed to parse pull request identity: %w", err)
+	}
+	parsed, err := url.Parse(response.URL)
+	if err != nil {
+		return domain.PullRequestKey{}, fmt.Errorf("failed to parse pull request URL: %w", err)
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 4 || parts[2] != "pull" {
+		return domain.PullRequestKey{}, fmt.Errorf("pull request URL %q has an unexpected path", response.URL)
+	}
+	pathNumber, err := strconv.Atoi(parts[3])
+	if err != nil || pathNumber != response.Number {
+		return domain.PullRequestKey{}, fmt.Errorf("pull request URL %q does not match number %d", response.URL, response.Number)
+	}
+	key := domain.PullRequestKey{
+		Host:       parsed.Hostname(),
+		Owner:      parts[0],
+		Repository: parts[1],
+		Number:     response.Number,
+	}
+	if err := key.Validate(); err != nil {
+		return domain.PullRequestKey{}, err
+	}
+	return key, nil
+}

--- a/internal/github/pr_identity_test.go
+++ b/internal/github/pr_identity_test.go
@@ -1,0 +1,25 @@
+package github
+
+import "testing"
+
+func TestParsePullRequestKey(t *testing.T) {
+	key, err := parsePullRequestKey([]byte(`{"number":195,"url":"https://github.com/richhaase/agentic-code-reviewer/pull/195"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.Host != "github.com" || key.Owner != "richhaase" || key.Repository != "agentic-code-reviewer" || key.Number != 195 {
+		t.Fatalf("key = %#v", key)
+	}
+}
+
+func TestParsePullRequestKeyRejectsMismatchedNumber(t *testing.T) {
+	if _, err := parsePullRequestKey([]byte(`{"number":195,"url":"https://github.com/richhaase/agentic-code-reviewer/pull/194"}`)); err == nil {
+		t.Fatal("mismatched pull request identity was accepted")
+	}
+}
+
+func TestParsePullRequestKeyRejectsUnexpectedURL(t *testing.T) {
+	if _, err := parsePullRequestKey([]byte(`{"number":195,"url":"https://github.com/richhaase/agentic-code-reviewer/issues/195"}`)); err == nil {
+		t.Fatal("unexpected pull request URL was accepted")
+	}
+}

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -236,7 +236,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 		Guidance:        values.Guidance,
 		UseRefFile:      values.UseRefFile,
 		Diff:            diff,
-		DiffPrecomputed: true,
+		DiffPrecomputed: agent.AgentsNeedDiff(reviewAgents),
 		Events:          reviewerEvents,
 	}, reviewAgents)
 	if err != nil {
@@ -531,7 +531,14 @@ func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) 
 	case <-ctx.Done():
 		return "", ctx.Err()
 	}
-	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback})
+	completion := "empty"
+	if feedbackResult.summary != "" {
+		completion = "summarized"
+	}
+	if feedbackResult.err != nil {
+		completion = "failed"
+	}
+	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback, Message: completion})
 	if feedbackResult.err != nil {
 		message := "prior feedback unavailable: " + feedbackResult.err.Error()
 		if feedbackResult.summary != "" {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -312,7 +312,7 @@ func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
 	}
 }
 
-func TestServicePinsEveryReviewerToCapturedRevisionAndDiff(t *testing.T) {
+func TestServicePreservesNativeReviewerModeAgainstCapturedRevision(t *testing.T) {
 	configs := make(chan agent.ReviewConfig, 2)
 	reviewAgent := &mockReviewAgent{
 		name: "codex",
@@ -332,7 +332,7 @@ func TestServicePinsEveryReviewerToCapturedRevisionAndDiff(t *testing.T) {
 	}
 	for range 2 {
 		config := <-configs
-		if config.BaseRef != "base-object" || !config.DiffPrecomputed || config.Diff != "captured diff" {
+		if config.BaseRef != "base-object" || config.DiffPrecomputed || config.Diff != "captured diff" {
 			t.Fatalf("reviewer received mutable review input: %#v", config)
 		}
 	}
@@ -1027,13 +1027,20 @@ func TestServiceRetainsPriorFeedbackWhenCleanupWarns(t *testing.T) {
 		t.Fatalf("prior feedback was discarded: status=%q used=%v", run.Status, feedbackUsed.Load())
 	}
 	found := false
+	completion := ""
 	for _, event := range events {
 		if event.Kind == EventWarning && event.Phase == domain.ReviewPhaseFeedback && strings.Contains(event.Message, "feedback cleanup failed") {
 			found = true
 		}
+		if event.Kind == EventPhaseCompleted && event.Phase == domain.ReviewPhaseFeedback {
+			completion = event.Message
+		}
 	}
 	if !found {
 		t.Fatal("feedback cleanup warning event was not emitted")
+	}
+	if completion != "failed" {
+		t.Fatalf("feedback completion = %q", completion)
 	}
 }
 

--- a/internal/runner/report.go
+++ b/internal/runner/report.go
@@ -190,6 +190,17 @@ func RenderReport(
 	return strings.Join(lines, "\n")
 }
 
+func RenderReviewRun(run domain.ReviewRun) string {
+	summaryResult := &summarizer.Result{
+		Grouped:  run.FinalGroupedFindings(),
+		ExitCode: run.Summarizer.ExitCode,
+		Stderr:   run.Summarizer.Stderr,
+		RawOut:   run.Summarizer.DiagnosticOutput,
+		Duration: run.Summarizer.Duration,
+	}
+	return RenderReport(summaryResult.Grouped, summaryResult, run.Stats)
+}
+
 func RenderCommentMarkdown(
 	grouped domain.GroupedFindings,
 	totalReviewers int,

--- a/internal/runner/report_test.go
+++ b/internal/runner/report_test.go
@@ -567,6 +567,31 @@ func TestRenderReport_WithAuthFailedWarning(t *testing.T) {
 	})
 }
 
+func TestRenderReviewRunUsesTypedSemanticResult(t *testing.T) {
+	terminal.WithColorsDisabled(func() {
+		run := domain.ReviewRun{
+			Stats: domain.ReviewStats{TotalReviewers: 3, SuccessfulReviewers: 2, FailedReviewers: []int{3}},
+			Summarizer: domain.SummarizerOutcome{
+				ExitCode: 0,
+				Duration: time.Second,
+			},
+			Findings: []domain.ReviewFinding{{
+				ID:   "finding-001",
+				Kind: domain.ReviewFindingActionable,
+				Group: domain.FindingGroup{
+					Title:         "Typed finding",
+					Summary:       "Rendered from ReviewRun.",
+					ReviewerCount: 2,
+				},
+			}},
+		}
+		result := RenderReviewRun(run)
+		if !strings.Contains(result, "Typed finding") || !strings.Contains(result, "Failed reviewers") {
+			t.Fatalf("rendered report = %q", result)
+		}
+	})
+}
+
 func TestRenderDismissedLGTMMarkdown_BasicFormat(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Potential nil dereference"},


### PR DESCRIPTION
## Summary

- move the ordinary `acr` command onto `review.Service` through a typed `review.Request` and `domain.ReviewRun`
- map trusted configuration provenance field-for-field and pass explicit repository, worktree, revision, and pull-request identity
- preserve terminal progress, reports, exit codes, finding selection, LGTM handling, and existing posting paths while leaving `acr watch` on its unchanged executor for #194
- retain native Codex review mode when the reviewer cohort does not require a precomputed diff, while pinning the immutable base revision

## Behavior

The ordinary command now consumes semantic execution only through `ReviewRun`. Terminal rendering and GitHub actions remain adapter concerns outside the headless service. The reviewed worktree still cannot supply `.acr.yaml`, guidance, exclude policy, or configuration-relative inputs; the request carries only the already-resolved trusted source and values.

The watch command deliberately remains on the legacy executor so #194 can migrate its separate action/submission lifecycle without conflating that work with this ordinary-command adapter.

## Validation

- `go test -race -count=20 ./cmd/acr`
- `go test -race -count=10 ./internal/review ./internal/runner`
- `go test -race ./cmd/acr ./internal/...`
- `make vet`
- `make staticcheck`
- `make lint`
- compile-only `go build -o /private/tmp/acr-issue-195-build ./cmd/acr`
- `git diff --check`
- verified no added Go code comments

Local integration and `make check` targets were not run because they execute the built ACR CLI. GitHub CI is the authoritative integration gate for this PR.

Closes #195
Part of #191
