### PR TITLE
[P2] Persist snapshots, runs, adjudications, and review-loop telemetry

### DIFF
--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -86,9 +86,12 @@ func newDeskForgetCmd() *cobra.Command {
 }
 
 func renderHistory(history desk.History) {
-	if len(history.Entries) == 0 {
+	switch {
+	case len(history.Entries) == 0 && len(history.Corrupt) == 0:
 		fmt.Printf("No stored history found for %s.\n", history.PullRequest.String())
-	} else {
+	case len(history.Entries) == 0:
+		fmt.Printf("No readable history found for %s.\n", history.PullRequest.String())
+	default:
 		fmt.Printf("History for %s (%d record(s)):\n\n", history.PullRequest.String(), len(history.Entries))
 		for _, entry := range history.Entries {
 			renderTimelineEntry(entry)

--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+)
+
+func newDeskCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "desk",
+		Short: "Inspect and manage the persistent review workspace",
+		Long:  "View and manage locally stored pull request review history.",
+	}
+
+	cmd.AddCommand(newDeskHistoryCmd())
+	cmd.AddCommand(newDeskForgetCmd())
+
+	return cmd
+}
+
+func newDeskHistoryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "history <owner/repo#number>",
+		Short: "Show the chronological review history for a pull request",
+		Long:  "Render every stored run, event, adjudication, loop decision, and economics record for a pull request as one chronological timeline.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := desk.ParsePullRequestRef(args[0])
+			if err != nil {
+				return err
+			}
+			dataDir, err := store.DataDir()
+			if err != nil {
+				return err
+			}
+			history, err := desk.LoadHistory(dataDir, key)
+			if err != nil {
+				return err
+			}
+			renderHistory(history)
+			return nil
+		},
+	}
+}
+
+func newDeskForgetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "forget <owner/repo#number>",
+		Short: "Permanently delete a pull request's stored review history",
+		Long:  "Delete every stored run, event, adjudication, loop decision, economics record, and snapshot for a pull request. Refuses while another acr process owns the workspace.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := desk.ParsePullRequestRef(args[0])
+			if err != nil {
+				return err
+			}
+			dataDir, err := store.DataDir()
+			if err != nil {
+				return err
+			}
+			lock, err := store.AcquireWriteLock(dataDir)
+			if err != nil {
+				if errors.Is(err, store.ErrWriterLocked) {
+					return fmt.Errorf("cannot forget %s: %w", key.String(), err)
+				}
+				return err
+			}
+
+			report, forgetErr := store.ForgetPullRequest(dataDir, key)
+			if releaseErr := lock.Release(); releaseErr != nil && forgetErr == nil {
+				return releaseErr
+			}
+			if forgetErr != nil {
+				return forgetErr
+			}
+			renderForgetReport(report)
+			return nil
+		},
+	}
+}
+
+func renderHistory(history desk.History) {
+	if len(history.Entries) == 0 {
+		fmt.Printf("No stored history found for %s.\n", history.PullRequest.String())
+	} else {
+		fmt.Printf("History for %s (%d record(s)):\n\n", history.PullRequest.String(), len(history.Entries))
+		for _, entry := range history.Entries {
+			renderTimelineEntry(entry)
+		}
+	}
+
+	if len(history.Corrupt) > 0 {
+		fmt.Printf("\n%d record(s) could not be read and are not shown above:\n", len(history.Corrupt))
+		for _, corrupt := range history.Corrupt {
+			fmt.Printf("  - %s: %v\n", corrupt.Path, corrupt.Err)
+		}
+	}
+}
+
+func renderTimelineEntry(entry desk.TimelineEntry) {
+	timestamp := entry.Timestamp.UTC().Format("2006-01-02 15:04:05 UTC")
+	switch entry.Kind {
+	case desk.TimelineEntryEvent:
+		renderEventEntry(timestamp, entry.Event)
+	case desk.TimelineEntryRun:
+		renderRunEntry(timestamp, entry.Run)
+	case desk.TimelineEntryAdjudication:
+		renderAdjudicationEntry(timestamp, entry.Adjudication)
+	case desk.TimelineEntryLoopDecision:
+		renderLoopDecisionEntry(timestamp, entry.LoopDecision)
+	case desk.TimelineEntryEconomics:
+		renderEconomicsEntry(timestamp, entry.Economics)
+	}
+}
+
+func renderEventEntry(timestamp string, event *store.ReviewEventV1) {
+	fmt.Printf("%s  event          %s", timestamp, event.Type)
+	if event.RunID != "" {
+		fmt.Printf("  run=%s", event.RunID)
+	}
+	if event.HeadObjectID != "" {
+		fmt.Printf("  head=%s", event.HeadObjectID)
+	}
+	if event.PriorHeadObjectID != "" {
+		fmt.Printf("  prior_head=%s", event.PriorHeadObjectID)
+	}
+	if event.FindingID != "" {
+		fmt.Printf("  finding=%s", event.FindingID)
+	}
+	if event.Actor != "" {
+		fmt.Printf("  actor=%s", event.Actor)
+	}
+	fmt.Println()
+	if event.Reason != "" {
+		fmt.Printf("                            reason: %s\n", event.Reason)
+	}
+	if event.Message != "" {
+		fmt.Printf("                            message: %s\n", event.Message)
+	}
+}
+
+func renderRunEntry(timestamp string, run *store.ReviewRunV1) {
+	fmt.Printf("%s  run            %s  %s/%s  engine=%s/%s  head=%s\n",
+		timestamp, run.ID, run.Status, orNone(run.Conclusion), run.Engine.Name, run.Engine.Version, run.Target.Revision.HeadObjectID)
+	if run.Failure != nil {
+		fmt.Printf("                            failure: %s: %s\n", run.Failure.Phase, run.Failure.Message)
+	}
+	fmt.Printf("                            findings: raw=%d aggregated=%d fp_filtered=%d exclude_filtered=%d final=%d info=%d\n",
+		len(run.RawFindings), len(run.AggregatedFindings), len(run.FalsePositiveFilter.Removed), len(run.ExcludeFilter.Removed), len(run.Findings), len(run.Info))
+	if run.Lifecycle.Stale {
+		fmt.Printf("                            lifecycle: stale (%s)\n", run.Lifecycle.StaleReason)
+	}
+	if run.Lifecycle.SupersededByRunID != "" {
+		fmt.Printf("                            lifecycle: superseded by %s\n", run.Lifecycle.SupersededByRunID)
+	}
+}
+
+func renderAdjudicationEntry(timestamp string, record *store.AdjudicationRecordV1) {
+	ref := record.FindingRef.FindingID
+	if ref == "" {
+		ref = record.FindingRef.ClusterID
+	}
+	fmt.Printf("%s  adjudication   finding=%s  disposition=%s  actor=%s:%s",
+		timestamp, ref, record.Disposition, record.DecidingActor.Kind, record.DecidingActor.Identity)
+	if record.RelationToPrior != store.AdjudicationRelationNone {
+		fmt.Printf("  relation=%s  supersedes=%s", record.RelationToPrior, record.SupersedesRecordID)
+	}
+	fmt.Println()
+	fmt.Printf("                            rationale: %s\n", record.Rationale)
+	fmt.Printf("                            scope: head=%s config=%s\n", record.Scope.HeadObjectID, record.Scope.ConfigurationFingerprint)
+	if len(record.InvalidationConditions) > 0 {
+		fmt.Printf("                            invalidation conditions: %s\n", strings.Join(record.InvalidationConditions, "; "))
+	}
+}
+
+func renderLoopDecisionEntry(timestamp string, decision *store.LoopDecisionV1) {
+	fmt.Printf("%s  loop_decision  %s  iteration=%d  reason=%s\n",
+		timestamp, decision.Decision, decision.IterationCount, decision.Reason)
+	if decision.Budget.Known {
+		fmt.Printf("                            budget: iterations %d/%d  cost $%.2f/$%.2f\n",
+			decision.Budget.IterationsUsed, decision.Budget.IterationsLimit, decision.Budget.CostUSDUsed, decision.Budget.CostUSDLimit)
+	} else {
+		fmt.Println("                            budget: unknown")
+	}
+	if len(decision.SupportingAdjudicationIDs) > 0 {
+		fmt.Printf("                            supporting adjudications: %s\n", strings.Join(decision.SupportingAdjudicationIDs, ", "))
+	}
+}
+
+func renderEconomicsEntry(timestamp string, record *store.EconomicsRecordV1) {
+	economics := record.Economics
+	fmt.Printf("%s  economics      run=%s  reviewer_calls=%d  model_calls=%d  duration=%s\n",
+		timestamp, economics.RunID, economics.ReviewerCallCount, economics.ModelCallCount, economics.Duration)
+	for _, usage := range economics.ProviderUsage {
+		if usage.Usage.Known {
+			fmt.Printf("                            %s/%s: tokens=%d cost=$%.4f\n", usage.Provider, usage.Model, usage.Usage.TotalTokens, usage.Usage.CostUSD)
+		} else {
+			fmt.Printf("                            %s/%s: usage unknown\n", usage.Provider, usage.Model)
+		}
+	}
+}
+
+func orNone(conclusion string) string {
+	if conclusion == "" {
+		return "none"
+	}
+	return conclusion
+}
+
+func renderForgetReport(report store.ForgetReport) {
+	if !report.Existed {
+		fmt.Printf("No stored history found for %s.\n", report.PullRequest.String())
+		return
+	}
+	fmt.Printf("Removed stored history for %s:\n", report.PullRequest.String())
+	fmt.Printf("  snapshot:        %t\n", report.SnapshotRemoved)
+	fmt.Printf("  runs:            %d\n", report.RunsRemoved)
+	fmt.Printf("  events:          %d\n", report.EventsRemoved)
+	fmt.Printf("  adjudications:   %d\n", report.AdjudicationsRemoved)
+	fmt.Printf("  loop decisions:  %d\n", report.LoopDecisionsRemoved)
+	fmt.Printf("  economics:       %d\n", report.EconomicsRemoved)
+}

--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -26,7 +26,7 @@ func newDeskCmd() *cobra.Command {
 
 func newDeskHistoryCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "history <owner/repo#number>",
+		Use:   "history <[host/]owner/repo#number>",
 		Short: "Show the chronological review history for a pull request",
 		Long:  "Render every stored run, event, adjudication, loop decision, and economics record for a pull request as one chronological timeline.",
 		Args:  cobra.ExactArgs(1),
@@ -51,7 +51,7 @@ func newDeskHistoryCmd() *cobra.Command {
 
 func newDeskForgetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "forget <owner/repo#number>",
+		Use:   "forget <[host/]owner/repo#number>",
 		Short: "Permanently delete a pull request's stored review history",
 		Long:  "Delete every stored run, event, adjudication, loop decision, economics record, and snapshot for a pull request. Refuses while another acr process owns the workspace.",
 		Args:  cobra.ExactArgs(1),

--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -153,12 +153,6 @@ func renderRunEntry(timestamp string, run *store.ReviewRunV1) {
 	}
 	fmt.Printf("                            findings: raw=%d aggregated=%d fp_filtered=%d exclude_filtered=%d final=%d info=%d\n",
 		len(run.RawFindings), len(run.AggregatedFindings), len(run.FalsePositiveFilter.Removed), len(run.ExcludeFilter.Removed), len(run.Findings), len(run.Info))
-	if run.Lifecycle.Stale {
-		fmt.Printf("                            lifecycle: stale (%s)\n", run.Lifecycle.StaleReason)
-	}
-	if run.Lifecycle.SupersededByRunID != "" {
-		fmt.Printf("                            lifecycle: superseded by %s\n", run.Lifecycle.SupersededByRunID)
-	}
 }
 
 func renderAdjudicationEntry(timestamp string, record *store.AdjudicationRecordV1) {

--- a/cmd/acr/desk_test.go
+++ b/cmd/acr/desk_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +51,48 @@ func TestDeskHistory_NoStoredHistory(t *testing.T) {
 	}
 	if !strings.Contains(output, "No stored history found for github.com/richhaase/agentic-code-reviewer#198") {
 		t.Fatalf("unexpected output: %q", output)
+	}
+}
+
+func TestDeskHistory_CorruptOnlyHistoryIsNotReportedAsMissing(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+
+	key := store.PullRequestKeyV1{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 198}
+	event := store.ReviewEventV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "event-good",
+		PullRequest:   key,
+		Type:          store.EventTypePRDiscovered,
+		OccurredAt:    time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+	}
+	path, err := store.NewFilesystemEventStore(dataDir).AppendEvent(event)
+	if err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove the only readable record, leaving a corrupt-only history: %v", err)
+	}
+	corruptPath := filepath.Join(filepath.Dir(path), "20260722T120000.000000000Z-event-corrupt.json")
+	if err := os.WriteFile(corruptPath, []byte(`{"schema_version": 1, "id": "event-corrupt", "truncated`), 0o600); err != nil {
+		t.Fatalf("seed corrupt record: %v", err)
+	}
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"history", "richhaase/agentic-code-reviewer#198"})
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = cmd.Execute()
+	})
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+
+	if strings.Contains(output, "No stored history found") {
+		t.Fatalf("a corrupt-only history must not be reported as missing, got:\n%s", output)
+	}
+	if !strings.Contains(output, "could not be read") {
+		t.Fatalf("expected the corrupt record to be reported, got:\n%s", output)
 	}
 }
 

--- a/cmd/acr/desk_test.go
+++ b/cmd/acr/desk_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+)
+
+func captureStdout(t *testing.T, run func()) string {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	func() {
+		os.Stdout = writer
+		defer func() { os.Stdout = original }()
+		run()
+	}()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestDeskHistory_NoStoredHistory(t *testing.T) {
+	t.Setenv("ACR_DATA_DIR", t.TempDir())
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"history", "richhaase/agentic-code-reviewer#198"})
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = cmd.Execute()
+	})
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if !strings.Contains(output, "No stored history found for github.com/richhaase/agentic-code-reviewer#198") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}
+
+func TestDeskHistory_RejectsInvalidRef(t *testing.T) {
+	t.Setenv("ACR_DATA_DIR", t.TempDir())
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"history", "not-a-valid-ref"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error for an invalid pull request reference")
+	}
+}
+
+func TestDeskHistory_RendersStoredRecordsHonestly(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+
+	key := store.PullRequestKeyV1{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 198}
+	recordedAt := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	economics := store.ReviewEconomicsV1{
+		SchemaVersion:     store.CurrentSchemaVersion,
+		RunID:             "run-1",
+		ReviewerCallCount: 2,
+		ModelCallCount:    2,
+		ProviderUsage: []store.ProviderUsageRecordV1{
+			{Provider: "anthropic", Model: "claude-opus", Usage: store.ProviderUsageV1{Known: true, TotalTokens: 100, CostUSD: 0.05}},
+			{Provider: "codex", Model: "gpt", Usage: store.ProviderUsageV1{Known: false}},
+		},
+	}
+	if _, err := store.NewFilesystemEconomicsStore(dataDir).SaveEconomics(key, recordedAt, economics); err != nil {
+		t.Fatalf("save economics: %v", err)
+	}
+
+	adjudication := store.AdjudicationRecordV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "adjudication-1",
+		FindingRef:    store.AdjudicationFindingRefV1{FindingID: "finding-1"},
+		Disposition:   store.AdjudicationFalsePositive,
+		DecidingActor: store.AdjudicationActorV1{Kind: store.AdjudicationActorHuman, Identity: "richhaase"},
+		Rationale:     "not actually a bug",
+		Scope: store.AdjudicationScopeV1{
+			PullRequest:              key,
+			HeadObjectID:             "headsha",
+			ConfigurationFingerprint: "sha256:abc",
+		},
+		InvalidationConditions: []string{"head changes"},
+		RecordedAt:             recordedAt.Add(time.Minute),
+	}
+	if _, err := store.NewFilesystemAdjudicationStore(dataDir).SaveAdjudication(adjudication); err != nil {
+		t.Fatalf("save adjudication: %v", err)
+	}
+
+	decision := store.LoopDecisionV1{
+		SchemaVersion:  store.CurrentSchemaVersion,
+		ID:             "loop-1",
+		PullRequest:    key,
+		RunID:          "run-1",
+		Decision:       store.LoopDecisionStop,
+		Reason:         "clean run",
+		IterationCount: 1,
+		DecidedAt:      recordedAt.Add(2 * time.Minute),
+	}
+	if _, err := store.NewFilesystemLoopDecisionStore(dataDir).SaveLoopDecision(decision); err != nil {
+		t.Fatalf("save loop decision: %v", err)
+	}
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"history", "richhaase/agentic-code-reviewer#198"})
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"disposition=false_positive",
+		"not actually a bug",
+		"head changes",
+		"tokens=100 cost=$0.0500",
+		"usage unknown",
+		"budget: unknown",
+		"clean run",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "cost=$0.0000") {
+		t.Fatalf("expected unknown usage to render as unknown, not zero, got:\n%s", output)
+	}
+}
+
+func TestDeskForget_RefusesWhileWriterLockHeld(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+
+	lock, err := store.AcquireWriteLock(dataDir)
+	if err != nil {
+		t.Fatalf("acquire write lock: %v", err)
+	}
+	defer lock.Release()
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"forget", "richhaase/agentic-code-reviewer#198"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected forget to refuse while another process holds the write lock")
+	}
+}
+
+func TestDeskForget_RemovesHistoryAndReportsIt(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+
+	key := store.PullRequestKeyV1{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 198}
+	event := store.ReviewEventV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "event-1",
+		PullRequest:   key,
+		Type:          store.EventTypePRDiscovered,
+		OccurredAt:    time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+	}
+	if _, err := store.NewFilesystemEventStore(dataDir).AppendEvent(event); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"forget", "richhaase/agentic-code-reviewer#198"})
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !strings.Contains(output, "Removed stored history for github.com/richhaase/agentic-code-reviewer#198") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+	if !strings.Contains(output, "events:          1") {
+		t.Fatalf("expected events removed count in output, got: %q", output)
+	}
+
+	events, _, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	if err != nil {
+		t.Fatalf("list events after forget: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no events remaining after forget, got %+v", events)
+	}
+}

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -89,6 +89,7 @@ Exit codes:
 
 	rootCmd.AddCommand(newConfigCmd())
 	rootCmd.AddCommand(newWatchCmd())
+	rootCmd.AddCommand(newDeskCmd())
 
 	setGroupedUsage(rootCmd)
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -11,11 +11,13 @@ stored type has its own DTO and an explicit mapping function
 (`ToXSchema`/`FromXSchema` or `ToDomain`) rather than being serialized
 directly.
 
-This issue (#196) defines the schemas only. The filesystem-backed store that
-writes and reads these records, the `acr desk` command surface, and the
-actual adjudication/economics/loop-decision logic that produces
-`AdjudicationRecordV1`, `ReviewEconomicsV1`, and `LoopDecisionV1` values are
-later work (issues #197, #198, #223).
+Issue #196 defined the schemas. Issue #197 added the filesystem-backed store
+that writes and reads these records. Issue #223 added the adjudication /
+economics / loop-decision logic (`store.ResolveFindingAdjudication`,
+`store.ResolveAdjudicationPolicy`) that produces and interprets
+`AdjudicationRecordV1`, `ReviewEconomicsV1`, `LoopDecisionV1`, and
+`AdjudicationPolicyV1` values. Issue #198 added the `acr desk history` and
+`acr desk forget` commands documented below.
 
 ## Versioning
 
@@ -95,11 +97,14 @@ for sharing. In particular:
   `FindingGroupV1.Messages`/`Summary`, adjudication `Rationale`/`Evidence`)
   can quote snippets of the reviewed code. Treat the data directory as
   containing source-derived content: do not assume it is safe to share
-  outside the access the source repository itself already has, and provide a
-  deletion path (an `acr desk forget <owner/repo#number>`-style command,
-  added in a later issue) so a user can remove a PR's stored history.
-  Deletion applies to the record kinds above; it is not yet implemented by
-  this issue.
+  outside the access the source repository itself already has.
+- **Deletion is per pull request and irreversible.** `acr desk forget
+  <owner/repo#number>` (see below) permanently removes every stored record for
+  that pull request — its snapshot, runs, events, adjudications, loop
+  decisions, and economics records, including any that failed to parse. There
+  is no undo and no partial deletion of one record kind; forgetting a pull
+  request forgets all of its local history at once. Other pull requests'
+  history, and the data directory itself, are left untouched.
 - **The data directory location and filesystem store are implemented by issue
   #197.** See the section below.
 
@@ -127,6 +132,12 @@ Records live under:
         <timestamp>-<event-id>.json
       runs/
         <timestamp>-<run-id>.json
+      adjudications/
+        <timestamp>-<adjudication-id>.json
+      loop_decisions/
+        <timestamp>-<loop-decision-id>.json
+      economics/
+        <timestamp>-<run-id>.json
 ```
 
 `RunStore` and `EventStore` (`internal/store/runstore.go`,
@@ -153,5 +164,67 @@ user is not left wondering whether their history is silently incomplete.
 Because the lock is an OS-level `flock` on the open file description, it is
 automatically released if the owning process dies, so a crashed writer never
 leaves a stale lock behind. Read-only access through `RunStore`, `EventStore`,
-and `SnapshotStore` never takes this lock; only a process that intends to
-write acquires it.
+`AdjudicationStore`, `LoopDecisionStore`, `EconomicsStore`, and
+`SnapshotStore` never takes this lock; only a process that intends to write —
+today, only `acr desk forget` — acquires it.
+
+`AdjudicationStore`, `LoopDecisionStore`, and `EconomicsStore`
+(`internal/store/adjudicationstore.go`, `internal/store/loopdecisionstore.go`,
+`internal/store/economicsstore.go`) follow the same append-only,
+never-overwrite pattern as `RunStore` and `EventStore`, under
+`adjudications/`, `loop_decisions/`, and `economics/` inside each pull
+request's directory. `ListEconomics` returns each `ReviewEconomicsV1` paired
+with the `RecordedAt` timestamp it was saved with (`EconomicsRecordV1`),
+because the schema itself carries no timestamp of its own; the timestamp is
+recovered from the record's filename, which every store already timestamps.
+
+## The `acr desk` command (issue #198)
+
+`acr desk` is the parent command for locally inspecting and managing the
+persistent review workspace. It currently has two subcommands; later epic
+phases add discovery and dispatch subcommands under the same parent.
+
+### `acr desk history <owner/repo#number>`
+
+Reads every stored run, event, adjudication, loop-decision, and economics
+record for the given pull request and renders them as one chronological
+timeline (`internal/desk.LoadHistory` / `internal/desk.BuildTimeline`), sorted
+by each record's own timestamp (`OccurredAt`, `CompletedAt`/`StartedAt`,
+`RecordedAt`, `DecidedAt`). `<owner/repo#number>` is parsed by
+`internal/desk.ParsePullRequestRef`; the host is always `github.com`, the only
+host this repository's GitHub integration supports.
+
+This is a read-only command: it never acquires the write lock, so history
+remains inspectable while another `acr` process (for example a long-running
+`acr desk` writer, once later phases add one) owns the workspace.
+
+Every adjudication record renders its own disposition, rationale, scope
+(head/configuration fingerprint), and invalidation conditions. Because
+reopening, correcting, or superseding an adjudication is always a new record
+(`RelationToPrior` + `SupersedesRecordID`) rather than an edit, the timeline
+naturally shows the full original → reopened → corrected chain in the order
+it happened. Loop decisions render their reason and budget state, printing
+`budget: unknown` rather than a fabricated zero when `BudgetStateV1.Known` is
+false. Economics records render provider usage the same way: known usage
+prints its token/cost figures, and usage recorded with `Known: false` prints
+as `usage unknown`, never as `0`.
+
+A pull request with no stored history renders `No stored history found for
+<key>` rather than an error. A record that fails to decode or validate is
+listed separately at the end of the output as an unreadable record and does
+not prevent the rest of that pull request's history — or any other pull
+request's history — from rendering.
+
+### `acr desk forget <owner/repo#number>`
+
+Permanently deletes a pull request's entire stored history:
+`store.ForgetPullRequest` removes its snapshot and every run, event,
+adjudication, loop-decision, and economics record (including any that are
+individually corrupt), then reports what it removed. A pull request with no
+stored history is reported as such and is not an error.
+
+`forget` is a mutation: it first calls `store.AcquireWriteLock`, and if
+another process already holds `desk.lock` it refuses immediately with an
+error identifying the conflict, rather than deleting partial state or
+blocking. It only ever removes the requested pull request's own directory;
+sibling pull requests under the same owner/repository are untouched.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -90,10 +90,15 @@ one.
 Stored records are local application data, not a general audit log intended
 for sharing. In particular:
 
-- **No full diffs and no raw agent transcripts are persisted by default.**
-  `ReviewRunV1` stores the structured findings, dispositions, and summarizer/
-  false-positive-filter outcomes produced during a run, not the diff that was
-  reviewed or the raw stdout/stderr of the underlying LLM CLI invocations.
+- **No full diffs and no raw, unbounded agent transcripts are persisted by
+  default.** `ReviewRunV1` stores the structured findings, dispositions, and
+  summarizer/false-positive-filter outcomes produced during a run, not the
+  diff that was reviewed. `SummarizerOutcomeV1.Stderr`/`DiagnosticOutput` are
+  the exception: they carry the same size-bounded (at most ten lines or
+  4096 bytes, truncated with a marker) summarizer failure excerpt already
+  shown in terminal output when a review fails, so a failed run stored on
+  disk stays diagnosable. They are never the full, unbounded subprocess
+  transcript.
 - **Findings may contain code excerpts.** Reviewer output (`FindingV1.Text`,
   `FindingGroupV1.Messages`/`Summary`, adjudication `Rationale`/`Evidence`)
   can quote snippets of the reviewed code. Treat the data directory as

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -100,8 +100,58 @@ for sharing. In particular:
   added in a later issue) so a user can remove a PR's stored history.
   Deletion applies to the record kinds above; it is not yet implemented by
   this issue.
-- **The data directory location is out of scope for this issue.** It is
-  established by issue #197 using the standard library's user-data-directory
-  resolution plus an `ACR_DATA_DIR` override, following the same
-  flags-over-env-vars-over-config-over-defaults precedence style already used
-  elsewhere in this repo.
+- **The data directory location and filesystem store are implemented by issue
+  #197.** See the section below.
+
+## Filesystem storage (issue #197)
+
+`store.DataDir()` resolves the application-data directory: an `ACR_DATA_DIR`
+environment variable override, or `os.UserCacheDir()/acr` by default. Every
+write goes through `atomicWriteFile`: content is written to a hidden temporary
+sibling file (`.tmp-<name>-*`) in the same directory, `fsync`'d, `chmod`'d,
+then atomically renamed over the destination; the containing directory is
+`fsync`'d afterward on a best-effort basis. A reader never observes a partial
+write, and a stray temporary file left behind by a killed process is ignored
+by every reader because its hidden name never matches the `*.json` pattern
+readers scan for.
+
+Records live under:
+
+```text
+<data-dir>/
+  desk.lock
+  prs/
+    <host>/<owner>/<repository>/<number>/
+      snapshot.json
+      events/
+        <timestamp>-<event-id>.json
+      runs/
+        <timestamp>-<run-id>.json
+```
+
+`RunStore` and `EventStore` (`internal/store/runstore.go`,
+`internal/store/eventstore.go`) are append-only: `SaveRun`/`AppendEvent`
+refuse to overwrite an existing record at the same path rather than silently
+replacing history. `SnapshotStore` (`internal/store/snapshotstore.go`) is the
+one mutable record per PR — each poll's `PRSnapshotV1` atomically replaces the
+previous one — and `PRSnapshotV1.Age(now)` reports how stale a loaded snapshot
+is relative to its `CapturedAt`, which is how a reader (for example `acr desk
+--once` rendering a stored snapshot without refreshing it) knows the data's
+age.
+
+Listing a PR's runs or events (`ListRuns`/`ListEvents`) never fails outright
+because of one bad record: each file is decoded and, for runs and events,
+independently validated (`FromReviewRunSchema` / `ReviewEventV1.Validate`);
+a file that fails either check is reported as a `store.CorruptRecord{Path,
+Err}` alongside the still-readable history rather than aborting the whole
+listing. `LoadRun` mentions how many corrupt records were also present so a
+user is not left wondering whether their history is silently incomplete.
+
+`AcquireWriteLock(dataDir)` takes an exclusive, non-blocking `flock` on
+`desk.lock`; a second call while the first still holds it returns
+`ErrWriterLocked` immediately instead of hanging or allowing a second writer.
+Because the lock is an OS-level `flock` on the open file description, it is
+automatically released if the owning process dies, so a crashed writer never
+leaves a stale lock behind. Read-only access through `RunStore`, `EventStore`,
+and `SnapshotStore` never takes this lock; only a process that intends to
+write acquires it.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -45,9 +45,10 @@ one.
   the false-positive and exclude-filter dispositions, final findings and
   informational results, and the terminal status/conclusion/failure. A
   successful, failed, or interrupted run's original outcome is never
-  rewritten in place: `RunLifecycleV1` records later desk-level observations
-  (the run became `stale` because the head moved, or was `superseded` by a
-  later run) alongside the original record, not instead of it.
+  rewritten in place: a run becoming `stale` (the head moved) or `superseded`
+  (by a later run) is recorded as a separate `review_stale` /
+  `review_superseded` `ReviewEventV1` referencing the run's ID, not as a
+  mutation of the original run record.
 - **`ReviewEventV1`** — an append-only entry in a pull request's local
   history. `ReviewEventTypeV1` enumerates the full event vocabulary from epic
   #191's Core Domain Model: PR discovery/refresh; review queued, started,

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,107 @@
+# Persistence schema (internal/store)
+
+This document describes the on-disk record shapes ACR's persistent review
+workspace (epic #191, "Persistent Review Workspace") uses to store pull
+request snapshots, review runs, review history events, and the adjudication /
+review-economics / loop-decision records owned by issue #223. The Go types
+live in `internal/store` and are deliberately separate from the in-memory
+types in `internal/domain`: a stored record's shape is a durability contract
+that must survive changes to how ACR represents state in memory, so every
+stored type has its own DTO and an explicit mapping function
+(`ToXSchema`/`FromXSchema` or `ToDomain`) rather than being serialized
+directly.
+
+This issue (#196) defines the schemas only. The filesystem-backed store that
+writes and reads these records, the `acr desk` command surface, and the
+actual adjudication/economics/loop-decision logic that produces
+`AdjudicationRecordV1`, `ReviewEconomicsV1`, and `LoopDecisionV1` values are
+later work (issues #197, #198, #223).
+
+## Versioning
+
+Every top-level record carries a `schema_version` field. The package exposes
+a single `store.CurrentSchemaVersion` for the whole schema family; decoding a
+record whose `schema_version` does not exactly match the version this build
+supports fails explicitly with an error naming the record kind and both
+version numbers. There is no silent best-effort decoding of an unsupported
+version and no implicit migration. When the schema needs to change in an
+incompatible way, `CurrentSchemaVersion` increments and old records are read
+by a version-specific decoder added at that time, not guessed at from the new
+one.
+
+## Record kinds
+
+- **`PRSnapshotV1`** — a timestamped, immutable observation of GitHub pull
+  request state (state, draft flag, head/base object IDs, review requests,
+  latest reviews, check-rollup state, merge state). Has no `internal/domain`
+  counterpart yet; the discovery/workspace phase that produces and consumes
+  it is later work in this epic.
+- **`ReviewRunV1`** — the complete typed output of one ACR execution, mapped
+  from and to `domain.ReviewRun` via `store.ToReviewRunSchema` /
+  `store.FromReviewRunSchema`. Preserves reviewer identities and the
+  configuration fingerprint, the pre-filter summary, exact-match aggregation,
+  the false-positive and exclude-filter dispositions, final findings and
+  informational results, and the terminal status/conclusion/failure. A
+  successful, failed, or interrupted run's original outcome is never
+  rewritten in place: `RunLifecycleV1` records later desk-level observations
+  (the run became `stale` because the head moved, or was `superseded` by a
+  later run) alongside the original record, not instead of it.
+- **`ReviewEventV1`** — an append-only entry in a pull request's local
+  history. `ReviewEventTypeV1` enumerates the full event vocabulary from epic
+  #191's Core Domain Model: PR discovery/refresh; review queued, started,
+  completed, failed, interrupted, superseded, and stale; finding selected,
+  dismissed, and posted; comment/request-changes/approval actions posted; PR
+  closed/merged; and user deferred/snoozed/retried/resolved actions. Events
+  are immutable; a correction is always a new event, never an edit.
+- **`AdjudicationRecordV1`** (issue #223) — a durable, additive decision
+  record for a finding or finding cluster, with the disposition vocabulary
+  `fixed`, `false_positive`, `duplicate`, `accepted_risk`, `policy_decision`,
+  `deferred`, `obsolete`; the deciding actor; rationale and evidence; PR/head/
+  configuration scope; and invalidation conditions. Reopening, correcting, or
+  superseding a decision is always a new record referencing the one it acts
+  on (`RelationToPrior` + `SupersedesRecordID`); the original record is never
+  mutated.
+- **`ReviewEconomicsV1`** (issue #223) — reviewer/model call counts, duration,
+  and provider usage/cost for a run. `ProviderUsageV1.Known` distinguishes
+  genuinely unavailable usage/cost data from a measured zero; validation
+  rejects a record that claims `Known: false` while also carrying nonzero
+  measurements, so "unknown" can never be silently reinterpreted as "zero."
+- **`LoopDecisionV1`** (issue #223) — one continue/stop/escalate decision from
+  the review convergence loop, with its reason, iteration counters, budget
+  state (`BudgetStateV1`, with the same known/unknown distinction as provider
+  usage), and the adjudication records that informed it.
+- **`AdjudicationPolicyV1`** (issue #223) — the budget policy, stop policy,
+  and evaluation guidance used by the convergence loop. `Source` is a
+  `PolicySourceV1`, which mirrors `config.SourceIdentity` — the exact trust
+  mechanism issue #220 established for resolving `.acr.yaml` — rather than
+  inventing a second trust boundary. `PolicySourceV1.Validate` rejects a raw
+  filesystem source outright (it resolves relative to whatever directory a
+  caller passes at run time, which could be a reviewed PR's own worktree),
+  and `store.ValidatePolicySourceOutsideReview` additionally rejects a pinned
+  repository-revision source whose revision equals the head of the PR under
+  review. Both checks exist so a reviewed PR cannot supply or alter its own
+  adjudication memory, budget policy, stop policy, or evaluation guidance.
+
+## Retention and sensitivity
+
+Stored records are local application data, not a general audit log intended
+for sharing. In particular:
+
+- **No full diffs and no raw agent transcripts are persisted by default.**
+  `ReviewRunV1` stores the structured findings, dispositions, and summarizer/
+  false-positive-filter outcomes produced during a run, not the diff that was
+  reviewed or the raw stdout/stderr of the underlying LLM CLI invocations.
+- **Findings may contain code excerpts.** Reviewer output (`FindingV1.Text`,
+  `FindingGroupV1.Messages`/`Summary`, adjudication `Rationale`/`Evidence`)
+  can quote snippets of the reviewed code. Treat the data directory as
+  containing source-derived content: do not assume it is safe to share
+  outside the access the source repository itself already has, and provide a
+  deletion path (an `acr desk forget <owner/repo#number>`-style command,
+  added in a later issue) so a user can remove a PR's stored history.
+  Deletion applies to the record kinds above; it is not yet implemented by
+  this issue.
+- **The data directory location is out of scope for this issue.** It is
+  established by issue #197 using the standard library's user-data-directory
+  resolution plus an `ACR_DATA_DIR` override, following the same
+  flags-over-env-vars-over-config-over-defaults precedence style already used
+  elsewhere in this repo.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -408,6 +408,12 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.WatchMaxDuration <= 0 {
 		errs = append(errs, fmt.Sprintf("watch.max_duration must be > 0, got %s", r.WatchMaxDuration))
 	}
+	if r.AdjudicationMaxIterations < 0 {
+		errs = append(errs, fmt.Sprintf("adjudication.max_iterations must be >= 0, got %d", r.AdjudicationMaxIterations))
+	}
+	if r.AdjudicationMaxCostUSD < 0 {
+		errs = append(errs, fmt.Sprintf("adjudication.max_cost_usd must be >= 0, got %g", r.AdjudicationMaxCostUSD))
+	}
 	return errs
 }
 
@@ -463,6 +469,9 @@ type ResolvedConfig struct {
 	WatchSettleTime   time.Duration
 	WatchMaxReviews   int
 	WatchMaxDuration  time.Duration
+
+	AdjudicationMaxIterations int
+	AdjudicationMaxCostUSD    float64
 }
 
 type FlagState struct {
@@ -758,6 +767,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		}
 		if cfg.Watch.MaxDuration != nil {
 			result.WatchMaxDuration = cfg.Watch.MaxDuration.AsDuration()
+		}
+		if cfg.Adjudication.MaxIterations != nil {
+			result.AdjudicationMaxIterations = *cfg.Adjudication.MaxIterations
+		}
+		if cfg.Adjudication.MaxCostUSD != nil {
+			result.AdjudicationMaxCostUSD = *cfg.Adjudication.MaxCostUSD
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -411,8 +412,8 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.AdjudicationMaxIterations < 0 {
 		errs = append(errs, fmt.Sprintf("adjudication.max_iterations must be >= 0, got %d", r.AdjudicationMaxIterations))
 	}
-	if r.AdjudicationMaxCostUSD < 0 {
-		errs = append(errs, fmt.Sprintf("adjudication.max_cost_usd must be >= 0, got %g", r.AdjudicationMaxCostUSD))
+	if r.AdjudicationMaxCostUSD < 0 || math.IsNaN(r.AdjudicationMaxCostUSD) || math.IsInf(r.AdjudicationMaxCostUSD, 0) {
+		errs = append(errs, fmt.Sprintf("adjudication.max_cost_usd must be a finite number >= 0, got %g", r.AdjudicationMaxCostUSD))
 	}
 	return errs
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,24 +49,39 @@ func (d Duration) AsDuration() time.Duration {
 }
 
 type Config struct {
-	Reviewers         *int             `yaml:"reviewers"`
-	Concurrency       *int             `yaml:"concurrency"`
-	Base              *string          `yaml:"base"`
-	Timeout           *Duration        `yaml:"timeout"`
-	Retries           *int             `yaml:"retries"`
-	Fetch             *bool            `yaml:"fetch"`
-	ReviewerAgent     *string          `yaml:"reviewer_agent"`
-	ReviewerAgents    []string         `yaml:"reviewer_agents"`
-	SummarizerAgent   *string          `yaml:"summarizer_agent"`
-	ReviewerModel     *string          `yaml:"reviewer_model"`
-	SummarizerModel   *string          `yaml:"summarizer_model"`
-	SummarizerTimeout *Duration        `yaml:"summarizer_timeout"`
-	FPFilterTimeout   *Duration        `yaml:"fp_filter_timeout"`
-	GuidanceFile      *string          `yaml:"guidance_file"`
-	Filters           FilterConfig     `yaml:"filters"`
-	FPFilter          FPFilterConfig   `yaml:"fp_filter"`
-	PRFeedback        PRFeedbackConfig `yaml:"pr_feedback"`
-	Watch             WatchConfig      `yaml:"watch"`
+	Reviewers         *int               `yaml:"reviewers"`
+	Concurrency       *int               `yaml:"concurrency"`
+	Base              *string            `yaml:"base"`
+	Timeout           *Duration          `yaml:"timeout"`
+	Retries           *int               `yaml:"retries"`
+	Fetch             *bool              `yaml:"fetch"`
+	ReviewerAgent     *string            `yaml:"reviewer_agent"`
+	ReviewerAgents    []string           `yaml:"reviewer_agents"`
+	SummarizerAgent   *string            `yaml:"summarizer_agent"`
+	ReviewerModel     *string            `yaml:"reviewer_model"`
+	SummarizerModel   *string            `yaml:"summarizer_model"`
+	SummarizerTimeout *Duration          `yaml:"summarizer_timeout"`
+	FPFilterTimeout   *Duration          `yaml:"fp_filter_timeout"`
+	GuidanceFile      *string            `yaml:"guidance_file"`
+	Filters           FilterConfig       `yaml:"filters"`
+	FPFilter          FPFilterConfig     `yaml:"fp_filter"`
+	PRFeedback        PRFeedbackConfig   `yaml:"pr_feedback"`
+	Watch             WatchConfig        `yaml:"watch"`
+	Adjudication      AdjudicationConfig `yaml:"adjudication"`
+}
+
+// AdjudicationConfig carries the review convergence loop's budget policy,
+// stop policy, and evaluation guidance. Unlike every other Config field,
+// callers must never resolve this section from a plain filesystem or
+// worktree read: it is only ever meaningful when loaded from a trusted
+// control-plane source outside the reviewed pull request head and worktree,
+// via internal/store's ResolveAdjudicationPolicy.
+type AdjudicationConfig struct {
+	MaxIterations       *int     `yaml:"max_iterations"`
+	MaxCostUSD          *float64 `yaml:"max_cost_usd"`
+	StopOnCleanRun      *bool    `yaml:"stop_on_clean_run"`
+	StopOnNoNewFindings *bool    `yaml:"stop_on_no_new_findings"`
+	EvaluationGuidance  *string  `yaml:"evaluation_guidance"`
 }
 
 type WatchConfig struct {
@@ -170,7 +185,7 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "guidance_file", "filters", "fp_filter", "pr_feedback", "watch"}
+var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "guidance_file", "filters", "fp_filter", "pr_feedback", "watch", "adjudication"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
@@ -179,6 +194,8 @@ var knownPRFeedbackKeys = []string{"enabled", "agent"}
 var knownWatchKeys = []string{"poll_interval", "settle_time", "max_reviews", "max_duration"}
 
 var knownFilterKeys = []string{"exclude_patterns"}
+
+var knownAdjudicationKeys = []string{"max_iterations", "max_cost_usd", "stop_on_clean_run", "stop_on_no_new_findings", "evaluation_guidance"}
 
 func checkUnknownKeys(data []byte) []string {
 	var warnings []string
@@ -240,6 +257,18 @@ func checkUnknownKeys(data []byte) []string {
 			if !slices.Contains(knownWatchKeys, key) {
 				warning := fmt.Sprintf("unknown key %q in watch section of %s", key, ConfigFileName)
 				if suggestion := findSimilar(key, knownWatchKeys); suggestion != "" {
+					warning += fmt.Sprintf(" (did you mean %q?)", suggestion)
+				}
+				warnings = append(warnings, warning)
+			}
+		}
+	}
+
+	if adjudication, ok := raw["adjudication"].(map[string]any); ok {
+		for key := range adjudication {
+			if !slices.Contains(knownAdjudicationKeys, key) {
+				warning := fmt.Sprintf("unknown key %q in adjudication section of %s", key, ConfigFileName)
+				if suggestion := findSimilar(key, knownAdjudicationKeys); suggestion != "" {
 					warning += fmt.Sprintf(" (did you mean %q?)", suggestion)
 				}
 				warnings = append(warnings, warning)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,12 +70,6 @@ type Config struct {
 	Adjudication      AdjudicationConfig `yaml:"adjudication"`
 }
 
-// AdjudicationConfig carries the review convergence loop's budget policy,
-// stop policy, and evaluation guidance. Unlike every other Config field,
-// callers must never resolve this section from a plain filesystem or
-// worktree read: it is only ever meaningful when loaded from a trusted
-// control-plane source outside the reviewed pull request head and worktree,
-// via internal/store's ResolveAdjudicationPolicy.
 type AdjudicationConfig struct {
 	MaxIterations       *int     `yaml:"max_iterations"`
 	MaxCostUSD          *float64 `yaml:"max_cost_usd"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -646,6 +646,72 @@ func TestLoadFromPathWithWarnings_UnknownFilterKey(t *testing.T) {
 	}
 }
 
+func TestLoadFromPathWithWarnings_AdjudicationSection(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `adjudication:
+  max_iterations: 5
+  max_cost_usd: 2.5
+  stop_on_clean_run: true
+  stop_on_no_new_findings: false
+  evaluation_guidance: prefer precision over recall
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", result.Warnings)
+	}
+
+	adjudication := result.Config.Adjudication
+	if adjudication.MaxIterations == nil || *adjudication.MaxIterations != 5 {
+		t.Errorf("expected max_iterations=5, got %v", adjudication.MaxIterations)
+	}
+	if adjudication.MaxCostUSD == nil || *adjudication.MaxCostUSD != 2.5 {
+		t.Errorf("expected max_cost_usd=2.5, got %v", adjudication.MaxCostUSD)
+	}
+	if adjudication.StopOnCleanRun == nil || !*adjudication.StopOnCleanRun {
+		t.Errorf("expected stop_on_clean_run=true, got %v", adjudication.StopOnCleanRun)
+	}
+	if adjudication.StopOnNoNewFindings == nil || *adjudication.StopOnNoNewFindings {
+		t.Errorf("expected stop_on_no_new_findings=false, got %v", adjudication.StopOnNoNewFindings)
+	}
+	if adjudication.EvaluationGuidance == nil || *adjudication.EvaluationGuidance != "prefer precision over recall" {
+		t.Errorf("expected evaluation_guidance to round trip, got %v", adjudication.EvaluationGuidance)
+	}
+}
+
+func TestLoadFromPathWithWarnings_UnknownAdjudicationKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `adjudication:
+  max_iteration: 5
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+	expected := `unknown key "max_iteration" in adjudication section of .acr.yaml (did you mean "max_iterations"?)`
+	if result.Warnings[0] != expected {
+		t.Errorf("expected warning %q, got %q", expected, result.Warnings[0])
+	}
+}
+
 func TestLoadFromPathWithWarnings_MultipleUnknownKeys(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".acr.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1743,6 +1744,34 @@ func TestValidate_AdjudicationBounds(t *testing.T) {
 		if !found {
 			t.Errorf("expected validation error mentioning %s, got %v", want, errs)
 		}
+	}
+}
+
+func TestValidate_AdjudicationMaxCostUSDRejectsNonFiniteValues(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cost float64
+	}{
+		{name: "NaN", cost: math.NaN()},
+		{name: "positive infinity", cost: math.Inf(1)},
+		{name: "negative infinity", cost: math.Inf(-1)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := Defaults
+			resolved.AdjudicationMaxCostUSD = tt.cost
+
+			errs := resolved.ValidateAll()
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e, "adjudication.max_cost_usd") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected a validation error for a non-finite adjudication.max_cost_usd (%v), got %v", tt.cost, errs)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1726,6 +1726,44 @@ func TestValidate_WatchBounds(t *testing.T) {
 	}
 }
 
+func TestValidate_AdjudicationBounds(t *testing.T) {
+	resolved := Defaults
+	resolved.AdjudicationMaxIterations = -1
+	resolved.AdjudicationMaxCostUSD = -0.01
+
+	errs := resolved.ValidateAll()
+	for _, want := range []string{"adjudication.max_iterations", "adjudication.max_cost_usd"} {
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected validation error mentioning %s, got %v", want, errs)
+		}
+	}
+}
+
+func TestResolve_AdjudicationBudget(t *testing.T) {
+	maxIterations := -1
+	maxCostUSD := -0.01
+	cfg := &Config{Adjudication: AdjudicationConfig{MaxIterations: &maxIterations, MaxCostUSD: &maxCostUSD}}
+
+	resolved := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if resolved.AdjudicationMaxIterations != maxIterations {
+		t.Errorf("AdjudicationMaxIterations = %d, want %d", resolved.AdjudicationMaxIterations, maxIterations)
+	}
+	if resolved.AdjudicationMaxCostUSD != maxCostUSD {
+		t.Errorf("AdjudicationMaxCostUSD = %g, want %g", resolved.AdjudicationMaxCostUSD, maxCostUSD)
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected acr config validate to reject a negative adjudication budget instead of accepting it")
+	}
+}
+
 func TestLoadFromPathWithWarnings_WatchSection(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ConfigFileName)

--- a/internal/desk/history.go
+++ b/internal/desk/history.go
@@ -1,0 +1,114 @@
+package desk
+
+import (
+	"sort"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+)
+
+type TimelineEntryKind string
+
+const (
+	TimelineEntryEvent        TimelineEntryKind = "event"
+	TimelineEntryRun          TimelineEntryKind = "run"
+	TimelineEntryAdjudication TimelineEntryKind = "adjudication"
+	TimelineEntryLoopDecision TimelineEntryKind = "loop_decision"
+	TimelineEntryEconomics    TimelineEntryKind = "economics"
+)
+
+type TimelineEntry struct {
+	Kind         TimelineEntryKind
+	Timestamp    time.Time
+	Event        *store.ReviewEventV1
+	Run          *store.ReviewRunV1
+	Adjudication *store.AdjudicationRecordV1
+	LoopDecision *store.LoopDecisionV1
+	Economics    *store.EconomicsRecordV1
+}
+
+type History struct {
+	PullRequest store.PullRequestKeyV1
+	Entries     []TimelineEntry
+	Corrupt     []store.CorruptRecord
+}
+
+func BuildTimeline(
+	events []store.ReviewEventV1,
+	runs []store.ReviewRunV1,
+	adjudications []store.AdjudicationRecordV1,
+	loopDecisions []store.LoopDecisionV1,
+	economics []store.EconomicsRecordV1,
+) []TimelineEntry {
+	entries := make([]TimelineEntry, 0, len(events)+len(runs)+len(adjudications)+len(loopDecisions)+len(economics))
+
+	for i := range events {
+		event := events[i]
+		entries = append(entries, TimelineEntry{Kind: TimelineEntryEvent, Timestamp: event.OccurredAt, Event: &event})
+	}
+	for i := range runs {
+		run := runs[i]
+		timestamp := run.CompletedAt
+		if timestamp.IsZero() {
+			timestamp = run.StartedAt
+		}
+		entries = append(entries, TimelineEntry{Kind: TimelineEntryRun, Timestamp: timestamp, Run: &run})
+	}
+	for i := range adjudications {
+		adjudication := adjudications[i]
+		entries = append(entries, TimelineEntry{Kind: TimelineEntryAdjudication, Timestamp: adjudication.RecordedAt, Adjudication: &adjudication})
+	}
+	for i := range loopDecisions {
+		decision := loopDecisions[i]
+		entries = append(entries, TimelineEntry{Kind: TimelineEntryLoopDecision, Timestamp: decision.DecidedAt, LoopDecision: &decision})
+	}
+	for i := range economics {
+		record := economics[i]
+		entries = append(entries, TimelineEntry{Kind: TimelineEntryEconomics, Timestamp: record.RecordedAt, Economics: &record})
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Timestamp.Before(entries[j].Timestamp)
+	})
+	return entries
+}
+
+func LoadHistory(dataDir string, key store.PullRequestKeyV1) (History, error) {
+	if err := key.Validate(); err != nil {
+		return History{}, err
+	}
+
+	events, eventsCorrupt, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	if err != nil {
+		return History{}, err
+	}
+	runs, runsCorrupt, err := store.NewFilesystemRunStore(dataDir).ListRuns(key)
+	if err != nil {
+		return History{}, err
+	}
+	adjudications, adjudicationsCorrupt, err := store.NewFilesystemAdjudicationStore(dataDir).ListAdjudications(key)
+	if err != nil {
+		return History{}, err
+	}
+	loopDecisions, loopDecisionsCorrupt, err := store.NewFilesystemLoopDecisionStore(dataDir).ListLoopDecisions(key)
+	if err != nil {
+		return History{}, err
+	}
+	economics, economicsCorrupt, err := store.NewFilesystemEconomicsStore(dataDir).ListEconomics(key)
+	if err != nil {
+		return History{}, err
+	}
+
+	var corrupt []store.CorruptRecord
+	corrupt = append(corrupt, eventsCorrupt...)
+	corrupt = append(corrupt, runsCorrupt...)
+	corrupt = append(corrupt, adjudicationsCorrupt...)
+	corrupt = append(corrupt, loopDecisionsCorrupt...)
+	corrupt = append(corrupt, economicsCorrupt...)
+
+	return History{
+		PullRequest: key,
+		Entries:     BuildTimeline(events, runs, adjudications, loopDecisions, economics),
+		Corrupt:     corrupt,
+	}, nil
+}

--- a/internal/desk/history_test.go
+++ b/internal/desk/history_test.go
@@ -1,0 +1,320 @@
+package desk
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+)
+
+func testDeskPullRequestKey() store.PullRequestKeyV1 {
+	return store.PullRequestKeyV1{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 198}
+}
+
+func testDeskReviewEvent(id string, key store.PullRequestKeyV1, eventType store.ReviewEventTypeV1, occurredAt time.Time, runID string) store.ReviewEventV1 {
+	return store.ReviewEventV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            id,
+		PullRequest:   key,
+		Type:          eventType,
+		OccurredAt:    occurredAt,
+		RunID:         runID,
+	}
+}
+
+func testDeskReviewRun(t *testing.T, id string, key store.PullRequestKeyV1, status domain.ReviewStatus, completedAt time.Time) store.ReviewRunV1 {
+	t.Helper()
+	pr := key.ToDomain()
+	cfg, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"codex"},
+		SummarizerAgent:   "codex",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatalf("NewReviewConfiguration: %v", err)
+	}
+	run := domain.ReviewRun{
+		ID:      id,
+		Trigger: domain.ReviewTriggerDesk,
+		Target: domain.ReviewTarget{
+			RepositoryRoot: "/repo",
+			WorktreeRoot:   "/repo",
+			Revision: domain.RevisionEvidence{
+				RequestedBaseRef: "main",
+				ResolvedBaseRef:  "main",
+				HeadObjectID:     "head-" + id,
+				BaseObjectID:     "base",
+			},
+			PullRequest: &pr,
+		},
+		Engine:                   domain.ReviewEngine{Name: "acr", Version: "test"},
+		StartedAt:                completedAt.Add(-time.Minute),
+		CompletedAt:              completedAt,
+		Configuration:            cfg,
+		ConfigurationSource:      domain.ConfigurationSourceIdentity{Kind: "defaults"},
+		ConfigurationFingerprint: cfg.Fingerprint(),
+		Status:                   status,
+	}
+	switch status {
+	case domain.ReviewStatusCompleted:
+		run.Conclusion = domain.ReviewConclusionClean
+	case domain.ReviewStatusFailed:
+		run.Failure = &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: "all reviewers failed"}
+	}
+	schema, err := store.ToReviewRunSchema(run, store.RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	return schema
+}
+
+func testDeskAdjudication(id string, key store.PullRequestKeyV1, recordedAt time.Time, disposition store.AdjudicationDispositionV1, relation store.AdjudicationRelationV1, supersedes string) store.AdjudicationRecordV1 {
+	return store.AdjudicationRecordV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            id,
+		FindingRef:    store.AdjudicationFindingRefV1{FindingID: "finding-1"},
+		Disposition:   disposition,
+		DecidingActor: store.AdjudicationActorV1{Kind: store.AdjudicationActorHuman, Identity: "richhaase"},
+		Rationale:     "test rationale",
+		Scope: store.AdjudicationScopeV1{
+			PullRequest:              key,
+			HeadObjectID:             "headsha",
+			ConfigurationFingerprint: "sha256:abc",
+		},
+		InvalidationConditions: []string{"head changes"},
+		RecordedAt:             recordedAt,
+		RelationToPrior:        relation,
+		SupersedesRecordID:     supersedes,
+	}
+}
+
+func testDeskLoopDecision(id string, key store.PullRequestKeyV1, decidedAt time.Time, decision store.LoopDecisionKindV1) store.LoopDecisionV1 {
+	return store.LoopDecisionV1{
+		SchemaVersion:  store.CurrentSchemaVersion,
+		ID:             id,
+		PullRequest:    key,
+		RunID:          "run-1",
+		Decision:       decision,
+		Reason:         "test reason",
+		IterationCount: 1,
+		DecidedAt:      decidedAt,
+	}
+}
+
+func testDeskEconomics(runID string) store.ReviewEconomicsV1 {
+	return store.ReviewEconomicsV1{
+		SchemaVersion:     store.CurrentSchemaVersion,
+		RunID:             runID,
+		ReviewerCallCount: 2,
+		ModelCallCount:    3,
+		Duration:          5 * time.Second,
+		ProviderUsage: []store.ProviderUsageRecordV1{
+			{Provider: "anthropic", Model: "claude-opus", Usage: store.ProviderUsageV1{Known: true, InputTokens: 500, TotalTokens: 600, CostUSD: 0.1}},
+			{Provider: "codex", Model: "gpt", Usage: store.ProviderUsageV1{Known: false}},
+		},
+	}
+}
+
+func TestBuildTimeline_OrdersEntriesChronologicallyAcrossAllKinds(t *testing.T) {
+	key := testDeskPullRequestKey()
+	base := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	events := []store.ReviewEventV1{testDeskReviewEvent("event-1", key, store.EventTypePRDiscovered, base, "")}
+	adjudications := []store.AdjudicationRecordV1{testDeskAdjudication("adjudication-1", key, base.Add(2*time.Minute), store.AdjudicationFalsePositive, store.AdjudicationRelationNone, "")}
+	runs := []store.ReviewRunV1{}
+	loopDecisions := []store.LoopDecisionV1{testDeskLoopDecision("loop-1", key, base.Add(4*time.Minute), store.LoopDecisionStop)}
+	economics := []store.EconomicsRecordV1{{RecordedAt: base.Add(3 * time.Minute), Economics: testDeskEconomics("run-1")}}
+
+	run := testDeskReviewRun(t, "run-1", key, domain.ReviewStatusCompleted, base.Add(1*time.Minute))
+	runs = append(runs, run)
+
+	entries := BuildTimeline(events, runs, adjudications, loopDecisions, economics)
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+
+	wantKinds := []TimelineEntryKind{
+		TimelineEntryEvent,
+		TimelineEntryRun,
+		TimelineEntryAdjudication,
+		TimelineEntryEconomics,
+		TimelineEntryLoopDecision,
+	}
+	for i, want := range wantKinds {
+		if entries[i].Kind != want {
+			t.Fatalf("entry %d: expected kind %q, got %q (full: %+v)", i, want, entries[i].Kind, entries)
+		}
+	}
+	for i := 1; i < len(entries); i++ {
+		if entries[i].Timestamp.Before(entries[i-1].Timestamp) {
+			t.Fatalf("entries not chronologically ordered: %+v", entries)
+		}
+	}
+}
+
+func TestLoadHistory_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	key := testDeskPullRequestKey()
+	base := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	firstProcessEvents := store.NewFilesystemEventStore(dir)
+	firstProcessRuns := store.NewFilesystemRunStore(dir)
+	firstProcessAdjudications := store.NewFilesystemAdjudicationStore(dir)
+	firstProcessLoopDecisions := store.NewFilesystemLoopDecisionStore(dir)
+	firstProcessEconomics := store.NewFilesystemEconomicsStore(dir)
+
+	discovered := testDeskReviewEvent("event-discovered", key, store.EventTypePRDiscovered, base, "")
+	if _, err := firstProcessEvents.AppendEvent(discovered); err != nil {
+		t.Fatalf("append discovered event: %v", err)
+	}
+	queued := testDeskReviewEvent("event-queued", key, store.EventTypeReviewQueued, base.Add(time.Minute), "run-1")
+	if _, err := firstProcessEvents.AppendEvent(queued); err != nil {
+		t.Fatalf("append queued event: %v", err)
+	}
+
+	run := testDeskReviewRun(t, "run-1", key, domain.ReviewStatusCompleted, base.Add(2*time.Minute))
+	if _, err := firstProcessRuns.SaveRun(run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+
+	stale := testDeskReviewEvent("event-stale", key, store.EventTypeReviewStale, base.Add(3*time.Minute), "run-1")
+	if _, err := firstProcessEvents.AppendEvent(stale); err != nil {
+		t.Fatalf("append stale event: %v", err)
+	}
+
+	original := testDeskAdjudication("adjudication-1", key, base.Add(4*time.Minute), store.AdjudicationAcceptedRisk, store.AdjudicationRelationNone, "")
+	if _, err := firstProcessAdjudications.SaveAdjudication(original); err != nil {
+		t.Fatalf("save original adjudication: %v", err)
+	}
+	reopened := testDeskAdjudication("adjudication-2", key, base.Add(5*time.Minute), store.AdjudicationFalsePositive, store.AdjudicationRelationReopened, original.ID)
+	if _, err := firstProcessAdjudications.SaveAdjudication(reopened); err != nil {
+		t.Fatalf("save reopened adjudication: %v", err)
+	}
+
+	continueDecision := testDeskLoopDecision("loop-1", key, base.Add(6*time.Minute), store.LoopDecisionContinue)
+	if _, err := firstProcessLoopDecisions.SaveLoopDecision(continueDecision); err != nil {
+		t.Fatalf("save continue decision: %v", err)
+	}
+	stopDecision := testDeskLoopDecision("loop-2", key, base.Add(7*time.Minute), store.LoopDecisionStop)
+	if _, err := firstProcessLoopDecisions.SaveLoopDecision(stopDecision); err != nil {
+		t.Fatalf("save stop decision: %v", err)
+	}
+
+	economics := testDeskEconomics("run-1")
+	if _, err := firstProcessEconomics.SaveEconomics(key, base.Add(8*time.Minute), economics); err != nil {
+		t.Fatalf("save economics: %v", err)
+	}
+
+	history, err := LoadHistory(dir, key)
+	if err != nil {
+		t.Fatalf("load history after restart: %v", err)
+	}
+	if len(history.Corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %+v", history.Corrupt)
+	}
+	if len(history.Entries) != 9 {
+		t.Fatalf("expected 9 timeline entries, got %d: %+v", len(history.Entries), history.Entries)
+	}
+
+	wantKinds := []TimelineEntryKind{
+		TimelineEntryEvent,
+		TimelineEntryEvent,
+		TimelineEntryRun,
+		TimelineEntryEvent,
+		TimelineEntryAdjudication,
+		TimelineEntryAdjudication,
+		TimelineEntryLoopDecision,
+		TimelineEntryLoopDecision,
+		TimelineEntryEconomics,
+	}
+	for i, want := range wantKinds {
+		if history.Entries[i].Kind != want {
+			t.Fatalf("entry %d: expected kind %q, got %q", i, want, history.Entries[i].Kind)
+		}
+	}
+
+	reopenedEntry := history.Entries[5].Adjudication
+	if reopenedEntry.RelationToPrior != store.AdjudicationRelationReopened || reopenedEntry.SupersedesRecordID != "adjudication-1" {
+		t.Fatalf("expected reopened adjudication to reference its prior, got %+v", reopenedEntry)
+	}
+	originalEntry := history.Entries[4].Adjudication
+	if originalEntry.Disposition != store.AdjudicationAcceptedRisk || originalEntry.RelationToPrior != store.AdjudicationRelationNone {
+		t.Fatalf("expected original adjudication to remain unmutated, got %+v", originalEntry)
+	}
+
+	secondLoad, err := LoadHistory(dir, key)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if !reflect.DeepEqual(history.Entries, secondLoad.Entries) {
+		t.Fatalf("expected a freshly constructed history to match the first load exactly:\nfirst:  %+v\nsecond: %+v", history.Entries, secondLoad.Entries)
+	}
+}
+
+func TestLoadHistory_IsolatesCorruptRecordsAcrossKinds(t *testing.T) {
+	dir := t.TempDir()
+	key := testDeskPullRequestKey()
+	base := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	run := testDeskReviewRun(t, "run-good", key, domain.ReviewStatusCompleted, base)
+	if _, err := store.NewFilesystemRunStore(dir).SaveRun(run); err != nil {
+		t.Fatalf("save good run: %v", err)
+	}
+	economics := testDeskEconomics("run-good")
+	if _, err := store.NewFilesystemEconomicsStore(dir).SaveEconomics(key, base, economics); err != nil {
+		t.Fatalf("save good economics: %v", err)
+	}
+
+	prDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, "198")
+	corruptRunsDir := filepath.Join(prDir, "runs")
+	if err := os.WriteFile(filepath.Join(corruptRunsDir, "20260722T130000.000000000Z-run-bad.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt run: %v", err)
+	}
+	corruptEconomicsDir := filepath.Join(prDir, "economics")
+	if err := os.WriteFile(filepath.Join(corruptEconomicsDir, "20260722T130000.000000000Z-economics-bad.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt economics: %v", err)
+	}
+
+	history, err := LoadHistory(dir, key)
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+	if len(history.Entries) != 2 {
+		t.Fatalf("expected the 2 healthy records to remain visible, got %d: %+v", len(history.Entries), history.Entries)
+	}
+	if len(history.Corrupt) != 2 {
+		t.Fatalf("expected 2 corrupt records reported, got %d: %+v", len(history.Corrupt), history.Corrupt)
+	}
+}
+
+func TestLoadHistory_RejectsInvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := LoadHistory(dir, store.PullRequestKeyV1{}); err == nil {
+		t.Fatal("expected an error for an invalid pull request key")
+	}
+}
+
+func TestLoadHistory_EmptyForUnknownPullRequest(t *testing.T) {
+	dir := t.TempDir()
+	key := testDeskPullRequestKey()
+
+	history, err := LoadHistory(dir, key)
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+	if len(history.Entries) != 0 {
+		t.Fatalf("expected no timeline entries, got %+v", history.Entries)
+	}
+	if len(history.Corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %+v", history.Corrupt)
+	}
+}

--- a/internal/desk/pr_ref.go
+++ b/internal/desk/pr_ref.go
@@ -2,30 +2,35 @@ package desk
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/store"
 )
 
 const DefaultPullRequestHost = "github.com"
 
-var pullRequestRefPattern = regexp.MustCompile(`^([^/#]+)/([^/#]+)#([0-9]+)$`)
+const pullRequestRefFormat = "pull request reference %q must have the form [host/]owner/repo#number"
 
 func ParsePullRequestRef(ref string) (store.PullRequestKeyV1, error) {
-	matches := pullRequestRefPattern.FindStringSubmatch(ref)
-	if matches == nil {
-		return store.PullRequestKeyV1{}, fmt.Errorf("pull request reference %q must have the form owner/repo#number", ref)
+	hashIndex := strings.LastIndex(ref, "#")
+	if hashIndex < 0 {
+		return store.PullRequestKeyV1{}, fmt.Errorf(pullRequestRefFormat, ref)
 	}
-	number, err := strconv.Atoi(matches[3])
+	number, err := strconv.Atoi(ref[hashIndex+1:])
 	if err != nil {
 		return store.PullRequestKeyV1{}, fmt.Errorf("pull request reference %q has an invalid number: %w", ref, err)
 	}
-	key := store.PullRequestKeyV1{
-		Host:       DefaultPullRequestHost,
-		Owner:      matches[1],
-		Repository: matches[2],
-		Number:     number,
+
+	segments := strings.Split(ref[:hashIndex], "/")
+	var key store.PullRequestKeyV1
+	switch len(segments) {
+	case 2:
+		key = store.PullRequestKeyV1{Host: DefaultPullRequestHost, Owner: segments[0], Repository: segments[1], Number: number}
+	case 3:
+		key = store.PullRequestKeyV1{Host: segments[0], Owner: segments[1], Repository: segments[2], Number: number}
+	default:
+		return store.PullRequestKeyV1{}, fmt.Errorf(pullRequestRefFormat, ref)
 	}
 	if err := key.Validate(); err != nil {
 		return store.PullRequestKeyV1{}, fmt.Errorf("pull request reference %q is invalid: %w", ref, err)

--- a/internal/desk/pr_ref.go
+++ b/internal/desk/pr_ref.go
@@ -1,0 +1,34 @@
+package desk
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+)
+
+const DefaultPullRequestHost = "github.com"
+
+var pullRequestRefPattern = regexp.MustCompile(`^([^/#]+)/([^/#]+)#([0-9]+)$`)
+
+func ParsePullRequestRef(ref string) (store.PullRequestKeyV1, error) {
+	matches := pullRequestRefPattern.FindStringSubmatch(ref)
+	if matches == nil {
+		return store.PullRequestKeyV1{}, fmt.Errorf("pull request reference %q must have the form owner/repo#number", ref)
+	}
+	number, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return store.PullRequestKeyV1{}, fmt.Errorf("pull request reference %q has an invalid number: %w", ref, err)
+	}
+	key := store.PullRequestKeyV1{
+		Host:       DefaultPullRequestHost,
+		Owner:      matches[1],
+		Repository: matches[2],
+		Number:     number,
+	}
+	if err := key.Validate(); err != nil {
+		return store.PullRequestKeyV1{}, fmt.Errorf("pull request reference %q is invalid: %w", ref, err)
+	}
+	return key, nil
+}

--- a/internal/desk/pr_ref_test.go
+++ b/internal/desk/pr_ref_test.go
@@ -7,17 +7,20 @@ func TestParsePullRequestRef(t *testing.T) {
 		name    string
 		ref     string
 		wantErr bool
+		host    string
 		owner   string
 		repo    string
 		number  int
 	}{
-		{name: "valid ref", ref: "richhaase/agentic-code-reviewer#198", owner: "richhaase", repo: "agentic-code-reviewer", number: 198},
+		{name: "valid ref defaults to github.com", ref: "richhaase/agentic-code-reviewer#198", host: DefaultPullRequestHost, owner: "richhaase", repo: "agentic-code-reviewer", number: 198},
+		{name: "valid ref with explicit enterprise host", ref: "github.example.com/richhaase/agentic-code-reviewer#198", host: "github.example.com", owner: "richhaase", repo: "agentic-code-reviewer", number: 198},
 		{name: "missing hash", ref: "richhaase/agentic-code-reviewer", wantErr: true},
 		{name: "missing owner", ref: "/agentic-code-reviewer#198", wantErr: true},
 		{name: "missing repo", ref: "richhaase/#198", wantErr: true},
+		{name: "missing host with prefix form", ref: "/richhaase/agentic-code-reviewer#198", wantErr: true},
 		{name: "non numeric number", ref: "richhaase/agentic-code-reviewer#abc", wantErr: true},
 		{name: "zero number", ref: "richhaase/agentic-code-reviewer#0", wantErr: true},
-		{name: "extra path segment", ref: "github.com/richhaase/agentic-code-reviewer#198", wantErr: true},
+		{name: "too many path segments", ref: "extra/github.com/richhaase/agentic-code-reviewer#198", wantErr: true},
 		{name: "empty string", ref: "", wantErr: true},
 	}
 
@@ -33,10 +36,7 @@ func TestParsePullRequestRef(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error for ref %q: %v", tt.ref, err)
 			}
-			if key.Host != DefaultPullRequestHost {
-				t.Fatalf("expected default host %q, got %q", DefaultPullRequestHost, key.Host)
-			}
-			if key.Owner != tt.owner || key.Repository != tt.repo || key.Number != tt.number {
+			if key.Host != tt.host || key.Owner != tt.owner || key.Repository != tt.repo || key.Number != tt.number {
 				t.Fatalf("unexpected key for ref %q: %+v", tt.ref, key)
 			}
 		})

--- a/internal/desk/pr_ref_test.go
+++ b/internal/desk/pr_ref_test.go
@@ -1,0 +1,44 @@
+package desk
+
+import "testing"
+
+func TestParsePullRequestRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		wantErr bool
+		owner   string
+		repo    string
+		number  int
+	}{
+		{name: "valid ref", ref: "richhaase/agentic-code-reviewer#198", owner: "richhaase", repo: "agentic-code-reviewer", number: 198},
+		{name: "missing hash", ref: "richhaase/agentic-code-reviewer", wantErr: true},
+		{name: "missing owner", ref: "/agentic-code-reviewer#198", wantErr: true},
+		{name: "missing repo", ref: "richhaase/#198", wantErr: true},
+		{name: "non numeric number", ref: "richhaase/agentic-code-reviewer#abc", wantErr: true},
+		{name: "zero number", ref: "richhaase/agentic-code-reviewer#0", wantErr: true},
+		{name: "extra path segment", ref: "github.com/richhaase/agentic-code-reviewer#198", wantErr: true},
+		{name: "empty string", ref: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := ParsePullRequestRef(tt.ref)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for ref %q, got key %+v", tt.ref, key)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for ref %q: %v", tt.ref, err)
+			}
+			if key.Host != DefaultPullRequestHost {
+				t.Fatalf("expected default host %q, got %q", DefaultPullRequestHost, key.Host)
+			}
+			if key.Owner != tt.owner || key.Repository != tt.repo || key.Number != tt.number {
+				t.Fatalf("unexpected key for ref %q: %+v", tt.ref, key)
+			}
+		})
+	}
+}

--- a/internal/store/adjudication.go
+++ b/internal/store/adjudication.go
@@ -96,7 +96,10 @@ func (s AdjudicationScopeV1) Validate() error {
 	if err := s.PullRequest.Validate(); err != nil {
 		return err
 	}
-	return validateNonEmpty("adjudication scope head object id", s.HeadObjectID)
+	if err := validateNonEmpty("adjudication scope head object id", s.HeadObjectID); err != nil {
+		return err
+	}
+	return validateNonEmpty("adjudication scope configuration fingerprint", s.ConfigurationFingerprint)
 }
 
 type AdjudicationRecordV1 struct {

--- a/internal/store/adjudication.go
+++ b/internal/store/adjudication.go
@@ -83,6 +83,9 @@ func (r AdjudicationFindingRefV1) Validate() error {
 	if r.FindingID == "" && r.ClusterID == "" {
 		return fmt.Errorf("adjudication finding reference requires a finding_id or cluster_id")
 	}
+	if r.FindingID != "" && r.ClusterID != "" {
+		return fmt.Errorf("adjudication finding reference must not set both finding_id and cluster_id: exact-match resolution cannot later find it by either alone")
+	}
 	return nil
 }
 

--- a/internal/store/adjudication.go
+++ b/internal/store/adjudication.go
@@ -169,3 +169,27 @@ func (r AdjudicationRecordV1) Validate() error {
 	}
 	return nil
 }
+
+// ResolveFindingAdjudication returns the most recently recorded adjudication
+// in records whose finding reference and scope match ref and scope exactly,
+// and reports whether one was found. records is expected in chronological
+// order, as returned by AdjudicationStore.ListAdjudications, so the last
+// match is the newest entry in that finding's reopen/correct/supersede
+// history. Matching requires the pull request, head object id, and
+// configuration fingerprint to all be identical: an adjudication is only
+// ever reused for a genuine exact repeat. A finding observed under a
+// different head or configuration is semantically uncertain and must not
+// silently inherit a prior decision, so it reports no match and remains
+// visible rather than being suppressed.
+func ResolveFindingAdjudication(records []AdjudicationRecordV1, ref AdjudicationFindingRefV1, scope AdjudicationScopeV1) (AdjudicationRecordV1, bool) {
+	var latest AdjudicationRecordV1
+	found := false
+	for _, record := range records {
+		if record.FindingRef != ref || record.Scope != scope {
+			continue
+		}
+		latest = record
+		found = true
+	}
+	return latest, found
+}

--- a/internal/store/adjudication.go
+++ b/internal/store/adjudication.go
@@ -151,14 +151,41 @@ func (r AdjudicationRecordV1) Validate() error {
 }
 
 func ResolveFindingAdjudication(records []AdjudicationRecordV1, ref AdjudicationFindingRefV1, scope AdjudicationScopeV1) (AdjudicationRecordV1, bool) {
-	var latest AdjudicationRecordV1
-	found := false
+	matches := make([]AdjudicationRecordV1, 0, len(records))
 	for _, record := range records {
 		if record.FindingRef != ref || record.Scope != scope {
 			continue
 		}
-		latest = record
-		found = true
+		matches = append(matches, record)
+	}
+	if len(matches) == 0 {
+		return AdjudicationRecordV1{}, false
+	}
+
+	superseded := make(map[string]bool, len(matches))
+	for _, record := range matches {
+		if record.SupersedesRecordID != "" {
+			superseded[record.SupersedesRecordID] = true
+		}
+	}
+
+	if latest, ok := latestRecordedAdjudication(matches, func(r AdjudicationRecordV1) bool { return !superseded[r.ID] }); ok {
+		return latest, true
+	}
+	return latestRecordedAdjudication(matches, func(AdjudicationRecordV1) bool { return true })
+}
+
+func latestRecordedAdjudication(records []AdjudicationRecordV1, include func(AdjudicationRecordV1) bool) (AdjudicationRecordV1, bool) {
+	var latest AdjudicationRecordV1
+	found := false
+	for _, record := range records {
+		if !include(record) {
+			continue
+		}
+		if !found || record.RecordedAt.After(latest.RecordedAt) || (record.RecordedAt.Equal(latest.RecordedAt) && record.ID > latest.ID) {
+			latest = record
+			found = true
+		}
 	}
 	return latest, found
 }

--- a/internal/store/adjudication.go
+++ b/internal/store/adjudication.go
@@ -1,0 +1,171 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// AdjudicationDispositionV1 is the disposition vocabulary for finding
+// adjudications, from issue #223.
+type AdjudicationDispositionV1 string
+
+const (
+	AdjudicationFixed          AdjudicationDispositionV1 = "fixed"
+	AdjudicationFalsePositive  AdjudicationDispositionV1 = "false_positive"
+	AdjudicationDuplicate      AdjudicationDispositionV1 = "duplicate"
+	AdjudicationAcceptedRisk   AdjudicationDispositionV1 = "accepted_risk"
+	AdjudicationPolicyDecision AdjudicationDispositionV1 = "policy_decision"
+	AdjudicationDeferred       AdjudicationDispositionV1 = "deferred"
+	AdjudicationObsolete       AdjudicationDispositionV1 = "obsolete"
+)
+
+func (d AdjudicationDispositionV1) Validate() error {
+	switch d {
+	case AdjudicationFixed, AdjudicationFalsePositive, AdjudicationDuplicate,
+		AdjudicationAcceptedRisk, AdjudicationPolicyDecision, AdjudicationDeferred, AdjudicationObsolete:
+		return nil
+	default:
+		return fmt.Errorf("unknown adjudication disposition %q", d)
+	}
+}
+
+// AdjudicationRelationV1 marks how a record relates to a prior adjudication
+// of the same finding or cluster. A record with no relation is an original
+// decision. Reopening, correcting, or superseding a decision is always
+// recorded as a new, additive record that references the one it acts on;
+// the original record is never edited or removed.
+type AdjudicationRelationV1 string
+
+const (
+	AdjudicationRelationNone       AdjudicationRelationV1 = ""
+	AdjudicationRelationReopened   AdjudicationRelationV1 = "reopened"
+	AdjudicationRelationCorrected  AdjudicationRelationV1 = "corrected"
+	AdjudicationRelationSuperseded AdjudicationRelationV1 = "superseded"
+)
+
+func (r AdjudicationRelationV1) Validate() error {
+	switch r {
+	case AdjudicationRelationNone, AdjudicationRelationReopened, AdjudicationRelationCorrected, AdjudicationRelationSuperseded:
+		return nil
+	default:
+		return fmt.Errorf("unknown adjudication relation %q", r)
+	}
+}
+
+// AdjudicationActorKindV1 distinguishes who or what made an adjudication
+// decision.
+type AdjudicationActorKindV1 string
+
+const (
+	AdjudicationActorHuman       AdjudicationActorKindV1 = "human"
+	AdjudicationActorReviewAgent AdjudicationActorKindV1 = "review_agent"
+	AdjudicationActorSystem      AdjudicationActorKindV1 = "system"
+)
+
+func (k AdjudicationActorKindV1) Validate() error {
+	switch k {
+	case AdjudicationActorHuman, AdjudicationActorReviewAgent, AdjudicationActorSystem:
+		return nil
+	default:
+		return fmt.Errorf("unknown adjudication actor kind %q", k)
+	}
+}
+
+type AdjudicationActorV1 struct {
+	Kind     AdjudicationActorKindV1 `json:"kind"`
+	Identity string                  `json:"identity"`
+}
+
+func (a AdjudicationActorV1) Validate() error {
+	if err := a.Kind.Validate(); err != nil {
+		return err
+	}
+	return validateNonEmpty("adjudication actor identity", a.Identity)
+}
+
+// AdjudicationFindingRefV1 identifies the finding or finding cluster an
+// adjudication decision applies to. At least one of FindingID or ClusterID
+// must be set.
+type AdjudicationFindingRefV1 struct {
+	FindingID string `json:"finding_id,omitempty"`
+	ClusterID string `json:"cluster_id,omitempty"`
+}
+
+func (r AdjudicationFindingRefV1) Validate() error {
+	if r.FindingID == "" && r.ClusterID == "" {
+		return fmt.Errorf("adjudication finding reference requires a finding_id or cluster_id")
+	}
+	return nil
+}
+
+// AdjudicationScopeV1 records the pull request, head, and configuration
+// fingerprint an adjudication decision was made under. Adjudication memory is
+// only meaningfully reusable within a matching scope.
+type AdjudicationScopeV1 struct {
+	PullRequest              PullRequestKeyV1 `json:"pull_request"`
+	HeadObjectID             string           `json:"head_object_id"`
+	ConfigurationFingerprint string           `json:"configuration_fingerprint"`
+}
+
+func (s AdjudicationScopeV1) Validate() error {
+	if err := s.PullRequest.Validate(); err != nil {
+		return err
+	}
+	return validateNonEmpty("adjudication scope head object id", s.HeadObjectID)
+}
+
+// AdjudicationRecordV1 is a durable, additive decision record for a finding
+// or finding cluster. See issue #223. A reopened, corrected, or superseded
+// decision is recorded as a new record with RelationToPrior and
+// SupersedesRecordID set, rather than mutating the record it replaces, so
+// the original decision remains part of history.
+type AdjudicationRecordV1 struct {
+	SchemaVersion          int                       `json:"schema_version"`
+	ID                     string                    `json:"id"`
+	FindingRef             AdjudicationFindingRefV1  `json:"finding_ref"`
+	Disposition            AdjudicationDispositionV1 `json:"disposition"`
+	DecidingActor          AdjudicationActorV1       `json:"deciding_actor"`
+	Rationale              string                    `json:"rationale"`
+	Evidence               []string                  `json:"evidence,omitempty"`
+	Scope                  AdjudicationScopeV1       `json:"scope"`
+	InvalidationConditions []string                  `json:"invalidation_conditions,omitempty"`
+	RecordedAt             time.Time                 `json:"recorded_at"`
+	RelationToPrior        AdjudicationRelationV1    `json:"relation_to_prior,omitempty"`
+	SupersedesRecordID     string                    `json:"supersedes_record_id,omitempty"`
+}
+
+func (r AdjudicationRecordV1) Validate() error {
+	if err := validateSchemaVersion("adjudication record", r.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("adjudication record id", r.ID); err != nil {
+		return err
+	}
+	if err := r.FindingRef.Validate(); err != nil {
+		return err
+	}
+	if err := r.Disposition.Validate(); err != nil {
+		return err
+	}
+	if err := r.DecidingActor.Validate(); err != nil {
+		return err
+	}
+	if err := r.Scope.Validate(); err != nil {
+		return err
+	}
+	if r.RecordedAt.IsZero() {
+		return fmt.Errorf("adjudication record recorded_at is required")
+	}
+	if err := r.RelationToPrior.Validate(); err != nil {
+		return err
+	}
+	if r.RelationToPrior != AdjudicationRelationNone {
+		if err := validateNonEmpty("adjudication record supersedes_record_id", r.SupersedesRecordID); err != nil {
+			return err
+		}
+	}
+	if r.RelationToPrior == AdjudicationRelationNone && r.SupersedesRecordID != "" {
+		return fmt.Errorf("adjudication record %s: supersedes_record_id requires a relation_to_prior", r.ID)
+	}
+	return nil
+}

--- a/internal/store/adjudication.go
+++ b/internal/store/adjudication.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-// AdjudicationDispositionV1 is the disposition vocabulary for finding
-// adjudications, from issue #223.
 type AdjudicationDispositionV1 string
 
 const (
@@ -29,11 +27,6 @@ func (d AdjudicationDispositionV1) Validate() error {
 	}
 }
 
-// AdjudicationRelationV1 marks how a record relates to a prior adjudication
-// of the same finding or cluster. A record with no relation is an original
-// decision. Reopening, correcting, or superseding a decision is always
-// recorded as a new, additive record that references the one it acts on;
-// the original record is never edited or removed.
 type AdjudicationRelationV1 string
 
 const (
@@ -52,8 +45,6 @@ func (r AdjudicationRelationV1) Validate() error {
 	}
 }
 
-// AdjudicationActorKindV1 distinguishes who or what made an adjudication
-// decision.
 type AdjudicationActorKindV1 string
 
 const (
@@ -83,9 +74,6 @@ func (a AdjudicationActorV1) Validate() error {
 	return validateNonEmpty("adjudication actor identity", a.Identity)
 }
 
-// AdjudicationFindingRefV1 identifies the finding or finding cluster an
-// adjudication decision applies to. At least one of FindingID or ClusterID
-// must be set.
 type AdjudicationFindingRefV1 struct {
 	FindingID string `json:"finding_id,omitempty"`
 	ClusterID string `json:"cluster_id,omitempty"`
@@ -98,9 +86,6 @@ func (r AdjudicationFindingRefV1) Validate() error {
 	return nil
 }
 
-// AdjudicationScopeV1 records the pull request, head, and configuration
-// fingerprint an adjudication decision was made under. Adjudication memory is
-// only meaningfully reusable within a matching scope.
 type AdjudicationScopeV1 struct {
 	PullRequest              PullRequestKeyV1 `json:"pull_request"`
 	HeadObjectID             string           `json:"head_object_id"`
@@ -114,11 +99,6 @@ func (s AdjudicationScopeV1) Validate() error {
 	return validateNonEmpty("adjudication scope head object id", s.HeadObjectID)
 }
 
-// AdjudicationRecordV1 is a durable, additive decision record for a finding
-// or finding cluster. See issue #223. A reopened, corrected, or superseded
-// decision is recorded as a new record with RelationToPrior and
-// SupersedesRecordID set, rather than mutating the record it replaces, so
-// the original decision remains part of history.
 type AdjudicationRecordV1 struct {
 	SchemaVersion          int                       `json:"schema_version"`
 	ID                     string                    `json:"id"`
@@ -170,17 +150,6 @@ func (r AdjudicationRecordV1) Validate() error {
 	return nil
 }
 
-// ResolveFindingAdjudication returns the most recently recorded adjudication
-// in records whose finding reference and scope match ref and scope exactly,
-// and reports whether one was found. records is expected in chronological
-// order, as returned by AdjudicationStore.ListAdjudications, so the last
-// match is the newest entry in that finding's reopen/correct/supersede
-// history. Matching requires the pull request, head object id, and
-// configuration fingerprint to all be identical: an adjudication is only
-// ever reused for a genuine exact repeat. A finding observed under a
-// different head or configuration is semantically uncertain and must not
-// silently inherit a prior decision, so it reports no match and remains
-// visible rather than being suppressed.
 func ResolveFindingAdjudication(records []AdjudicationRecordV1, ref AdjudicationFindingRefV1, scope AdjudicationScopeV1) (AdjudicationRecordV1, bool) {
 	var latest AdjudicationRecordV1
 	found := false

--- a/internal/store/adjudication_test.go
+++ b/internal/store/adjudication_test.go
@@ -149,3 +149,80 @@ func TestAdjudicationRecordV1_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveFindingAdjudication_ExactRepeatReturnsPriorDecisionWithoutBecomingNewlyActionable(t *testing.T) {
+	record := validAdjudicationRecord()
+
+	found, ok := ResolveFindingAdjudication([]AdjudicationRecordV1{record}, record.FindingRef, record.Scope)
+	if !ok {
+		t.Fatal("expected an exact repeat to resolve a prior adjudication")
+	}
+	if found.ID != record.ID || found.Disposition != record.Disposition {
+		t.Fatalf("expected the prior decision to be returned unchanged, got %+v", found)
+	}
+}
+
+func TestResolveFindingAdjudication_ReturnsMostRecentInSupersessionChain(t *testing.T) {
+	original := validAdjudicationRecord()
+	original.ID = "adjudication-1"
+
+	corrected := validAdjudicationRecord()
+	corrected.ID = "adjudication-2"
+	corrected.Disposition = AdjudicationFalsePositive
+	corrected.RelationToPrior = AdjudicationRelationCorrected
+	corrected.SupersedesRecordID = original.ID
+	corrected.RecordedAt = original.RecordedAt.Add(time.Hour)
+
+	found, ok := ResolveFindingAdjudication([]AdjudicationRecordV1{original, corrected}, original.FindingRef, original.Scope)
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if found.ID != corrected.ID {
+		t.Fatalf("expected the most recent record in the chain, got %+v", found)
+	}
+}
+
+func TestResolveFindingAdjudication_UncertaintyStaysVisibleAcrossScopeChanges(t *testing.T) {
+	record := validAdjudicationRecord()
+
+	tests := []struct {
+		name  string
+		scope AdjudicationScopeV1
+	}{
+		{
+			name: "different head object id",
+			scope: AdjudicationScopeV1{
+				PullRequest:              record.Scope.PullRequest,
+				HeadObjectID:             "different-head",
+				ConfigurationFingerprint: record.Scope.ConfigurationFingerprint,
+			},
+		},
+		{
+			name: "different configuration fingerprint",
+			scope: AdjudicationScopeV1{
+				PullRequest:              record.Scope.PullRequest,
+				HeadObjectID:             record.Scope.HeadObjectID,
+				ConfigurationFingerprint: "sha256:different",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := ResolveFindingAdjudication([]AdjudicationRecordV1{record}, record.FindingRef, tt.scope)
+			if ok {
+				t.Fatal("expected no match for a scope that differs from the recorded decision; uncertainty must stay visible")
+			}
+		})
+	}
+}
+
+func TestResolveFindingAdjudication_DifferentFindingRefDoesNotMatch(t *testing.T) {
+	record := validAdjudicationRecord()
+	otherRef := AdjudicationFindingRefV1{FindingID: "finding-2"}
+
+	_, ok := ResolveFindingAdjudication([]AdjudicationRecordV1{record}, otherRef, record.Scope)
+	if ok {
+		t.Fatal("expected no match for an unrelated finding reference")
+	}
+}

--- a/internal/store/adjudication_test.go
+++ b/internal/store/adjudication_test.go
@@ -114,6 +114,13 @@ func TestAdjudicationRecordV1_Validate(t *testing.T) {
 		{name: "unsupported schema version", mutate: func(r *AdjudicationRecordV1) { r.SchemaVersion = 99 }, wantErr: true},
 		{name: "missing finding and cluster reference", mutate: func(r *AdjudicationRecordV1) { r.FindingRef = AdjudicationFindingRefV1{} }, wantErr: true},
 		{name: "cluster reference is sufficient", mutate: func(r *AdjudicationRecordV1) { r.FindingRef = AdjudicationFindingRefV1{ClusterID: "cluster-1"} }, wantErr: false},
+		{
+			name: "both finding and cluster reference set is ambiguous",
+			mutate: func(r *AdjudicationRecordV1) {
+				r.FindingRef = AdjudicationFindingRefV1{FindingID: "finding-1", ClusterID: "cluster-1"}
+			},
+			wantErr: true,
+		},
 		{name: "unknown disposition", mutate: func(r *AdjudicationRecordV1) { r.Disposition = "wontfix" }, wantErr: true},
 		{name: "missing deciding actor identity", mutate: func(r *AdjudicationRecordV1) { r.DecidingActor.Identity = "" }, wantErr: true},
 		{name: "missing scope configuration fingerprint", mutate: func(r *AdjudicationRecordV1) { r.Scope.ConfigurationFingerprint = "" }, wantErr: true},

--- a/internal/store/adjudication_test.go
+++ b/internal/store/adjudication_test.go
@@ -182,6 +182,44 @@ func TestResolveFindingAdjudication_ReturnsMostRecentInSupersessionChain(t *test
 	}
 }
 
+func TestResolveFindingAdjudication_SelectionIsIndependentOfSliceOrder(t *testing.T) {
+	original := validAdjudicationRecord()
+	original.ID = "adjudication-1"
+
+	corrected := validAdjudicationRecord()
+	corrected.ID = "adjudication-2"
+	corrected.Disposition = AdjudicationFalsePositive
+	corrected.RelationToPrior = AdjudicationRelationCorrected
+	corrected.SupersedesRecordID = original.ID
+	corrected.RecordedAt = original.RecordedAt.Add(time.Hour)
+
+	forward, ok := ResolveFindingAdjudication([]AdjudicationRecordV1{original, corrected}, original.FindingRef, original.Scope)
+	if !ok || forward.ID != corrected.ID {
+		t.Fatalf("expected the correction regardless of order, got %+v (ok=%v)", forward, ok)
+	}
+
+	reversed, ok := ResolveFindingAdjudication([]AdjudicationRecordV1{corrected, original}, original.FindingRef, original.Scope)
+	if !ok || reversed.ID != corrected.ID {
+		t.Fatalf("expected the correction even when it sorts before the original in the input slice, got %+v (ok=%v)", reversed, ok)
+	}
+}
+
+func TestResolveFindingAdjudication_TiedTimestampPrefersSupersedingRecord(t *testing.T) {
+	original := validAdjudicationRecord()
+	original.ID = "adjudication-1"
+
+	corrected := validAdjudicationRecord()
+	corrected.ID = "adjudication-2"
+	corrected.Disposition = AdjudicationFalsePositive
+	corrected.RelationToPrior = AdjudicationRelationCorrected
+	corrected.SupersedesRecordID = original.ID
+
+	found, ok := ResolveFindingAdjudication([]AdjudicationRecordV1{corrected, original}, original.FindingRef, original.Scope)
+	if !ok || found.ID != corrected.ID {
+		t.Fatalf("expected the record that supersedes the other to win a recorded_at tie, got %+v (ok=%v)", found, ok)
+	}
+}
+
 func TestResolveFindingAdjudication_UncertaintyStaysVisibleAcrossScopeChanges(t *testing.T) {
 	record := validAdjudicationRecord()
 

--- a/internal/store/adjudication_test.go
+++ b/internal/store/adjudication_test.go
@@ -116,6 +116,7 @@ func TestAdjudicationRecordV1_Validate(t *testing.T) {
 		{name: "cluster reference is sufficient", mutate: func(r *AdjudicationRecordV1) { r.FindingRef = AdjudicationFindingRefV1{ClusterID: "cluster-1"} }, wantErr: false},
 		{name: "unknown disposition", mutate: func(r *AdjudicationRecordV1) { r.Disposition = "wontfix" }, wantErr: true},
 		{name: "missing deciding actor identity", mutate: func(r *AdjudicationRecordV1) { r.DecidingActor.Identity = "" }, wantErr: true},
+		{name: "missing scope configuration fingerprint", mutate: func(r *AdjudicationRecordV1) { r.Scope.ConfigurationFingerprint = "" }, wantErr: true},
 		{name: "zero recorded_at", mutate: func(r *AdjudicationRecordV1) { r.RecordedAt = time.Time{} }, wantErr: true},
 		{
 			name: "relation without supersedes id",

--- a/internal/store/adjudication_test.go
+++ b/internal/store/adjudication_test.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func validAdjudicationRecord() AdjudicationRecordV1 {
+	return AdjudicationRecordV1{
+		SchemaVersion: CurrentSchemaVersion,
+		ID:            "adjudication-1",
+		FindingRef:    AdjudicationFindingRefV1{FindingID: "finding-1"},
+		Disposition:   AdjudicationAcceptedRisk,
+		DecidingActor: AdjudicationActorV1{Kind: AdjudicationActorHuman, Identity: "richhaase"},
+		Rationale:     "known limitation, tracked separately",
+		Evidence:      []string{"see issue #42"},
+		Scope: AdjudicationScopeV1{
+			PullRequest:              testPullRequestKey(),
+			HeadObjectID:             "headsha",
+			ConfigurationFingerprint: "sha256:abc",
+		},
+		InvalidationConditions: []string{"invalidate if the flagged function signature changes"},
+		RecordedAt:             time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestAdjudicationRecordV1_RoundTripAllDispositions(t *testing.T) {
+	dispositions := []AdjudicationDispositionV1{
+		AdjudicationFixed,
+		AdjudicationFalsePositive,
+		AdjudicationDuplicate,
+		AdjudicationAcceptedRisk,
+		AdjudicationPolicyDecision,
+		AdjudicationDeferred,
+		AdjudicationObsolete,
+	}
+
+	for _, disposition := range dispositions {
+		t.Run(string(disposition), func(t *testing.T) {
+			record := validAdjudicationRecord()
+			record.Disposition = disposition
+
+			if err := record.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+
+			data, err := json.Marshal(record)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded AdjudicationRecordV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(decoded, record) {
+				t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, record)
+			}
+		})
+	}
+}
+
+func TestAdjudicationRecordV1_ReopenCorrectSupersedeChainPreservesOriginal(t *testing.T) {
+	original := validAdjudicationRecord()
+	original.ID = "adjudication-1"
+
+	reopened := validAdjudicationRecord()
+	reopened.ID = "adjudication-2"
+	reopened.Disposition = AdjudicationDeferred
+	reopened.RelationToPrior = AdjudicationRelationReopened
+	reopened.SupersedesRecordID = original.ID
+
+	corrected := validAdjudicationRecord()
+	corrected.ID = "adjudication-3"
+	corrected.Disposition = AdjudicationFalsePositive
+	corrected.RelationToPrior = AdjudicationRelationCorrected
+	corrected.SupersedesRecordID = reopened.ID
+
+	superseded := validAdjudicationRecord()
+	superseded.ID = "adjudication-4"
+	superseded.Disposition = AdjudicationFixed
+	superseded.RelationToPrior = AdjudicationRelationSuperseded
+	superseded.SupersedesRecordID = corrected.ID
+
+	chain := []AdjudicationRecordV1{original, reopened, corrected, superseded}
+	for _, record := range chain {
+		if err := record.Validate(); err != nil {
+			t.Fatalf("Validate(%s): %v", record.ID, err)
+		}
+	}
+
+	if original.RelationToPrior != AdjudicationRelationNone || original.SupersedesRecordID != "" {
+		t.Fatalf("the original decision must remain untouched by the chain built on top of it: %+v", original)
+	}
+	if reopened.SupersedesRecordID != original.ID {
+		t.Fatalf("reopened record must reference the original decision it acts on")
+	}
+	if corrected.SupersedesRecordID != reopened.ID {
+		t.Fatalf("corrected record must reference the decision it acts on")
+	}
+	if superseded.SupersedesRecordID != corrected.ID {
+		t.Fatalf("superseded record must reference the decision it acts on")
+	}
+}
+
+func TestAdjudicationRecordV1_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(r *AdjudicationRecordV1)
+		wantErr bool
+	}{
+		{name: "valid record", mutate: func(r *AdjudicationRecordV1) {}, wantErr: false},
+		{name: "unsupported schema version", mutate: func(r *AdjudicationRecordV1) { r.SchemaVersion = 99 }, wantErr: true},
+		{name: "missing finding and cluster reference", mutate: func(r *AdjudicationRecordV1) { r.FindingRef = AdjudicationFindingRefV1{} }, wantErr: true},
+		{name: "cluster reference is sufficient", mutate: func(r *AdjudicationRecordV1) { r.FindingRef = AdjudicationFindingRefV1{ClusterID: "cluster-1"} }, wantErr: false},
+		{name: "unknown disposition", mutate: func(r *AdjudicationRecordV1) { r.Disposition = "wontfix" }, wantErr: true},
+		{name: "missing deciding actor identity", mutate: func(r *AdjudicationRecordV1) { r.DecidingActor.Identity = "" }, wantErr: true},
+		{name: "zero recorded_at", mutate: func(r *AdjudicationRecordV1) { r.RecordedAt = time.Time{} }, wantErr: true},
+		{
+			name: "relation without supersedes id",
+			mutate: func(r *AdjudicationRecordV1) {
+				r.RelationToPrior = AdjudicationRelationReopened
+				r.SupersedesRecordID = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "supersedes id without relation",
+			mutate: func(r *AdjudicationRecordV1) {
+				r.RelationToPrior = AdjudicationRelationNone
+				r.SupersedesRecordID = "adjudication-0"
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := validAdjudicationRecord()
+			tt.mutate(&record)
+			err := record.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/store/adjudicationstore.go
+++ b/internal/store/adjudicationstore.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+type AdjudicationStore interface {
+	SaveAdjudication(record AdjudicationRecordV1) (string, error)
+	ListAdjudications(key PullRequestKeyV1) ([]AdjudicationRecordV1, []CorruptRecord, error)
+}
+
+type FilesystemAdjudicationStore struct {
+	dataDir string
+}
+
+func NewFilesystemAdjudicationStore(dataDir string) *FilesystemAdjudicationStore {
+	return &FilesystemAdjudicationStore{dataDir: dataDir}
+}
+
+var _ AdjudicationStore = (*FilesystemAdjudicationStore)(nil)
+
+func (s *FilesystemAdjudicationStore) SaveAdjudication(record AdjudicationRecordV1) (string, error) {
+	if err := record.Validate(); err != nil {
+		return "", err
+	}
+	dir, err := adjudicationsDir(s.dataDir, record.Scope.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	name, err := recordFileName("adjudication record", record.ID, record.RecordedAt)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, name)
+
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal adjudication record %s: %w", record.ID, err)
+	}
+	if err := writeNewFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("save adjudication record %s: %w", record.ID, err)
+	}
+	return path, nil
+}
+
+func (s *FilesystemAdjudicationStore) ListAdjudications(key PullRequestKeyV1) ([]AdjudicationRecordV1, []CorruptRecord, error) {
+	dir, err := adjudicationsDir(s.dataDir, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return listRecords(dir, decodeAdjudicationRecord)
+}

--- a/internal/store/adjudicationstore.go
+++ b/internal/store/adjudicationstore.go
@@ -25,6 +25,15 @@ func (s *FilesystemAdjudicationStore) SaveAdjudication(record AdjudicationRecord
 	if err := record.Validate(); err != nil {
 		return "", err
 	}
+	existing, _, err := s.ListAdjudications(record.Scope.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range existing {
+		if e.ID == record.ID {
+			return "", fmt.Errorf("adjudication record %s already exists for %s", record.ID, record.Scope.PullRequest.String())
+		}
+	}
 	dir, err := adjudicationsDir(s.dataDir, record.Scope.PullRequest)
 	if err != nil {
 		return "", err

--- a/internal/store/adjudicationstore.go
+++ b/internal/store/adjudicationstore.go
@@ -39,7 +39,7 @@ func (s *FilesystemAdjudicationStore) SaveAdjudication(record AdjudicationRecord
 	if err != nil {
 		return "", fmt.Errorf("marshal adjudication record %s: %w", record.ID, err)
 	}
-	if err := writeNewFile(path, data, 0o644); err != nil {
+	if err := writeNewFile(path, data, 0o600); err != nil {
 		return "", fmt.Errorf("save adjudication record %s: %w", record.ID, err)
 	}
 	return path, nil

--- a/internal/store/adjudicationstore_test.go
+++ b/internal/store/adjudicationstore_test.go
@@ -64,6 +64,33 @@ func TestFilesystemAdjudicationStore_RefusesDuplicateSave(t *testing.T) {
 	}
 }
 
+func TestFilesystemAdjudicationStore_RefusesDuplicateIDWithDifferentTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemAdjudicationStore(dir)
+	key := testPullRequestKey()
+
+	first := testAdjudicationRecord("adjudication-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveAdjudication(first); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	second := testAdjudicationRecord("adjudication-dup", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+	if _, err := store.SaveAdjudication(second); err == nil {
+		t.Fatal("expected an error re-saving the same adjudication id under a different timestamp")
+	}
+
+	records, corrupt, err := store.ListAdjudications(key)
+	if err != nil {
+		t.Fatalf("list adjudications: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected exactly one stored record for the duplicated id, got %d", len(records))
+	}
+}
+
 func TestFilesystemAdjudicationStore_RejectsInvalidRecord(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFilesystemAdjudicationStore(dir)

--- a/internal/store/adjudicationstore_test.go
+++ b/internal/store/adjudicationstore_test.go
@@ -1,0 +1,174 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testAdjudicationRecord(id string, recordedAt time.Time) AdjudicationRecordV1 {
+	return AdjudicationRecordV1{
+		SchemaVersion: CurrentSchemaVersion,
+		ID:            id,
+		FindingRef:    AdjudicationFindingRefV1{FindingID: "finding-1"},
+		Disposition:   AdjudicationAcceptedRisk,
+		DecidingActor: AdjudicationActorV1{Kind: AdjudicationActorHuman, Identity: "richhaase"},
+		Rationale:     "known limitation",
+		Scope: AdjudicationScopeV1{
+			PullRequest:              testPullRequestKey(),
+			HeadObjectID:             "headsha",
+			ConfigurationFingerprint: "sha256:abc",
+		},
+		RecordedAt: recordedAt,
+	}
+}
+
+func TestFilesystemAdjudicationStore_SaveAndList(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemAdjudicationStore(dir)
+	key := testPullRequestKey()
+
+	r1 := testAdjudicationRecord("adjudication-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	r2 := testAdjudicationRecord("adjudication-2", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+
+	if _, err := store.SaveAdjudication(r1); err != nil {
+		t.Fatalf("save r1: %v", err)
+	}
+	if _, err := store.SaveAdjudication(r2); err != nil {
+		t.Fatalf("save r2: %v", err)
+	}
+
+	records, corrupt, err := store.ListAdjudications(key)
+	if err != nil {
+		t.Fatalf("list adjudications: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(records) != 2 || records[0].ID != "adjudication-1" || records[1].ID != "adjudication-2" {
+		t.Fatalf("expected chronological adjudication-1, adjudication-2, got %+v", records)
+	}
+}
+
+func TestFilesystemAdjudicationStore_RefusesDuplicateSave(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemAdjudicationStore(dir)
+	record := testAdjudicationRecord("adjudication-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	if _, err := store.SaveAdjudication(record); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if _, err := store.SaveAdjudication(record); err == nil {
+		t.Fatal("expected an error re-saving the same adjudication id/timestamp")
+	}
+}
+
+func TestFilesystemAdjudicationStore_RejectsInvalidRecord(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemAdjudicationStore(dir)
+	invalid := testAdjudicationRecord("adjudication-invalid", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	invalid.Disposition = "wontfix"
+
+	if _, err := store.SaveAdjudication(invalid); err == nil {
+		t.Fatal("expected an error for an unknown disposition")
+	}
+}
+
+func TestFilesystemAdjudicationStore_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+	record := testAdjudicationRecord("adjudication-restart", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	firstProcessStore := NewFilesystemAdjudicationStore(dir)
+	if _, err := firstProcessStore.SaveAdjudication(record); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	secondProcessStore := NewFilesystemAdjudicationStore(dir)
+	records, _, err := secondProcessStore.ListAdjudications(key)
+	if err != nil {
+		t.Fatalf("list after restart: %v", err)
+	}
+	if len(records) != 1 || records[0].ID != "adjudication-restart" {
+		t.Fatalf("restart did not preserve adjudication history: got %+v", records)
+	}
+}
+
+func TestFilesystemAdjudicationStore_IsolatesCorruptRecords(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemAdjudicationStore(dir)
+	key := testPullRequestKey()
+
+	good := testAdjudicationRecord("adjudication-good", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveAdjudication(good); err != nil {
+		t.Fatalf("save good record: %v", err)
+	}
+
+	dirPath, err := adjudicationsDir(dir, key)
+	if err != nil {
+		t.Fatalf("adjudicationsDir: %v", err)
+	}
+	corruptPath := filepath.Join(dirPath, "20260722T130000.000000000Z-adjudication-bad.json")
+	if err := os.WriteFile(corruptPath, []byte(`not json at all`), 0o644); err != nil {
+		t.Fatalf("seed corrupt record: %v", err)
+	}
+
+	records, corrupt, err := store.ListAdjudications(key)
+	if err != nil {
+		t.Fatalf("list adjudications: %v", err)
+	}
+	if len(records) != 1 || records[0].ID != "adjudication-good" {
+		t.Fatalf("expected the good record to remain readable, got %+v", records)
+	}
+	if len(corrupt) != 1 || corrupt[0].Path != corruptPath {
+		t.Fatalf("expected exactly one corrupt record reported for %s, got %+v", corruptPath, corrupt)
+	}
+}
+
+func TestFilesystemAdjudicationStore_PreservesHistoryOnReopenCorrectSupersede(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemAdjudicationStore(dir)
+	key := testPullRequestKey()
+
+	original := testAdjudicationRecord("adjudication-1", time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC))
+
+	reopened := testAdjudicationRecord("adjudication-2", time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC))
+	reopened.Disposition = AdjudicationDeferred
+	reopened.RelationToPrior = AdjudicationRelationReopened
+	reopened.SupersedesRecordID = original.ID
+
+	corrected := testAdjudicationRecord("adjudication-3", time.Date(2026, 7, 22, 11, 0, 0, 0, time.UTC))
+	corrected.Disposition = AdjudicationFalsePositive
+	corrected.RelationToPrior = AdjudicationRelationCorrected
+	corrected.SupersedesRecordID = reopened.ID
+
+	for _, record := range []AdjudicationRecordV1{original, reopened, corrected} {
+		if _, err := store.SaveAdjudication(record); err != nil {
+			t.Fatalf("save %s: %v", record.ID, err)
+		}
+	}
+
+	records, corrupt, err := store.ListAdjudications(key)
+	if err != nil {
+		t.Fatalf("list adjudications: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(records) != 3 {
+		t.Fatalf("expected all 3 records preserved as separate history entries, got %d: %+v", len(records), records)
+	}
+
+	byID := make(map[string]AdjudicationRecordV1, len(records))
+	for _, record := range records {
+		byID[record.ID] = record
+	}
+	restoredOriginal, ok := byID[original.ID]
+	if !ok {
+		t.Fatalf("original record %s missing from history", original.ID)
+	}
+	if restoredOriginal.Disposition != AdjudicationAcceptedRisk || restoredOriginal.RelationToPrior != AdjudicationRelationNone {
+		t.Fatalf("original record was mutated by later reopen/correct events: %+v", restoredOriginal)
+	}
+}

--- a/internal/store/atomic.go
+++ b/internal/store/atomic.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create directory %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".tmp-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	renamed := false
+	defer func() {
+		if !renamed {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temporary file %s: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temporary file %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary file %s: %w", tmpPath, err)
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("set permissions on temporary file %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temporary file %s to %s: %w", tmpPath, path, err)
+	}
+	renamed = true
+
+	if dirFile, err := os.Open(dir); err == nil {
+		_ = dirFile.Sync()
+		_ = dirFile.Close()
+	}
+	return nil
+}
+
+func writeNewFile(path string, data []byte, perm os.FileMode) error {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("record already exists at %s", path)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	return atomicWriteFile(path, data, perm)
+}

--- a/internal/store/atomic.go
+++ b/internal/store/atomic.go
@@ -1,60 +1,82 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 )
 
-func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create directory %s: %w", dir, err)
+func writeTempFile(dir, base string, data []byte, perm os.FileMode) (string, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create directory %s: %w", dir, err)
 	}
 
-	tmp, err := os.CreateTemp(dir, ".tmp-"+filepath.Base(path)+"-*")
+	tmp, err := os.CreateTemp(dir, ".tmp-"+base+"-*")
 	if err != nil {
-		return fmt.Errorf("create temporary file in %s: %w", dir, err)
+		return "", fmt.Errorf("create temporary file in %s: %w", dir, err)
 	}
 	tmpPath := tmp.Name()
-	renamed := false
+	ok := false
 	defer func() {
-		if !renamed {
+		if !ok {
 			os.Remove(tmpPath)
 		}
 	}()
 
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
-		return fmt.Errorf("write temporary file %s: %w", tmpPath, err)
+		return "", fmt.Errorf("write temporary file %s: %w", tmpPath, err)
 	}
 	if err := tmp.Sync(); err != nil {
 		tmp.Close()
-		return fmt.Errorf("sync temporary file %s: %w", tmpPath, err)
+		return "", fmt.Errorf("sync temporary file %s: %w", tmpPath, err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temporary file %s: %w", tmpPath, err)
+		return "", fmt.Errorf("close temporary file %s: %w", tmpPath, err)
 	}
 	if err := os.Chmod(tmpPath, perm); err != nil {
-		return fmt.Errorf("set permissions on temporary file %s: %w", tmpPath, err)
+		return "", fmt.Errorf("set permissions on temporary file %s: %w", tmpPath, err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("rename temporary file %s to %s: %w", tmpPath, path, err)
-	}
-	renamed = true
+	ok = true
+	return tmpPath, nil
+}
 
+func syncDir(dir string) {
 	if dirFile, err := os.Open(dir); err == nil {
 		_ = dirFile.Sync()
 		_ = dirFile.Close()
 	}
+}
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmpPath, err := writeTempFile(dir, filepath.Base(path), data, perm)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename temporary file %s to %s: %w", tmpPath, path, err)
+	}
+	syncDir(dir)
 	return nil
 }
 
 func writeNewFile(path string, data []byte, perm os.FileMode) error {
-	if _, err := os.Stat(path); err == nil {
-		return fmt.Errorf("record already exists at %s", path)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat %s: %w", path, err)
+	dir := filepath.Dir(path)
+	tmpPath, err := writeTempFile(dir, filepath.Base(path), data, perm)
+	if err != nil {
+		return err
 	}
-	return atomicWriteFile(path, data, perm)
+	if err := os.Link(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("record already exists at %s", path)
+		}
+		return fmt.Errorf("link temporary file %s to %s: %w", tmpPath, path, err)
+	}
+	os.Remove(tmpPath)
+	syncDir(dir)
+	return nil
 }

--- a/internal/store/atomic_test.go
+++ b/internal/store/atomic_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAtomicWriteFile_WritesAndReplaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "record.json")
+
+	if err := atomicWriteFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := atomicWriteFile(path, []byte(`{"a":2}`), 0o644); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != `{"a":2}` {
+		t.Fatalf("expected latest content, got %q", data)
+	}
+}
+
+func TestAtomicWriteFile_LeavesNoTempFileBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "record.json")
+
+	if err := atomicWriteFile(path, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "record.json" {
+		t.Fatalf("expected only the final file to remain, got %v", entries)
+	}
+}
+
+func TestAtomicWriteFile_StrayTempFileIgnoredByCaller(t *testing.T) {
+	dir := t.TempDir()
+	strayPath := filepath.Join(dir, ".tmp-record.json-abc123")
+	if err := os.WriteFile(strayPath, []byte(`{"trunc`), 0o644); err != nil {
+		t.Fatalf("seed stray temp file: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".") {
+			t.Fatalf("expected only hidden stray files, found %q", entry.Name())
+		}
+	}
+}
+
+func TestWriteNewFile_RefusesToOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "record.json")
+
+	if err := writeNewFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeNewFile(path, []byte(`{"a":2}`), 0o644); err == nil {
+		t.Fatal("expected an error when writing over an existing record")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != `{"a":1}` {
+		t.Fatalf("original record must be preserved, got %q", data)
+	}
+}

--- a/internal/store/atomic_test.go
+++ b/internal/store/atomic_test.go
@@ -1,9 +1,11 @@
 package store
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -59,6 +61,42 @@ func TestAtomicWriteFile_StrayTempFileIgnoredByCaller(t *testing.T) {
 		if !strings.HasPrefix(entry.Name(), ".") {
 			t.Fatalf("expected only hidden stray files, found %q", entry.Name())
 		}
+	}
+}
+
+func TestWriteNewFile_ConcurrentWritersToTheSamePathNeverBothSucceed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "record.json")
+
+	const writers = 20
+	var wg sync.WaitGroup
+	results := make([]error, writers)
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			results[i] = writeNewFile(path, []byte(fmt.Sprintf(`{"writer":%d}`, i)), 0o600)
+		}()
+	}
+	wg.Wait()
+
+	successes := 0
+	for _, err := range results {
+		if err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly one of %d concurrent writers to the same path to succeed, got %d", writers, successes)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "record.json" {
+		t.Fatalf("expected exactly one surviving record and no leftover temp files, got %v", entries)
 	}
 }
 

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -178,8 +178,11 @@ func ValidatePolicySourceOutsideReview(source PolicySourceV1, target ReviewTarge
 	if source.Kind != config.SourceKindRepositoryRevision {
 		return nil
 	}
-	if source.Revision == "" || target.Revision.HeadObjectID == "" {
-		return nil
+	if source.Revision == "" {
+		return fmt.Errorf("adjudication policy source revision is required to verify it is outside the reviewed pull request head")
+	}
+	if target.Revision.HeadObjectID == "" {
+		return fmt.Errorf("reviewed pull request head revision is required to verify adjudication policy source %q is outside the reviewed head", source.Revision)
 	}
 	if source.Revision == target.Revision.HeadObjectID {
 		return fmt.Errorf("adjudication policy source revision %q matches the reviewed pull request head; policy must come from a source outside the reviewed head and worktree", source.Revision)

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -127,14 +127,6 @@ func (c ReviewConfigurationV1) ToDomain() (domain.ReviewConfiguration, error) {
 	return cfg, nil
 }
 
-// PolicySourceV1 records the provenance of a trusted control-plane input used
-// to seed adjudication memory, budget policy, stop policy, or evaluation
-// guidance. It mirrors config.SourceIdentity, the trust boundary established
-// by issue #220, rather than inventing a second one. Only sources capable of
-// resolving to a pinned, non-PR-relative input are accepted; a raw filesystem
-// read (config.SourceKindFilesystem) is never a valid policy source because it
-// resolves relative to whatever directory a caller passes at run time,
-// including a reviewed PR's own worktree.
 type PolicySourceV1 struct {
 	Kind          string `json:"kind"`
 	Locator       string `json:"locator"`
@@ -179,12 +171,6 @@ func (s PolicySourceV1) Validate() error {
 	}
 }
 
-// ValidatePolicySourceOutsideReview rejects a policy source that resolves to
-// the head revision of the pull request under review. A pinned
-// repository-revision source is otherwise trusted, but it must not pin the
-// very head the review is evaluating: that would let the reviewed PR content
-// supply its own adjudication memory, budget policy, stop policy, or
-// evaluation guidance.
 func ValidatePolicySourceOutsideReview(source PolicySourceV1, target ReviewTargetV1) error {
 	if err := source.Validate(); err != nil {
 		return err

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -1,0 +1,202 @@
+package store
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type ConfigurationSourceIdentityV1 struct {
+	Kind          string `json:"kind"`
+	Locator       string `json:"locator"`
+	Ref           string `json:"ref"`
+	Revision      string `json:"revision"`
+	ConfigPresent bool   `json:"config_present"`
+	ConfigDigest  string `json:"config_digest"`
+}
+
+func ToConfigurationSourceIdentitySchema(s domain.ConfigurationSourceIdentity) ConfigurationSourceIdentityV1 {
+	return ConfigurationSourceIdentityV1{
+		Kind:          s.Kind,
+		Locator:       s.Locator,
+		Ref:           s.Ref,
+		Revision:      s.Revision,
+		ConfigPresent: s.ConfigPresent,
+		ConfigDigest:  s.ConfigDigest,
+	}
+}
+
+func (s ConfigurationSourceIdentityV1) ToDomain() domain.ConfigurationSourceIdentity {
+	return domain.ConfigurationSourceIdentity{
+		Kind:          s.Kind,
+		Locator:       s.Locator,
+		Ref:           s.Ref,
+		Revision:      s.Revision,
+		ConfigPresent: s.ConfigPresent,
+		ConfigDigest:  s.ConfigDigest,
+	}
+}
+
+func (s ConfigurationSourceIdentityV1) Validate() error {
+	return s.ToDomain().Validate()
+}
+
+type ReviewConfigurationValuesV1 struct {
+	Reviewers         int           `json:"reviewers"`
+	Concurrency       int           `json:"concurrency"`
+	Timeout           time.Duration `json:"timeout"`
+	Retries           int           `json:"retries"`
+	ReviewerAgents    []string      `json:"reviewer_agents"`
+	ReviewerModel     string        `json:"reviewer_model"`
+	SummarizerAgent   string        `json:"summarizer_agent"`
+	SummarizerModel   string        `json:"summarizer_model"`
+	SummarizerTimeout time.Duration `json:"summarizer_timeout"`
+	FPFilterTimeout   time.Duration `json:"fp_filter_timeout"`
+	Guidance          string        `json:"guidance"`
+	UseRefFile        bool          `json:"use_ref_file"`
+	FPFilterEnabled   bool          `json:"fp_filter_enabled"`
+	FPThreshold       int           `json:"fp_threshold"`
+	PRFeedbackEnabled bool          `json:"pr_feedback_enabled"`
+	PRFeedbackAgent   string        `json:"pr_feedback_agent"`
+	ExcludePatterns   []string      `json:"exclude_patterns"`
+}
+
+type ReviewConfigurationV1 struct {
+	Values      ReviewConfigurationValuesV1 `json:"values"`
+	Fingerprint string                      `json:"fingerprint"`
+}
+
+func ToReviewConfigurationSchema(c domain.ReviewConfiguration) ReviewConfigurationV1 {
+	values := c.Values()
+	return ReviewConfigurationV1{
+		Values: ReviewConfigurationValuesV1{
+			Reviewers:         values.Reviewers,
+			Concurrency:       values.Concurrency,
+			Timeout:           values.Timeout,
+			Retries:           values.Retries,
+			ReviewerAgents:    append([]string(nil), values.ReviewerAgents...),
+			ReviewerModel:     values.ReviewerModel,
+			SummarizerAgent:   values.SummarizerAgent,
+			SummarizerModel:   values.SummarizerModel,
+			SummarizerTimeout: values.SummarizerTimeout,
+			FPFilterTimeout:   values.FPFilterTimeout,
+			Guidance:          values.Guidance,
+			UseRefFile:        values.UseRefFile,
+			FPFilterEnabled:   values.FPFilterEnabled,
+			FPThreshold:       values.FPThreshold,
+			PRFeedbackEnabled: values.PRFeedbackEnabled,
+			PRFeedbackAgent:   values.PRFeedbackAgent,
+			ExcludePatterns:   append([]string(nil), values.ExcludePatterns...),
+		},
+		Fingerprint: c.Fingerprint(),
+	}
+}
+
+func (c ReviewConfigurationV1) ToDomain() (domain.ReviewConfiguration, error) {
+	values := domain.ReviewConfigurationValues{
+		Reviewers:         c.Values.Reviewers,
+		Concurrency:       c.Values.Concurrency,
+		Timeout:           c.Values.Timeout,
+		Retries:           c.Values.Retries,
+		ReviewerAgents:    append([]string(nil), c.Values.ReviewerAgents...),
+		ReviewerModel:     c.Values.ReviewerModel,
+		SummarizerAgent:   c.Values.SummarizerAgent,
+		SummarizerModel:   c.Values.SummarizerModel,
+		SummarizerTimeout: c.Values.SummarizerTimeout,
+		FPFilterTimeout:   c.Values.FPFilterTimeout,
+		Guidance:          c.Values.Guidance,
+		UseRefFile:        c.Values.UseRefFile,
+		FPFilterEnabled:   c.Values.FPFilterEnabled,
+		FPThreshold:       c.Values.FPThreshold,
+		PRFeedbackEnabled: c.Values.PRFeedbackEnabled,
+		PRFeedbackAgent:   c.Values.PRFeedbackAgent,
+		ExcludePatterns:   append([]string(nil), c.Values.ExcludePatterns...),
+	}
+	cfg, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		return domain.ReviewConfiguration{}, fmt.Errorf("reconstruct stored review configuration: %w", err)
+	}
+	if cfg.Fingerprint() != c.Fingerprint {
+		return domain.ReviewConfiguration{}, fmt.Errorf(
+			"stored review configuration fingerprint %q does not match recomputed fingerprint %q; record may be corrupt",
+			c.Fingerprint, cfg.Fingerprint(),
+		)
+	}
+	return cfg, nil
+}
+
+// PolicySourceV1 records the provenance of a trusted control-plane input used
+// to seed adjudication memory, budget policy, stop policy, or evaluation
+// guidance. It mirrors config.SourceIdentity, the trust boundary established
+// by issue #220, rather than inventing a second one. Only sources capable of
+// resolving to a pinned, non-PR-relative input are accepted; a raw filesystem
+// read (config.SourceKindFilesystem) is never a valid policy source because it
+// resolves relative to whatever directory a caller passes at run time,
+// including a reviewed PR's own worktree.
+type PolicySourceV1 struct {
+	Kind          string `json:"kind"`
+	Locator       string `json:"locator"`
+	Ref           string `json:"ref"`
+	Revision      string `json:"revision"`
+	ConfigPresent bool   `json:"config_present"`
+	ConfigDigest  string `json:"config_digest"`
+}
+
+func ToPolicySourceSchema(s config.SourceIdentity) PolicySourceV1 {
+	return PolicySourceV1{
+		Kind:          s.Kind,
+		Locator:       s.Locator,
+		Ref:           s.Ref,
+		Revision:      s.Revision,
+		ConfigPresent: s.ConfigPresent,
+		ConfigDigest:  s.ConfigDigest,
+	}
+}
+
+func (s PolicySourceV1) ToConfigSourceIdentity() config.SourceIdentity {
+	return config.SourceIdentity{
+		Kind:          s.Kind,
+		Locator:       s.Locator,
+		Ref:           s.Ref,
+		Revision:      s.Revision,
+		ConfigPresent: s.ConfigPresent,
+		ConfigDigest:  s.ConfigDigest,
+	}
+}
+
+func (s PolicySourceV1) Validate() error {
+	switch s.Kind {
+	case config.SourceKindDisabled, config.SourceKindDefaults, config.SourceKindRepositoryRevision:
+		return nil
+	case config.SourceKindFilesystem:
+		return fmt.Errorf("adjudication policy source kind %q resolves relative to a caller-supplied directory and can never be trusted for adjudication memory, budget policy, stop policy, or evaluation guidance", s.Kind)
+	case "":
+		return fmt.Errorf("adjudication policy source kind is required")
+	default:
+		return fmt.Errorf("adjudication policy source kind %q is not a recognized trusted configuration source", s.Kind)
+	}
+}
+
+// ValidatePolicySourceOutsideReview rejects a policy source that resolves to
+// the head revision of the pull request under review. A pinned
+// repository-revision source is otherwise trusted, but it must not pin the
+// very head the review is evaluating: that would let the reviewed PR content
+// supply its own adjudication memory, budget policy, stop policy, or
+// evaluation guidance.
+func ValidatePolicySourceOutsideReview(source PolicySourceV1, target ReviewTargetV1) error {
+	if err := source.Validate(); err != nil {
+		return err
+	}
+	if source.Kind != config.SourceKindRepositoryRevision {
+		return nil
+	}
+	if source.Revision == "" || target.Revision.HeadObjectID == "" {
+		return nil
+	}
+	if source.Revision == target.Revision.HeadObjectID {
+		return fmt.Errorf("adjudication policy source revision %q matches the reviewed pull request head; policy must come from a source outside the reviewed head and worktree", source.Revision)
+	}
+	return nil
+}

--- a/internal/store/config_test.go
+++ b/internal/store/config_test.go
@@ -1,0 +1,198 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+func newTestReviewConfiguration(t *testing.T) domain.ReviewConfiguration {
+	t.Helper()
+	cfg, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         3,
+		Concurrency:       3,
+		Timeout:           10 * time.Minute,
+		Retries:           1,
+		ReviewerAgents:    []string{"claude", "codex"},
+		ReviewerModel:     "opus",
+		SummarizerAgent:   "claude",
+		SummarizerModel:   "opus",
+		SummarizerTimeout: 5 * time.Minute,
+		FPFilterTimeout:   5 * time.Minute,
+		Guidance:          "focus on security",
+		UseRefFile:        true,
+		FPFilterEnabled:   true,
+		FPThreshold:       75,
+		PRFeedbackEnabled: true,
+		PRFeedbackAgent:   "claude",
+		ExcludePatterns:   []string{"vendor/.*"},
+	})
+	if err != nil {
+		t.Fatalf("NewReviewConfiguration: %v", err)
+	}
+	return cfg
+}
+
+func TestReviewConfigurationV1_RoundTrip(t *testing.T) {
+	cfg := newTestReviewConfiguration(t)
+	schema := ToReviewConfigurationSchema(cfg)
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ReviewConfigurationV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	restored, err := decoded.ToDomain()
+	if err != nil {
+		t.Fatalf("ToDomain: %v", err)
+	}
+	if restored.Fingerprint() != cfg.Fingerprint() {
+		t.Fatalf("fingerprint mismatch: got %s, want %s", restored.Fingerprint(), cfg.Fingerprint())
+	}
+	if restored.Values().Guidance != cfg.Values().Guidance {
+		t.Fatalf("guidance mismatch: got %s, want %s", restored.Values().Guidance, cfg.Values().Guidance)
+	}
+}
+
+func TestReviewConfigurationV1_RejectsCorruptedFingerprint(t *testing.T) {
+	cfg := newTestReviewConfiguration(t)
+	schema := ToReviewConfigurationSchema(cfg)
+	schema.Fingerprint = "sha256:corrupted"
+
+	if _, err := schema.ToDomain(); err == nil {
+		t.Fatal("expected an error for a fingerprint that does not match the stored values")
+	}
+}
+
+func TestConfigurationSourceIdentityV1_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		source domain.ConfigurationSourceIdentity
+	}{
+		{
+			name:   "disabled",
+			source: domain.ConfigurationSourceIdentity{Kind: "disabled", Locator: "--no-config"},
+		},
+		{
+			name: "repository revision with config present",
+			source: domain.ConfigurationSourceIdentity{
+				Kind:          "repository-revision",
+				Locator:       "/repo",
+				Ref:           "refs/acr/trusted-config/origin/main",
+				Revision:      "abc123",
+				ConfigPresent: true,
+				ConfigDigest:  "deadbeef",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := ToConfigurationSourceIdentitySchema(tt.source)
+			data, err := json.Marshal(schema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded ConfigurationSourceIdentityV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := decoded.ToDomain(); got != tt.source {
+				t.Fatalf("round trip mismatch: got %+v, want %+v", got, tt.source)
+			}
+		})
+	}
+}
+
+func TestPolicySourceV1_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  PolicySourceV1
+		wantErr bool
+	}{
+		{name: "disabled is trusted", source: PolicySourceV1{Kind: config.SourceKindDisabled}, wantErr: false},
+		{name: "defaults is trusted", source: PolicySourceV1{Kind: config.SourceKindDefaults}, wantErr: false},
+		{name: "repository revision is trusted", source: PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: "abc"}, wantErr: false},
+		{name: "filesystem is rejected", source: PolicySourceV1{Kind: config.SourceKindFilesystem}, wantErr: true},
+		{name: "empty kind is rejected", source: PolicySourceV1{}, wantErr: true},
+		{name: "unknown kind is rejected", source: PolicySourceV1{Kind: "pr-worktree"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.source.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidatePolicySourceOutsideReview(t *testing.T) {
+	reviewedHead := "reviewed-head-sha"
+	target := ReviewTargetV1{Revision: RevisionEvidenceV1{HeadObjectID: reviewedHead}}
+
+	tests := []struct {
+		name    string
+		source  PolicySourceV1
+		wantErr bool
+	}{
+		{
+			name:    "pinned revision distinct from reviewed head is allowed",
+			source:  PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: "trusted-branch-sha"},
+			wantErr: false,
+		},
+		{
+			name:    "pinned revision equal to reviewed head is rejected",
+			source:  PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: reviewedHead},
+			wantErr: true,
+		},
+		{
+			name:    "disabled source is allowed regardless of head",
+			source:  PolicySourceV1{Kind: config.SourceKindDisabled},
+			wantErr: false,
+		},
+		{
+			name:    "filesystem source is rejected outright",
+			source:  PolicySourceV1{Kind: config.SourceKindFilesystem},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePolicySourceOutsideReview(tt.source, target)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPolicySourceV1_ToConfigSourceIdentityRoundTrip(t *testing.T) {
+	identity := config.SourceIdentity{
+		Kind:          config.SourceKindRepositoryRevision,
+		Locator:       "/repo",
+		Ref:           "refs/acr/trusted-config/origin/main",
+		Revision:      "abc123",
+		ConfigPresent: true,
+		ConfigDigest:  "digest",
+	}
+	schema := ToPolicySourceSchema(identity)
+	if got := schema.ToConfigSourceIdentity(); got != identity {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, identity)
+	}
+}

--- a/internal/store/config_test.go
+++ b/internal/store/config_test.go
@@ -167,6 +167,11 @@ func TestValidatePolicySourceOutsideReview(t *testing.T) {
 			source:  PolicySourceV1{Kind: config.SourceKindFilesystem},
 			wantErr: true,
 		},
+		{
+			name:    "missing source revision fails closed rather than passing",
+			source:  PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: ""},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +184,15 @@ func TestValidatePolicySourceOutsideReview(t *testing.T) {
 				t.Fatalf("expected no error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestValidatePolicySourceOutsideReview_MissingTargetHeadFailsClosed(t *testing.T) {
+	incompleteTarget := ReviewTargetV1{Revision: RevisionEvidenceV1{HeadObjectID: ""}}
+	source := PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: "trusted-branch-sha"}
+
+	if err := ValidatePolicySourceOutsideReview(source, incompleteTarget); err == nil {
+		t.Fatal("expected an error when the reviewed target has no head revision to compare against; missing evidence must not be treated as a passing check")
 	}
 }
 

--- a/internal/store/corrupt.go
+++ b/internal/store/corrupt.go
@@ -5,11 +5,17 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type CorruptRecord struct {
 	Path string
 	Err  error
+}
+
+type timestampedRecord[T any] struct {
+	recordedAt time.Time
+	record     T
 }
 
 func listRecords[T any](dir string, decode func([]byte) (T, error)) ([]T, []CorruptRecord, error) {
@@ -40,6 +46,43 @@ func listRecords[T any](dir string, decode func([]byte) (T, error)) ([]T, []Corr
 			continue
 		}
 		records = append(records, record)
+	}
+	return records, corrupt, nil
+}
+
+func listTimestampedRecords[T any](dir string, decode func([]byte) (T, error)) ([]timestampedRecord[T], []CorruptRecord, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("read directory %s: %w", dir, err)
+	}
+
+	var records []timestampedRecord[T]
+	var corrupt []CorruptRecord
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		recordedAt, err := parseRecordTimestamp(name)
+		if err != nil {
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: err})
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("read %s: %w", path, err)})
+			continue
+		}
+		record, err := decode(data)
+		if err != nil {
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
+			continue
+		}
+		records = append(records, timestampedRecord[T]{recordedAt: recordedAt, record: record})
 	}
 	return records, corrupt, nil
 }

--- a/internal/store/corrupt.go
+++ b/internal/store/corrupt.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type CorruptRecord struct {
+	Path string
+	Err  error
+}
+
+func listRecords[T any](dir string, decode func([]byte) (T, error)) ([]T, []CorruptRecord, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("read directory %s: %w", dir, err)
+	}
+
+	var records []T
+	var corrupt []CorruptRecord
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("read %s: %w", path, err)})
+			continue
+		}
+		record, err := decode(data)
+		if err != nil {
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
+			continue
+		}
+		records = append(records, record)
+	}
+	return records, corrupt, nil
+}

--- a/internal/store/datadir.go
+++ b/internal/store/datadir.go
@@ -1,0 +1,20 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const DataDirEnvVar = "ACR_DATA_DIR"
+
+func DataDir() (string, error) {
+	if dir := os.Getenv(DataDirEnvVar); dir != "" {
+		return dir, nil
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve application data directory: %w", err)
+	}
+	return filepath.Join(base, "acr"), nil
+}

--- a/internal/store/datadir_test.go
+++ b/internal/store/datadir_test.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDir_EnvVarOverride(t *testing.T) {
+	t.Setenv(DataDirEnvVar, "/custom/data/dir")
+
+	dir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if dir != "/custom/data/dir" {
+		t.Fatalf("expected env override to win, got %q", dir)
+	}
+}
+
+func TestDataDir_DefaultsUnderUserCacheDir(t *testing.T) {
+	t.Setenv(DataDirEnvVar, "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	dir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if filepath.Base(dir) != "acr" {
+		t.Fatalf("expected data dir to be named acr, got %q", dir)
+	}
+}

--- a/internal/store/decode.go
+++ b/internal/store/decode.go
@@ -1,0 +1,36 @@
+package store
+
+import "encoding/json"
+
+func decodeReviewRun(data []byte) (ReviewRunV1, error) {
+	var run ReviewRunV1
+	if err := json.Unmarshal(data, &run); err != nil {
+		return ReviewRunV1{}, err
+	}
+	if _, _, err := FromReviewRunSchema(run); err != nil {
+		return ReviewRunV1{}, err
+	}
+	return run, nil
+}
+
+func decodeReviewEvent(data []byte) (ReviewEventV1, error) {
+	var event ReviewEventV1
+	if err := json.Unmarshal(data, &event); err != nil {
+		return ReviewEventV1{}, err
+	}
+	if err := event.Validate(); err != nil {
+		return ReviewEventV1{}, err
+	}
+	return event, nil
+}
+
+func decodePRSnapshot(data []byte) (PRSnapshotV1, error) {
+	var snapshot PRSnapshotV1
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return PRSnapshotV1{}, err
+	}
+	if err := snapshot.Validate(); err != nil {
+		return PRSnapshotV1{}, err
+	}
+	return snapshot, nil
+}

--- a/internal/store/decode.go
+++ b/internal/store/decode.go
@@ -34,3 +34,36 @@ func decodePRSnapshot(data []byte) (PRSnapshotV1, error) {
 	}
 	return snapshot, nil
 }
+
+func decodeAdjudicationRecord(data []byte) (AdjudicationRecordV1, error) {
+	var record AdjudicationRecordV1
+	if err := json.Unmarshal(data, &record); err != nil {
+		return AdjudicationRecordV1{}, err
+	}
+	if err := record.Validate(); err != nil {
+		return AdjudicationRecordV1{}, err
+	}
+	return record, nil
+}
+
+func decodeLoopDecision(data []byte) (LoopDecisionV1, error) {
+	var decision LoopDecisionV1
+	if err := json.Unmarshal(data, &decision); err != nil {
+		return LoopDecisionV1{}, err
+	}
+	if err := decision.Validate(); err != nil {
+		return LoopDecisionV1{}, err
+	}
+	return decision, nil
+}
+
+func decodeReviewEconomics(data []byte) (ReviewEconomicsV1, error) {
+	var economics ReviewEconomicsV1
+	if err := json.Unmarshal(data, &economics); err != nil {
+		return ReviewEconomicsV1{}, err
+	}
+	if err := economics.Validate(); err != nil {
+		return ReviewEconomicsV1{}, err
+	}
+	return economics, nil
+}

--- a/internal/store/economics.go
+++ b/internal/store/economics.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// ProviderUsageV1 records provider token usage and cost for one reviewer or
+// model invocation. Known distinguishes genuinely unavailable usage data from
+// zero usage: when Known is false, the numeric fields must be zero and are
+// not to be read as measured values. See issue #223: unavailable usage or
+// cost must remain visibly unknown rather than being estimated as zero.
+type ProviderUsageV1 struct {
+	Known        bool    `json:"known"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	CostUSD      float64 `json:"cost_usd"`
+}
+
+func (u ProviderUsageV1) Validate() error {
+	if u.Known {
+		return nil
+	}
+	if u.InputTokens != 0 || u.OutputTokens != 0 || u.TotalTokens != 0 || u.CostUSD != 0 {
+		return fmt.Errorf("provider usage marked unknown must not carry nonzero measurements")
+	}
+	return nil
+}
+
+// ProviderUsageRecordV1 attributes a ProviderUsageV1 measurement to the
+// provider and model that produced it.
+type ProviderUsageRecordV1 struct {
+	Provider string          `json:"provider"`
+	Model    string          `json:"model"`
+	Usage    ProviderUsageV1 `json:"usage"`
+}
+
+func (r ProviderUsageRecordV1) Validate() error {
+	if err := validateNonEmpty("provider usage record provider", r.Provider); err != nil {
+		return err
+	}
+	return r.Usage.Validate()
+}
+
+// ReviewEconomicsV1 records the measured cost of running one review: how
+// many reviewer and model calls it took, how long it took, and what provider
+// usage/cost data is available for it. See issue #223.
+type ReviewEconomicsV1 struct {
+	SchemaVersion     int                     `json:"schema_version"`
+	RunID             string                  `json:"run_id"`
+	ReviewerCallCount int                     `json:"reviewer_call_count"`
+	ModelCallCount    int                     `json:"model_call_count"`
+	Duration          time.Duration           `json:"duration"`
+	ProviderUsage     []ProviderUsageRecordV1 `json:"provider_usage,omitempty"`
+}
+
+func (e ReviewEconomicsV1) Validate() error {
+	if err := validateSchemaVersion("review economics", e.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("review economics run_id", e.RunID); err != nil {
+		return err
+	}
+	if e.ReviewerCallCount < 0 {
+		return fmt.Errorf("review economics reviewer_call_count must not be negative")
+	}
+	if e.ModelCallCount < 0 {
+		return fmt.Errorf("review economics model_call_count must not be negative")
+	}
+	if e.Duration < 0 {
+		return fmt.Errorf("review economics duration must not be negative")
+	}
+	for i, usage := range e.ProviderUsage {
+		if err := usage.Validate(); err != nil {
+			return fmt.Errorf("provider usage %d: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/internal/store/economics.go
+++ b/internal/store/economics.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -23,8 +24,8 @@ func (u ProviderUsageV1) Validate() error {
 	if u.InputTokens < 0 || u.OutputTokens < 0 || u.TotalTokens < 0 {
 		return fmt.Errorf("known provider usage token counts must not be negative")
 	}
-	if u.CostUSD < 0 {
-		return fmt.Errorf("known provider usage cost must not be negative")
+	if u.CostUSD < 0 || math.IsNaN(u.CostUSD) || math.IsInf(u.CostUSD, 0) {
+		return fmt.Errorf("known provider usage cost must be a finite number that is not negative")
 	}
 	return nil
 }

--- a/internal/store/economics.go
+++ b/internal/store/economics.go
@@ -14,11 +14,17 @@ type ProviderUsageV1 struct {
 }
 
 func (u ProviderUsageV1) Validate() error {
-	if u.Known {
+	if !u.Known {
+		if u.InputTokens != 0 || u.OutputTokens != 0 || u.TotalTokens != 0 || u.CostUSD != 0 {
+			return fmt.Errorf("provider usage marked unknown must not carry nonzero measurements")
+		}
 		return nil
 	}
-	if u.InputTokens != 0 || u.OutputTokens != 0 || u.TotalTokens != 0 || u.CostUSD != 0 {
-		return fmt.Errorf("provider usage marked unknown must not carry nonzero measurements")
+	if u.InputTokens < 0 || u.OutputTokens < 0 || u.TotalTokens < 0 {
+		return fmt.Errorf("known provider usage token counts must not be negative")
+	}
+	if u.CostUSD < 0 {
+		return fmt.Errorf("known provider usage cost must not be negative")
 	}
 	return nil
 }

--- a/internal/store/economics.go
+++ b/internal/store/economics.go
@@ -5,11 +5,6 @@ import (
 	"time"
 )
 
-// ProviderUsageV1 records provider token usage and cost for one reviewer or
-// model invocation. Known distinguishes genuinely unavailable usage data from
-// zero usage: when Known is false, the numeric fields must be zero and are
-// not to be read as measured values. See issue #223: unavailable usage or
-// cost must remain visibly unknown rather than being estimated as zero.
 type ProviderUsageV1 struct {
 	Known        bool    `json:"known"`
 	InputTokens  int64   `json:"input_tokens"`
@@ -28,8 +23,6 @@ func (u ProviderUsageV1) Validate() error {
 	return nil
 }
 
-// ProviderUsageRecordV1 attributes a ProviderUsageV1 measurement to the
-// provider and model that produced it.
 type ProviderUsageRecordV1 struct {
 	Provider string          `json:"provider"`
 	Model    string          `json:"model"`
@@ -43,9 +36,6 @@ func (r ProviderUsageRecordV1) Validate() error {
 	return r.Usage.Validate()
 }
 
-// ReviewEconomicsV1 records the measured cost of running one review: how
-// many reviewer and model calls it took, how long it took, and what provider
-// usage/cost data is available for it. See issue #223.
 type ReviewEconomicsV1 struct {
 	SchemaVersion     int                     `json:"schema_version"`
 	RunID             string                  `json:"run_id"`

--- a/internal/store/economics_test.go
+++ b/internal/store/economics_test.go
@@ -102,11 +102,12 @@ func TestProviderUsageV1_ValidateRejectsUnknownWithNonzeroMeasurements(t *testin
 	}
 }
 
-func TestReviewEconomicsV1_ValidateRejectsNegativeCounters(t *testing.T) {
+func TestReviewEconomicsV1_ValidateRejectsInvalidFields(t *testing.T) {
 	tests := []struct {
 		name   string
 		mutate func(e *ReviewEconomicsV1)
 	}{
+		{name: "unsupported schema version", mutate: func(e *ReviewEconomicsV1) { e.SchemaVersion = 99 }},
 		{name: "negative reviewer call count", mutate: func(e *ReviewEconomicsV1) { e.ReviewerCallCount = -1 }},
 		{name: "negative model call count", mutate: func(e *ReviewEconomicsV1) { e.ModelCallCount = -1 }},
 		{name: "negative duration", mutate: func(e *ReviewEconomicsV1) { e.Duration = -time.Second }},

--- a/internal/store/economics_test.go
+++ b/internal/store/economics_test.go
@@ -102,6 +102,25 @@ func TestProviderUsageV1_ValidateRejectsUnknownWithNonzeroMeasurements(t *testin
 	}
 }
 
+func TestProviderUsageV1_ValidateRejectsNegativeKnownMeasurements(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage ProviderUsageV1
+	}{
+		{name: "negative input tokens", usage: ProviderUsageV1{Known: true, InputTokens: -1}},
+		{name: "negative output tokens", usage: ProviderUsageV1{Known: true, OutputTokens: -1}},
+		{name: "negative total tokens", usage: ProviderUsageV1{Known: true, TotalTokens: -1}},
+		{name: "negative cost", usage: ProviderUsageV1{Known: true, CostUSD: -0.01}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.usage.Validate(); err == nil {
+				t.Fatalf("expected an error for known usage with a negative measurement: %+v", tt.usage)
+			}
+		})
+	}
+}
+
 func TestReviewEconomicsV1_ValidateRejectsInvalidFields(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/store/economics_test.go
+++ b/internal/store/economics_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -111,6 +112,8 @@ func TestProviderUsageV1_ValidateRejectsNegativeKnownMeasurements(t *testing.T) 
 		{name: "negative output tokens", usage: ProviderUsageV1{Known: true, OutputTokens: -1}},
 		{name: "negative total tokens", usage: ProviderUsageV1{Known: true, TotalTokens: -1}},
 		{name: "negative cost", usage: ProviderUsageV1{Known: true, CostUSD: -0.01}},
+		{name: "NaN cost", usage: ProviderUsageV1{Known: true, CostUSD: math.NaN()}},
+		{name: "infinite cost", usage: ProviderUsageV1{Known: true, CostUSD: math.Inf(1)}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/store/economics_test.go
+++ b/internal/store/economics_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestReviewEconomicsV1_RoundTrip(t *testing.T) {
+	economics := ReviewEconomicsV1{
+		SchemaVersion:     CurrentSchemaVersion,
+		RunID:             "run-1",
+		ReviewerCallCount: 3,
+		ModelCallCount:    5,
+		Duration:          12 * time.Second,
+		ProviderUsage: []ProviderUsageRecordV1{
+			{
+				Provider: "anthropic",
+				Model:    "claude-opus",
+				Usage:    ProviderUsageV1{Known: true, InputTokens: 1000, OutputTokens: 200, TotalTokens: 1200, CostUSD: 0.42},
+			},
+			{
+				Provider: "openai",
+				Model:    "gpt",
+				Usage:    ProviderUsageV1{Known: false},
+			},
+		},
+	}
+
+	if err := economics.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	data, err := json.Marshal(economics)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ReviewEconomicsV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, economics) {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, economics)
+	}
+}
+
+func TestProviderUsageV1_KnownZeroDistinguishableFromUnknown(t *testing.T) {
+	known := ProviderUsageV1{Known: true, InputTokens: 0, OutputTokens: 0, TotalTokens: 0, CostUSD: 0}
+	unknown := ProviderUsageV1{Known: false}
+
+	if err := known.Validate(); err != nil {
+		t.Fatalf("Validate(known zero usage): %v", err)
+	}
+	if err := unknown.Validate(); err != nil {
+		t.Fatalf("Validate(unknown usage): %v", err)
+	}
+
+	knownData, err := json.Marshal(known)
+	if err != nil {
+		t.Fatalf("marshal known: %v", err)
+	}
+	unknownData, err := json.Marshal(unknown)
+	if err != nil {
+		t.Fatalf("marshal unknown: %v", err)
+	}
+	if string(knownData) == string(unknownData) {
+		t.Fatalf("known-zero and unknown usage must serialize differently: %s", knownData)
+	}
+
+	var decodedKnown, decodedUnknown ProviderUsageV1
+	if err := json.Unmarshal(knownData, &decodedKnown); err != nil {
+		t.Fatalf("unmarshal known: %v", err)
+	}
+	if err := json.Unmarshal(unknownData, &decodedUnknown); err != nil {
+		t.Fatalf("unmarshal unknown: %v", err)
+	}
+	if !decodedKnown.Known {
+		t.Fatal("expected decoded known usage to remain Known=true")
+	}
+	if decodedUnknown.Known {
+		t.Fatal("expected decoded unknown usage to remain Known=false")
+	}
+}
+
+func TestProviderUsageV1_ValidateRejectsUnknownWithNonzeroMeasurements(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage ProviderUsageV1
+	}{
+		{name: "nonzero input tokens", usage: ProviderUsageV1{Known: false, InputTokens: 1}},
+		{name: "nonzero output tokens", usage: ProviderUsageV1{Known: false, OutputTokens: 1}},
+		{name: "nonzero total tokens", usage: ProviderUsageV1{Known: false, TotalTokens: 1}},
+		{name: "nonzero cost", usage: ProviderUsageV1{Known: false, CostUSD: 0.01}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.usage.Validate(); err == nil {
+				t.Fatalf("expected an error for unknown usage with a nonzero measurement: %+v", tt.usage)
+			}
+		})
+	}
+}
+
+func TestReviewEconomicsV1_ValidateRejectsNegativeCounters(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(e *ReviewEconomicsV1)
+	}{
+		{name: "negative reviewer call count", mutate: func(e *ReviewEconomicsV1) { e.ReviewerCallCount = -1 }},
+		{name: "negative model call count", mutate: func(e *ReviewEconomicsV1) { e.ModelCallCount = -1 }},
+		{name: "negative duration", mutate: func(e *ReviewEconomicsV1) { e.Duration = -time.Second }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			economics := ReviewEconomicsV1{SchemaVersion: CurrentSchemaVersion, RunID: "run-1"}
+			tt.mutate(&economics)
+			if err := economics.Validate(); err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+		})
+	}
+}

--- a/internal/store/economicsstore.go
+++ b/internal/store/economicsstore.go
@@ -34,6 +34,15 @@ func (s *FilesystemEconomicsStore) SaveEconomics(key PullRequestKeyV1, recordedA
 	if recordedAt.IsZero() {
 		return "", fmt.Errorf("review economics %s: recorded_at is required", economics.RunID)
 	}
+	existing, _, err := s.ListEconomics(key)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range existing {
+		if e.Economics.RunID == economics.RunID {
+			return "", fmt.Errorf("review economics for run %s already exists for %s", economics.RunID, key.String())
+		}
+	}
 	dir, err := economicsDir(s.dataDir, key)
 	if err != nil {
 		return "", err

--- a/internal/store/economicsstore.go
+++ b/internal/store/economicsstore.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"time"
+)
+
+type EconomicsStore interface {
+	SaveEconomics(key PullRequestKeyV1, recordedAt time.Time, economics ReviewEconomicsV1) (string, error)
+	ListEconomics(key PullRequestKeyV1) ([]ReviewEconomicsV1, []CorruptRecord, error)
+}
+
+type FilesystemEconomicsStore struct {
+	dataDir string
+}
+
+func NewFilesystemEconomicsStore(dataDir string) *FilesystemEconomicsStore {
+	return &FilesystemEconomicsStore{dataDir: dataDir}
+}
+
+var _ EconomicsStore = (*FilesystemEconomicsStore)(nil)
+
+func (s *FilesystemEconomicsStore) SaveEconomics(key PullRequestKeyV1, recordedAt time.Time, economics ReviewEconomicsV1) (string, error) {
+	if err := economics.Validate(); err != nil {
+		return "", err
+	}
+	if recordedAt.IsZero() {
+		return "", fmt.Errorf("review economics %s: recorded_at is required", economics.RunID)
+	}
+	dir, err := economicsDir(s.dataDir, key)
+	if err != nil {
+		return "", err
+	}
+	name, err := recordFileName("review economics", economics.RunID, recordedAt)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, name)
+
+	data, err := json.MarshalIndent(economics, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal review economics %s: %w", economics.RunID, err)
+	}
+	if err := writeNewFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("save review economics %s: %w", economics.RunID, err)
+	}
+	return path, nil
+}
+
+func (s *FilesystemEconomicsStore) ListEconomics(key PullRequestKeyV1) ([]ReviewEconomicsV1, []CorruptRecord, error) {
+	dir, err := economicsDir(s.dataDir, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return listRecords(dir, decodeReviewEconomics)
+}

--- a/internal/store/economicsstore.go
+++ b/internal/store/economicsstore.go
@@ -48,7 +48,7 @@ func (s *FilesystemEconomicsStore) SaveEconomics(key PullRequestKeyV1, recordedA
 	if err != nil {
 		return "", fmt.Errorf("marshal review economics %s: %w", economics.RunID, err)
 	}
-	if err := writeNewFile(path, data, 0o644); err != nil {
+	if err := writeNewFile(path, data, 0o600); err != nil {
 		return "", fmt.Errorf("save review economics %s: %w", economics.RunID, err)
 	}
 	return path, nil

--- a/internal/store/economicsstore.go
+++ b/internal/store/economicsstore.go
@@ -7,9 +7,14 @@ import (
 	"time"
 )
 
+type EconomicsRecordV1 struct {
+	RecordedAt time.Time
+	Economics  ReviewEconomicsV1
+}
+
 type EconomicsStore interface {
 	SaveEconomics(key PullRequestKeyV1, recordedAt time.Time, economics ReviewEconomicsV1) (string, error)
-	ListEconomics(key PullRequestKeyV1) ([]ReviewEconomicsV1, []CorruptRecord, error)
+	ListEconomics(key PullRequestKeyV1) ([]EconomicsRecordV1, []CorruptRecord, error)
 }
 
 type FilesystemEconomicsStore struct {
@@ -49,10 +54,18 @@ func (s *FilesystemEconomicsStore) SaveEconomics(key PullRequestKeyV1, recordedA
 	return path, nil
 }
 
-func (s *FilesystemEconomicsStore) ListEconomics(key PullRequestKeyV1) ([]ReviewEconomicsV1, []CorruptRecord, error) {
+func (s *FilesystemEconomicsStore) ListEconomics(key PullRequestKeyV1) ([]EconomicsRecordV1, []CorruptRecord, error) {
 	dir, err := economicsDir(s.dataDir, key)
 	if err != nil {
 		return nil, nil, err
 	}
-	return listRecords(dir, decodeReviewEconomics)
+	timestamped, corrupt, err := listTimestampedRecords(dir, decodeReviewEconomics)
+	if err != nil {
+		return nil, nil, err
+	}
+	records := make([]EconomicsRecordV1, 0, len(timestamped))
+	for _, t := range timestamped {
+		records = append(records, EconomicsRecordV1{RecordedAt: t.recordedAt, Economics: t.record})
+	}
+	return records, corrupt, nil
 }

--- a/internal/store/economicsstore_test.go
+++ b/internal/store/economicsstore_test.go
@@ -111,6 +111,31 @@ func TestFilesystemEconomicsStore_RefusesDuplicateSave(t *testing.T) {
 	}
 }
 
+func TestFilesystemEconomicsStore_RefusesDuplicateRunIDWithDifferentTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEconomicsStore(dir)
+	key := testPullRequestKey()
+	economics := testReviewEconomics("run-dup")
+
+	if _, err := store.SaveEconomics(key, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), economics); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if _, err := store.SaveEconomics(key, time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC), economics); err == nil {
+		t.Fatal("expected an error re-saving economics for the same run id under a different timestamp")
+	}
+
+	records, corrupt, err := store.ListEconomics(key)
+	if err != nil {
+		t.Fatalf("list economics: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected exactly one stored economics record for the duplicated run id, got %d", len(records))
+	}
+}
+
 func TestFilesystemEconomicsStore_RejectsZeroRecordedAt(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFilesystemEconomicsStore(dir)

--- a/internal/store/economicsstore_test.go
+++ b/internal/store/economicsstore_test.go
@@ -1,0 +1,167 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testReviewEconomics(runID string) ReviewEconomicsV1 {
+	return ReviewEconomicsV1{
+		SchemaVersion:     CurrentSchemaVersion,
+		RunID:             runID,
+		ReviewerCallCount: 3,
+		ModelCallCount:    5,
+		Duration:          12 * time.Second,
+		ProviderUsage: []ProviderUsageRecordV1{
+			{
+				Provider: "anthropic",
+				Model:    "claude-opus",
+				Usage:    ProviderUsageV1{Known: true, InputTokens: 1000, OutputTokens: 200, TotalTokens: 1200, CostUSD: 0.42},
+			},
+			{
+				Provider: "codex",
+				Model:    "gpt",
+				Usage:    ProviderUsageV1{Known: false},
+			},
+		},
+	}
+}
+
+func TestFilesystemEconomicsStore_SaveAndList(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEconomicsStore(dir)
+	key := testPullRequestKey()
+
+	e1 := testReviewEconomics("run-1")
+	e2 := testReviewEconomics("run-2")
+
+	if _, err := store.SaveEconomics(key, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), e1); err != nil {
+		t.Fatalf("save e1: %v", err)
+	}
+	if _, err := store.SaveEconomics(key, time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC), e2); err != nil {
+		t.Fatalf("save e2: %v", err)
+	}
+
+	records, corrupt, err := store.ListEconomics(key)
+	if err != nil {
+		t.Fatalf("list economics: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(records) != 2 || records[0].RunID != "run-1" || records[1].RunID != "run-2" {
+		t.Fatalf("expected chronological run-1, run-2, got %+v", records)
+	}
+}
+
+func TestFilesystemEconomicsStore_PreservesUnknownUsageThroughRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEconomicsStore(dir)
+	key := testPullRequestKey()
+
+	economics := testReviewEconomics("run-unknown-usage")
+	if _, err := store.SaveEconomics(key, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), economics); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	records, _, err := store.ListEconomics(key)
+	if err != nil {
+		t.Fatalf("list economics: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	loaded := records[0]
+	if len(loaded.ProviderUsage) != 2 {
+		t.Fatalf("expected 2 provider usage records, got %d", len(loaded.ProviderUsage))
+	}
+	unknown := loaded.ProviderUsage[1]
+	if unknown.Usage.Known {
+		t.Fatalf("expected codex usage to remain marked unknown after round trip, got %+v", unknown.Usage)
+	}
+	if unknown.Usage.InputTokens != 0 || unknown.Usage.CostUSD != 0 {
+		t.Fatalf("unknown usage must not carry nonzero measurements, got %+v", unknown.Usage)
+	}
+	known := loaded.ProviderUsage[0]
+	if !known.Usage.Known || known.Usage.InputTokens != 1000 {
+		t.Fatalf("expected anthropic usage to remain known with its measurements intact, got %+v", known.Usage)
+	}
+}
+
+func TestFilesystemEconomicsStore_RefusesDuplicateSave(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEconomicsStore(dir)
+	key := testPullRequestKey()
+	economics := testReviewEconomics("run-dup")
+	recordedAt := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	if _, err := store.SaveEconomics(key, recordedAt, economics); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if _, err := store.SaveEconomics(key, recordedAt, economics); err == nil {
+		t.Fatal("expected an error re-saving the same run id/timestamp")
+	}
+}
+
+func TestFilesystemEconomicsStore_RejectsZeroRecordedAt(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEconomicsStore(dir)
+	key := testPullRequestKey()
+
+	if _, err := store.SaveEconomics(key, time.Time{}, testReviewEconomics("run-no-time")); err == nil {
+		t.Fatal("expected an error for a zero recorded_at")
+	}
+}
+
+func TestFilesystemEconomicsStore_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+	economics := testReviewEconomics("run-restart")
+
+	firstProcessStore := NewFilesystemEconomicsStore(dir)
+	if _, err := firstProcessStore.SaveEconomics(key, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), economics); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	secondProcessStore := NewFilesystemEconomicsStore(dir)
+	records, _, err := secondProcessStore.ListEconomics(key)
+	if err != nil {
+		t.Fatalf("list after restart: %v", err)
+	}
+	if len(records) != 1 || records[0].RunID != "run-restart" {
+		t.Fatalf("restart did not preserve economics history: got %+v", records)
+	}
+}
+
+func TestFilesystemEconomicsStore_IsolatesCorruptRecords(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEconomicsStore(dir)
+	key := testPullRequestKey()
+
+	good := testReviewEconomics("run-good")
+	if _, err := store.SaveEconomics(key, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), good); err != nil {
+		t.Fatalf("save good record: %v", err)
+	}
+
+	dirPath, err := economicsDir(dir, key)
+	if err != nil {
+		t.Fatalf("economicsDir: %v", err)
+	}
+	corruptPath := filepath.Join(dirPath, "20260722T130000.000000000Z-run-bad.json")
+	if err := os.WriteFile(corruptPath, []byte(`not json at all`), 0o644); err != nil {
+		t.Fatalf("seed corrupt record: %v", err)
+	}
+
+	records, corrupt, err := store.ListEconomics(key)
+	if err != nil {
+		t.Fatalf("list economics: %v", err)
+	}
+	if len(records) != 1 || records[0].RunID != "run-good" {
+		t.Fatalf("expected the good record to remain readable, got %+v", records)
+	}
+	if len(corrupt) != 1 || corrupt[0].Path != corruptPath {
+		t.Fatalf("expected exactly one corrupt record reported for %s, got %+v", corruptPath, corrupt)
+	}
+}

--- a/internal/store/economicsstore_test.go
+++ b/internal/store/economicsstore_test.go
@@ -51,8 +51,14 @@ func TestFilesystemEconomicsStore_SaveAndList(t *testing.T) {
 	if len(corrupt) != 0 {
 		t.Fatalf("expected no corrupt records, got %v", corrupt)
 	}
-	if len(records) != 2 || records[0].RunID != "run-1" || records[1].RunID != "run-2" {
+	if len(records) != 2 || records[0].Economics.RunID != "run-1" || records[1].Economics.RunID != "run-2" {
 		t.Fatalf("expected chronological run-1, run-2, got %+v", records)
+	}
+	if !records[0].RecordedAt.Equal(time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected record 1 recorded_at to round-trip, got %v", records[0].RecordedAt)
+	}
+	if !records[1].RecordedAt.Equal(time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected record 2 recorded_at to round-trip, got %v", records[1].RecordedAt)
 	}
 }
 
@@ -73,7 +79,7 @@ func TestFilesystemEconomicsStore_PreservesUnknownUsageThroughRoundTrip(t *testi
 	if len(records) != 1 {
 		t.Fatalf("expected 1 record, got %d", len(records))
 	}
-	loaded := records[0]
+	loaded := records[0].Economics
 	if len(loaded.ProviderUsage) != 2 {
 		t.Fatalf("expected 2 provider usage records, got %d", len(loaded.ProviderUsage))
 	}
@@ -130,7 +136,7 @@ func TestFilesystemEconomicsStore_SurvivesRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list after restart: %v", err)
 	}
-	if len(records) != 1 || records[0].RunID != "run-restart" {
+	if len(records) != 1 || records[0].Economics.RunID != "run-restart" {
 		t.Fatalf("restart did not preserve economics history: got %+v", records)
 	}
 }
@@ -158,10 +164,57 @@ func TestFilesystemEconomicsStore_IsolatesCorruptRecords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list economics: %v", err)
 	}
-	if len(records) != 1 || records[0].RunID != "run-good" {
+	if len(records) != 1 || records[0].Economics.RunID != "run-good" {
 		t.Fatalf("expected the good record to remain readable, got %+v", records)
 	}
 	if len(corrupt) != 1 || corrupt[0].Path != corruptPath {
 		t.Fatalf("expected exactly one corrupt record reported for %s, got %+v", corruptPath, corrupt)
 	}
+}
+
+func TestFilesystemEconomicsStore_IsolatesRecordsWithUnparsableTimestampFilenames(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEconomicsStore(dir)
+	key := testPullRequestKey()
+
+	good := testReviewEconomics("run-good")
+	if _, err := store.SaveEconomics(key, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), good); err != nil {
+		t.Fatalf("save good record: %v", err)
+	}
+
+	dirPath, err := economicsDir(dir, key)
+	if err != nil {
+		t.Fatalf("economicsDir: %v", err)
+	}
+	corruptPath := filepath.Join(dirPath, "not-a-timestamp-run-bad.json")
+	data, err := os.ReadFile(filepath.Join(dirPath, mustSingleFileName(t, dirPath)))
+	if err != nil {
+		t.Fatalf("read seeded good record: %v", err)
+	}
+	if err := os.WriteFile(corruptPath, data, 0o644); err != nil {
+		t.Fatalf("seed record with unparsable timestamp filename: %v", err)
+	}
+
+	records, corrupt, err := store.ListEconomics(key)
+	if err != nil {
+		t.Fatalf("list economics: %v", err)
+	}
+	if len(records) != 1 || records[0].Economics.RunID != "run-good" {
+		t.Fatalf("expected the good record to remain readable, got %+v", records)
+	}
+	if len(corrupt) != 1 || corrupt[0].Path != corruptPath {
+		t.Fatalf("expected exactly one corrupt record reported for %s, got %+v", corruptPath, corrupt)
+	}
+}
+
+func mustSingleFileName(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one file in %s, got %d", dir, len(entries))
+	}
+	return entries[0].Name()
 }

--- a/internal/store/event.go
+++ b/internal/store/event.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// ReviewEventTypeV1 enumerates the append-only pull-request history event
+// vocabulary from epic #191's Core Domain Model / ReviewEvent section.
+type ReviewEventTypeV1 string
+
+const (
+	EventTypePRDiscovered ReviewEventTypeV1 = "pr_discovered"
+	EventTypePRRefreshed  ReviewEventTypeV1 = "pr_refreshed"
+
+	EventTypeReviewQueued      ReviewEventTypeV1 = "review_queued"
+	EventTypeReviewStarted     ReviewEventTypeV1 = "review_started"
+	EventTypeReviewCompleted   ReviewEventTypeV1 = "review_completed"
+	EventTypeReviewFailed      ReviewEventTypeV1 = "review_failed"
+	EventTypeReviewInterrupted ReviewEventTypeV1 = "review_interrupted"
+	EventTypeReviewSuperseded  ReviewEventTypeV1 = "review_superseded"
+	EventTypeReviewStale       ReviewEventTypeV1 = "review_stale"
+
+	EventTypeFindingSelected  ReviewEventTypeV1 = "finding_selected"
+	EventTypeFindingDismissed ReviewEventTypeV1 = "finding_dismissed"
+	EventTypeFindingPosted    ReviewEventTypeV1 = "finding_posted"
+
+	EventTypeActionCommentPosted        ReviewEventTypeV1 = "action_comment_posted"
+	EventTypeActionRequestChangesPosted ReviewEventTypeV1 = "action_request_changes_posted"
+	EventTypeActionApprovalPosted       ReviewEventTypeV1 = "action_approval_posted"
+
+	EventTypePRClosed ReviewEventTypeV1 = "pr_closed"
+	EventTypePRMerged ReviewEventTypeV1 = "pr_merged"
+
+	EventTypeUserDeferred ReviewEventTypeV1 = "user_deferred"
+	EventTypeUserSnoozed  ReviewEventTypeV1 = "user_snoozed"
+	EventTypeUserRetried  ReviewEventTypeV1 = "user_retried"
+	EventTypeUserResolved ReviewEventTypeV1 = "user_resolved"
+)
+
+func (t ReviewEventTypeV1) Validate() error {
+	switch t {
+	case EventTypePRDiscovered, EventTypePRRefreshed,
+		EventTypeReviewQueued, EventTypeReviewStarted, EventTypeReviewCompleted,
+		EventTypeReviewFailed, EventTypeReviewInterrupted, EventTypeReviewSuperseded, EventTypeReviewStale,
+		EventTypeFindingSelected, EventTypeFindingDismissed, EventTypeFindingPosted,
+		EventTypeActionCommentPosted, EventTypeActionRequestChangesPosted, EventTypeActionApprovalPosted,
+		EventTypePRClosed, EventTypePRMerged,
+		EventTypeUserDeferred, EventTypeUserSnoozed, EventTypeUserRetried, EventTypeUserResolved:
+		return nil
+	default:
+		return fmt.Errorf("unknown review event type %q", t)
+	}
+}
+
+func (t ReviewEventTypeV1) requiresRunID() bool {
+	switch t {
+	case EventTypeReviewQueued, EventTypeReviewStarted, EventTypeReviewCompleted,
+		EventTypeReviewFailed, EventTypeReviewInterrupted, EventTypeReviewSuperseded, EventTypeReviewStale:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t ReviewEventTypeV1) requiresFindingID() bool {
+	switch t {
+	case EventTypeFindingSelected, EventTypeFindingDismissed, EventTypeFindingPosted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t ReviewEventTypeV1) requiresActor() bool {
+	switch t {
+	case EventTypeActionCommentPosted, EventTypeActionRequestChangesPosted, EventTypeActionApprovalPosted,
+		EventTypeUserDeferred, EventTypeUserSnoozed, EventTypeUserRetried, EventTypeUserResolved:
+		return true
+	default:
+		return false
+	}
+}
+
+// ReviewEventV1 is one immutable, append-only entry in a pull request's local
+// history. Fields are a flat superset across the event vocabulary; only the
+// fields relevant to a given Type are required. Events are never rewritten in
+// place: a correction or later observation is recorded as an additional
+// event, preserving the original.
+type ReviewEventV1 struct {
+	SchemaVersion     int               `json:"schema_version"`
+	ID                string            `json:"id"`
+	PullRequest       PullRequestKeyV1  `json:"pull_request"`
+	Type              ReviewEventTypeV1 `json:"type"`
+	OccurredAt        time.Time         `json:"occurred_at"`
+	RunID             string            `json:"run_id,omitempty"`
+	HeadObjectID      string            `json:"head_object_id,omitempty"`
+	PriorHeadObjectID string            `json:"prior_head_object_id,omitempty"`
+	FindingID         string            `json:"finding_id,omitempty"`
+	Actor             string            `json:"actor,omitempty"`
+	Reason            string            `json:"reason,omitempty"`
+	Message           string            `json:"message,omitempty"`
+}
+
+func (e ReviewEventV1) Validate() error {
+	if err := validateSchemaVersion("review event", e.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("review event id", e.ID); err != nil {
+		return err
+	}
+	if err := e.PullRequest.Validate(); err != nil {
+		return err
+	}
+	if err := e.Type.Validate(); err != nil {
+		return err
+	}
+	if e.OccurredAt.IsZero() {
+		return fmt.Errorf("review event occurred_at is required")
+	}
+	if e.Type.requiresRunID() {
+		if err := validateNonEmpty(fmt.Sprintf("review event %q run_id", e.Type), e.RunID); err != nil {
+			return err
+		}
+	}
+	if e.Type.requiresFindingID() {
+		if err := validateNonEmpty(fmt.Sprintf("review event %q finding_id", e.Type), e.FindingID); err != nil {
+			return err
+		}
+	}
+	if e.Type.requiresActor() {
+		if err := validateNonEmpty(fmt.Sprintf("review event %q actor", e.Type), e.Actor); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/store/event.go
+++ b/internal/store/event.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-// ReviewEventTypeV1 enumerates the append-only pull-request history event
-// vocabulary from epic #191's Core Domain Model / ReviewEvent section.
 type ReviewEventTypeV1 string
 
 const (
@@ -82,11 +80,6 @@ func (t ReviewEventTypeV1) requiresActor() bool {
 	}
 }
 
-// ReviewEventV1 is one immutable, append-only entry in a pull request's local
-// history. Fields are a flat superset across the event vocabulary; only the
-// fields relevant to a given Type are required. Events are never rewritten in
-// place: a correction or later observation is recorded as an additional
-// event, preserving the original.
 type ReviewEventV1 struct {
 	SchemaVersion     int               `json:"schema_version"`
 	ID                string            `json:"id"`

--- a/internal/store/event_test.go
+++ b/internal/store/event_test.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func testPullRequestKey() PullRequestKeyV1 {
+	return PullRequestKeyV1{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 196}
+}
+
+func TestReviewEventV1_AllVocabularyTypesRoundTripAndValidate(t *testing.T) {
+	occurredAt := time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		event ReviewEventV1
+	}{
+		{name: "pr discovered", event: ReviewEventV1{Type: EventTypePRDiscovered}},
+		{name: "pr refreshed", event: ReviewEventV1{Type: EventTypePRRefreshed}},
+		{name: "review queued", event: ReviewEventV1{Type: EventTypeReviewQueued, RunID: "run-1"}},
+		{name: "review started", event: ReviewEventV1{Type: EventTypeReviewStarted, RunID: "run-1"}},
+		{name: "review completed", event: ReviewEventV1{Type: EventTypeReviewCompleted, RunID: "run-1"}},
+		{name: "review failed", event: ReviewEventV1{Type: EventTypeReviewFailed, RunID: "run-1", Reason: "all reviewers failed"}},
+		{name: "review interrupted", event: ReviewEventV1{Type: EventTypeReviewInterrupted, RunID: "run-1"}},
+		{name: "review superseded", event: ReviewEventV1{Type: EventTypeReviewSuperseded, RunID: "run-1"}},
+		{name: "review stale", event: ReviewEventV1{Type: EventTypeReviewStale, RunID: "run-1", HeadObjectID: "new-head", PriorHeadObjectID: "old-head"}},
+		{name: "finding selected", event: ReviewEventV1{Type: EventTypeFindingSelected, FindingID: "finding-1"}},
+		{name: "finding dismissed", event: ReviewEventV1{Type: EventTypeFindingDismissed, FindingID: "finding-1"}},
+		{name: "finding posted", event: ReviewEventV1{Type: EventTypeFindingPosted, FindingID: "finding-1"}},
+		{name: "action comment posted", event: ReviewEventV1{Type: EventTypeActionCommentPosted, Actor: "richhaase"}},
+		{name: "action request changes posted", event: ReviewEventV1{Type: EventTypeActionRequestChangesPosted, Actor: "richhaase"}},
+		{name: "action approval posted", event: ReviewEventV1{Type: EventTypeActionApprovalPosted, Actor: "richhaase"}},
+		{name: "pr closed", event: ReviewEventV1{Type: EventTypePRClosed}},
+		{name: "pr merged", event: ReviewEventV1{Type: EventTypePRMerged}},
+		{name: "user deferred", event: ReviewEventV1{Type: EventTypeUserDeferred, Actor: "richhaase"}},
+		{name: "user snoozed", event: ReviewEventV1{Type: EventTypeUserSnoozed, Actor: "richhaase"}},
+		{name: "user retried", event: ReviewEventV1{Type: EventTypeUserRetried, Actor: "richhaase"}},
+		{name: "user resolved", event: ReviewEventV1{Type: EventTypeUserResolved, Actor: "richhaase"}},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := tt.event
+			event.SchemaVersion = CurrentSchemaVersion
+			event.ID = "event-" + string(rune('a'+i))
+			event.PullRequest = testPullRequestKey()
+			event.OccurredAt = occurredAt
+
+			if err := event.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+
+			data, err := json.Marshal(event)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded ReviewEventV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if decoded != event {
+				t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, event)
+			}
+		})
+	}
+}
+
+func TestReviewEventV1_Validate_RequiredFieldsPerType(t *testing.T) {
+	base := func() ReviewEventV1 {
+		return ReviewEventV1{
+			SchemaVersion: CurrentSchemaVersion,
+			ID:            "event-1",
+			PullRequest:   testPullRequestKey(),
+			OccurredAt:    time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC),
+		}
+	}
+
+	tests := []struct {
+		name  string
+		event ReviewEventV1
+	}{
+		{name: "review completed missing run id", event: func() ReviewEventV1 { e := base(); e.Type = EventTypeReviewCompleted; return e }()},
+		{name: "finding selected missing finding id", event: func() ReviewEventV1 { e := base(); e.Type = EventTypeFindingSelected; return e }()},
+		{name: "action approval posted missing actor", event: func() ReviewEventV1 { e := base(); e.Type = EventTypeActionApprovalPosted; return e }()},
+		{name: "user resolved missing actor", event: func() ReviewEventV1 { e := base(); e.Type = EventTypeUserResolved; return e }()},
+		{name: "unsupported schema version", event: func() ReviewEventV1 { e := base(); e.Type = EventTypePRDiscovered; e.SchemaVersion = 99; return e }()},
+		{name: "unknown event type", event: func() ReviewEventV1 { e := base(); e.Type = "something_else"; return e }()},
+		{name: "zero occurred at", event: func() ReviewEventV1 {
+			e := base()
+			e.Type = EventTypePRDiscovered
+			e.OccurredAt = time.Time{}
+			return e
+		}()},
+		{name: "empty id", event: func() ReviewEventV1 { e := base(); e.Type = EventTypePRDiscovered; e.ID = ""; return e }()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.event.Validate(); err == nil {
+				t.Fatalf("expected a validation error for %+v", tt.event)
+			}
+		})
+	}
+}

--- a/internal/store/eventstore.go
+++ b/internal/store/eventstore.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+type EventStore interface {
+	AppendEvent(event ReviewEventV1) (string, error)
+	ListEvents(key PullRequestKeyV1) ([]ReviewEventV1, []CorruptRecord, error)
+}
+
+type FilesystemEventStore struct {
+	dataDir string
+}
+
+func NewFilesystemEventStore(dataDir string) *FilesystemEventStore {
+	return &FilesystemEventStore{dataDir: dataDir}
+}
+
+var _ EventStore = (*FilesystemEventStore)(nil)
+
+func (s *FilesystemEventStore) AppendEvent(event ReviewEventV1) (string, error) {
+	if err := event.Validate(); err != nil {
+		return "", err
+	}
+	dir, err := eventsDir(s.dataDir, event.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	name, err := recordFileName("review event", event.ID, event.OccurredAt)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, name)
+
+	data, err := json.MarshalIndent(event, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal review event %s: %w", event.ID, err)
+	}
+	if err := writeNewFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("append review event %s: %w", event.ID, err)
+	}
+	return path, nil
+}
+
+func (s *FilesystemEventStore) ListEvents(key PullRequestKeyV1) ([]ReviewEventV1, []CorruptRecord, error) {
+	dir, err := eventsDir(s.dataDir, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return listRecords(dir, decodeReviewEvent)
+}

--- a/internal/store/eventstore.go
+++ b/internal/store/eventstore.go
@@ -39,7 +39,7 @@ func (s *FilesystemEventStore) AppendEvent(event ReviewEventV1) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("marshal review event %s: %w", event.ID, err)
 	}
-	if err := writeNewFile(path, data, 0o644); err != nil {
+	if err := writeNewFile(path, data, 0o600); err != nil {
 		return "", fmt.Errorf("append review event %s: %w", event.ID, err)
 	}
 	return path, nil

--- a/internal/store/eventstore.go
+++ b/internal/store/eventstore.go
@@ -25,6 +25,15 @@ func (s *FilesystemEventStore) AppendEvent(event ReviewEventV1) (string, error) 
 	if err := event.Validate(); err != nil {
 		return "", err
 	}
+	existing, _, err := s.ListEvents(event.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range existing {
+		if e.ID == event.ID {
+			return "", fmt.Errorf("review event %s already exists for %s", event.ID, event.PullRequest.String())
+		}
+	}
 	dir, err := eventsDir(s.dataDir, event.PullRequest)
 	if err != nil {
 		return "", err

--- a/internal/store/eventstore_test.go
+++ b/internal/store/eventstore_test.go
@@ -1,0 +1,121 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testReviewEvent(id string, occurredAt time.Time) ReviewEventV1 {
+	return ReviewEventV1{
+		SchemaVersion: CurrentSchemaVersion,
+		ID:            id,
+		PullRequest:   testPullRequestKey(),
+		Type:          EventTypePRDiscovered,
+		OccurredAt:    occurredAt,
+	}
+}
+
+func TestFilesystemEventStore_AppendAndList(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEventStore(dir)
+	key := testPullRequestKey()
+
+	e1 := testReviewEvent("event-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	e2 := testReviewEvent("event-2", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+
+	if _, err := store.AppendEvent(e1); err != nil {
+		t.Fatalf("append e1: %v", err)
+	}
+	if _, err := store.AppendEvent(e2); err != nil {
+		t.Fatalf("append e2: %v", err)
+	}
+
+	events, corrupt, err := store.ListEvents(key)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt events, got %v", corrupt)
+	}
+	if len(events) != 2 || events[0].ID != "event-1" || events[1].ID != "event-2" {
+		t.Fatalf("expected chronological event-1, event-2, got %+v", events)
+	}
+}
+
+func TestFilesystemEventStore_RejectsInvalidEvent(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEventStore(dir)
+
+	invalid := testReviewEvent("event-invalid", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	invalid.Type = EventTypeReviewCompleted
+
+	if _, err := store.AppendEvent(invalid); err == nil {
+		t.Fatal("expected an error for a review_completed event with no run_id")
+	}
+}
+
+func TestFilesystemEventStore_RefusesDuplicateAppend(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEventStore(dir)
+	event := testReviewEvent("event-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	if _, err := store.AppendEvent(event); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if _, err := store.AppendEvent(event); err == nil {
+		t.Fatal("expected an error re-appending the same event id/timestamp")
+	}
+}
+
+func TestFilesystemEventStore_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+	event := testReviewEvent("event-restart", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	firstProcessStore := NewFilesystemEventStore(dir)
+	if _, err := firstProcessStore.AppendEvent(event); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	secondProcessStore := NewFilesystemEventStore(dir)
+	events, _, err := secondProcessStore.ListEvents(key)
+	if err != nil {
+		t.Fatalf("list after restart: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != "event-restart" {
+		t.Fatalf("restart did not preserve event history: got %+v", events)
+	}
+}
+
+func TestFilesystemEventStore_IsolatesCorruptRecords(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEventStore(dir)
+	key := testPullRequestKey()
+
+	good := testReviewEvent("event-good", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.AppendEvent(good); err != nil {
+		t.Fatalf("append good event: %v", err)
+	}
+
+	eventsDirPath, err := eventsDir(dir, key)
+	if err != nil {
+		t.Fatalf("eventsDir: %v", err)
+	}
+	corruptPath := filepath.Join(eventsDirPath, "20260722T130000.000000000Z-event-bad.json")
+	if err := os.WriteFile(corruptPath, []byte(`not json at all`), 0o644); err != nil {
+		t.Fatalf("seed corrupt record: %v", err)
+	}
+
+	events, corrupt, err := store.ListEvents(key)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != "event-good" {
+		t.Fatalf("expected the good event to remain readable, got %+v", events)
+	}
+	if len(corrupt) != 1 || corrupt[0].Path != corruptPath {
+		t.Fatalf("expected exactly one corrupt record reported for %s, got %+v", corruptPath, corrupt)
+	}
+}

--- a/internal/store/eventstore_test.go
+++ b/internal/store/eventstore_test.go
@@ -69,6 +69,33 @@ func TestFilesystemEventStore_RefusesDuplicateAppend(t *testing.T) {
 	}
 }
 
+func TestFilesystemEventStore_RefusesDuplicateIDWithDifferentTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemEventStore(dir)
+	key := testPullRequestKey()
+
+	first := testReviewEvent("event-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.AppendEvent(first); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+
+	second := testReviewEvent("event-dup", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+	if _, err := store.AppendEvent(second); err == nil {
+		t.Fatal("expected an error re-appending the same event id under a different timestamp")
+	}
+
+	events, corrupt, err := store.ListEvents(key)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt events, got %v", corrupt)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one stored event for the duplicated id, got %d", len(events))
+	}
+}
+
 func TestFilesystemEventStore_SurvivesRestart(t *testing.T) {
 	dir := t.TempDir()
 	key := testPullRequestKey()

--- a/internal/store/finding.go
+++ b/internal/store/finding.go
@@ -1,0 +1,299 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type FindingV1 struct {
+	Text       string `json:"text"`
+	ReviewerID int    `json:"reviewer_id"`
+}
+
+func ToFindingSchema(f domain.Finding) FindingV1 {
+	return FindingV1{Text: f.Text, ReviewerID: f.ReviewerID}
+}
+
+func (f FindingV1) ToDomain() domain.Finding {
+	return domain.Finding{Text: f.Text, ReviewerID: f.ReviewerID}
+}
+
+func toFindingSchemaSlice(findings []domain.Finding) []FindingV1 {
+	out := make([]FindingV1, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, ToFindingSchema(f))
+	}
+	return out
+}
+
+func toFindingDomainSlice(findings []FindingV1) []domain.Finding {
+	out := make([]domain.Finding, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.ToDomain())
+	}
+	return out
+}
+
+type AggregatedFindingV1 struct {
+	Text      string `json:"text"`
+	Reviewers []int  `json:"reviewers"`
+}
+
+func ToAggregatedFindingSchema(f domain.AggregatedFinding) AggregatedFindingV1 {
+	return AggregatedFindingV1{Text: f.Text, Reviewers: append([]int(nil), f.Reviewers...)}
+}
+
+func (f AggregatedFindingV1) ToDomain() domain.AggregatedFinding {
+	return domain.AggregatedFinding{Text: f.Text, Reviewers: append([]int(nil), f.Reviewers...)}
+}
+
+func toAggregatedFindingSchemaSlice(findings []domain.AggregatedFinding) []AggregatedFindingV1 {
+	out := make([]AggregatedFindingV1, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, ToAggregatedFindingSchema(f))
+	}
+	return out
+}
+
+func toAggregatedFindingDomainSlice(findings []AggregatedFindingV1) []domain.AggregatedFinding {
+	out := make([]domain.AggregatedFinding, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.ToDomain())
+	}
+	return out
+}
+
+type FindingGroupV1 struct {
+	Title         string   `json:"title"`
+	Summary       string   `json:"summary"`
+	Messages      []string `json:"messages"`
+	ReviewerCount int      `json:"reviewer_count"`
+	Sources       []int    `json:"sources"`
+}
+
+func ToFindingGroupSchema(g domain.FindingGroup) FindingGroupV1 {
+	return FindingGroupV1{
+		Title:         g.Title,
+		Summary:       g.Summary,
+		Messages:      append([]string(nil), g.Messages...),
+		ReviewerCount: g.ReviewerCount,
+		Sources:       append([]int(nil), g.Sources...),
+	}
+}
+
+func (g FindingGroupV1) ToDomain() domain.FindingGroup {
+	return domain.FindingGroup{
+		Title:         g.Title,
+		Summary:       g.Summary,
+		Messages:      append([]string(nil), g.Messages...),
+		ReviewerCount: g.ReviewerCount,
+		Sources:       append([]int(nil), g.Sources...),
+	}
+}
+
+func toFindingGroupSchemaSlice(groups []domain.FindingGroup) []FindingGroupV1 {
+	out := make([]FindingGroupV1, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, ToFindingGroupSchema(g))
+	}
+	return out
+}
+
+func toFindingGroupDomainSlice(groups []FindingGroupV1) []domain.FindingGroup {
+	out := make([]domain.FindingGroup, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, g.ToDomain())
+	}
+	return out
+}
+
+type GroupedFindingsV1 struct {
+	Findings []FindingGroupV1 `json:"findings"`
+	Info     []FindingGroupV1 `json:"info"`
+}
+
+func ToGroupedFindingsSchema(g domain.GroupedFindings) GroupedFindingsV1 {
+	return GroupedFindingsV1{
+		Findings: toFindingGroupSchemaSlice(g.Findings),
+		Info:     toFindingGroupSchemaSlice(g.Info),
+	}
+}
+
+func (g GroupedFindingsV1) ToDomain() domain.GroupedFindings {
+	return domain.GroupedFindings{
+		Findings: toFindingGroupDomainSlice(g.Findings),
+		Info:     toFindingGroupDomainSlice(g.Info),
+	}
+}
+
+type DispositionKindV1 string
+
+const (
+	DispositionKindUnmapped        DispositionKindV1 = "unmapped"
+	DispositionKindInfo            DispositionKindV1 = "info"
+	DispositionKindFilteredFP      DispositionKindV1 = "filtered_false_positive"
+	DispositionKindFilteredExclude DispositionKindV1 = "filtered_exclude"
+	DispositionKindSurvived        DispositionKindV1 = "survived"
+)
+
+func toDispositionKindSchema(kind domain.DispositionKind) (DispositionKindV1, error) {
+	switch kind {
+	case domain.DispositionUnmapped:
+		return DispositionKindUnmapped, nil
+	case domain.DispositionInfo:
+		return DispositionKindInfo, nil
+	case domain.DispositionFilteredFP:
+		return DispositionKindFilteredFP, nil
+	case domain.DispositionFilteredExclude:
+		return DispositionKindFilteredExclude, nil
+	case domain.DispositionSurvived:
+		return DispositionKindSurvived, nil
+	default:
+		return "", fmt.Errorf("unknown disposition kind %d", kind)
+	}
+}
+
+func (k DispositionKindV1) ToDomain() (domain.DispositionKind, error) {
+	switch k {
+	case DispositionKindUnmapped:
+		return domain.DispositionUnmapped, nil
+	case DispositionKindInfo:
+		return domain.DispositionInfo, nil
+	case DispositionKindFilteredFP:
+		return domain.DispositionFilteredFP, nil
+	case DispositionKindFilteredExclude:
+		return domain.DispositionFilteredExclude, nil
+	case DispositionKindSurvived:
+		return domain.DispositionSurvived, nil
+	default:
+		return domain.DispositionUnmapped, fmt.Errorf("unknown stored disposition kind %q", k)
+	}
+}
+
+type DispositionV1 struct {
+	Kind       DispositionKindV1 `json:"kind"`
+	FPScore    int               `json:"fp_score"`
+	Reasoning  string            `json:"reasoning"`
+	GroupTitle string            `json:"group_title"`
+}
+
+func ToDispositionSchema(d domain.Disposition) (DispositionV1, error) {
+	kind, err := toDispositionKindSchema(d.Kind)
+	if err != nil {
+		return DispositionV1{}, err
+	}
+	return DispositionV1{
+		Kind:       kind,
+		FPScore:    d.FPScore,
+		Reasoning:  d.Reasoning,
+		GroupTitle: d.GroupTitle,
+	}, nil
+}
+
+func (d DispositionV1) ToDomain() (domain.Disposition, error) {
+	kind, err := d.Kind.ToDomain()
+	if err != nil {
+		return domain.Disposition{}, err
+	}
+	return domain.Disposition{
+		Kind:       kind,
+		FPScore:    d.FPScore,
+		Reasoning:  d.Reasoning,
+		GroupTitle: d.GroupTitle,
+	}, nil
+}
+
+type ReviewFindingKindV1 string
+
+const (
+	ReviewFindingKindActionable    ReviewFindingKindV1 = "actionable"
+	ReviewFindingKindInformational ReviewFindingKindV1 = "informational"
+)
+
+func toReviewFindingKindSchema(kind domain.ReviewFindingKind) (ReviewFindingKindV1, error) {
+	switch kind {
+	case domain.ReviewFindingActionable:
+		return ReviewFindingKindActionable, nil
+	case domain.ReviewFindingInformational:
+		return ReviewFindingKindInformational, nil
+	default:
+		return "", fmt.Errorf("unknown review finding kind %q", kind)
+	}
+}
+
+func (k ReviewFindingKindV1) ToDomain() (domain.ReviewFindingKind, error) {
+	switch k {
+	case ReviewFindingKindActionable:
+		return domain.ReviewFindingActionable, nil
+	case ReviewFindingKindInformational:
+		return domain.ReviewFindingInformational, nil
+	default:
+		return "", fmt.Errorf("unknown stored review finding kind %q", k)
+	}
+}
+
+type ReviewFindingV1 struct {
+	ID          string              `json:"id"`
+	Kind        ReviewFindingKindV1 `json:"kind"`
+	Group       FindingGroupV1      `json:"group"`
+	Disposition DispositionV1       `json:"disposition"`
+}
+
+func ToReviewFindingSchema(f domain.ReviewFinding) (ReviewFindingV1, error) {
+	kind, err := toReviewFindingKindSchema(f.Kind)
+	if err != nil {
+		return ReviewFindingV1{}, fmt.Errorf("finding %s: %w", f.ID, err)
+	}
+	disposition, err := ToDispositionSchema(f.Disposition)
+	if err != nil {
+		return ReviewFindingV1{}, fmt.Errorf("finding %s: %w", f.ID, err)
+	}
+	return ReviewFindingV1{
+		ID:          f.ID,
+		Kind:        kind,
+		Group:       ToFindingGroupSchema(f.Group),
+		Disposition: disposition,
+	}, nil
+}
+
+func (f ReviewFindingV1) ToDomain() (domain.ReviewFinding, error) {
+	kind, err := f.Kind.ToDomain()
+	if err != nil {
+		return domain.ReviewFinding{}, fmt.Errorf("finding %s: %w", f.ID, err)
+	}
+	disposition, err := f.Disposition.ToDomain()
+	if err != nil {
+		return domain.ReviewFinding{}, fmt.Errorf("finding %s: %w", f.ID, err)
+	}
+	return domain.ReviewFinding{
+		ID:          f.ID,
+		Kind:        kind,
+		Group:       f.Group.ToDomain(),
+		Disposition: disposition,
+	}, nil
+}
+
+func toReviewFindingSchemaSlice(findings []domain.ReviewFinding) ([]ReviewFindingV1, error) {
+	out := make([]ReviewFindingV1, 0, len(findings))
+	for _, f := range findings {
+		schema, err := ToReviewFindingSchema(f)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, schema)
+	}
+	return out, nil
+}
+
+func toReviewFindingDomainSlice(findings []ReviewFindingV1) ([]domain.ReviewFinding, error) {
+	out := make([]domain.ReviewFinding, 0, len(findings))
+	for _, f := range findings {
+		d, err := f.ToDomain()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}

--- a/internal/store/finding_test.go
+++ b/internal/store/finding_test.go
@@ -1,0 +1,162 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+func TestFindingV1_RoundTrip(t *testing.T) {
+	f := domain.Finding{Text: "possible nil deref", ReviewerID: 2}
+	schema := ToFindingSchema(f)
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded FindingV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := decoded.ToDomain(); got != f {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, f)
+	}
+}
+
+func TestAggregatedFindingV1_RoundTrip(t *testing.T) {
+	f := domain.AggregatedFinding{Text: "possible nil deref", Reviewers: []int{0, 2, 3}}
+	schema := ToAggregatedFindingSchema(f)
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded AggregatedFindingV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := decoded.ToDomain()
+	if got.Text != f.Text || len(got.Reviewers) != len(f.Reviewers) {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, f)
+	}
+	for i := range f.Reviewers {
+		if got.Reviewers[i] != f.Reviewers[i] {
+			t.Fatalf("reviewers[%d]: got %d, want %d", i, got.Reviewers[i], f.Reviewers[i])
+		}
+	}
+}
+
+func TestFindingGroupV1_RoundTrip(t *testing.T) {
+	g := domain.FindingGroup{
+		Title:         "Nil pointer dereference",
+		Summary:       "Two reviewers flagged a possible nil deref",
+		Messages:      []string{"reviewer 1 said X", "reviewer 3 said Y"},
+		ReviewerCount: 2,
+		Sources:       []int{1, 3},
+	}
+	schema := ToFindingGroupSchema(g)
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded FindingGroupV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := decoded.ToDomain()
+	if got.Title != g.Title || got.Summary != g.Summary || got.ReviewerCount != g.ReviewerCount {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, g)
+	}
+}
+
+func TestDispositionV1_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		d    domain.Disposition
+	}{
+		{name: "unmapped", d: domain.Disposition{Kind: domain.DispositionUnmapped}},
+		{name: "info", d: domain.Disposition{Kind: domain.DispositionInfo, GroupTitle: "note"}},
+		{name: "filtered fp", d: domain.Disposition{Kind: domain.DispositionFilteredFP, FPScore: 85, Reasoning: "likely noise", GroupTitle: "FP"}},
+		{name: "filtered exclude", d: domain.Disposition{Kind: domain.DispositionFilteredExclude, GroupTitle: "excluded"}},
+		{name: "survived", d: domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: "real bug"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema, err := ToDispositionSchema(tt.d)
+			if err != nil {
+				t.Fatalf("ToDispositionSchema: %v", err)
+			}
+			data, err := json.Marshal(schema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded DispositionV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got, err := decoded.ToDomain()
+			if err != nil {
+				t.Fatalf("ToDomain: %v", err)
+			}
+			if got != tt.d {
+				t.Fatalf("round trip mismatch: got %+v, want %+v", got, tt.d)
+			}
+		})
+	}
+}
+
+func TestDispositionKindV1_ToDomain_RejectsUnknown(t *testing.T) {
+	if _, err := DispositionKindV1("nonsense").ToDomain(); err == nil {
+		t.Fatal("expected an error for an unknown stored disposition kind")
+	}
+}
+
+func TestReviewFindingV1_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		f    domain.ReviewFinding
+	}{
+		{
+			name: "actionable survived finding",
+			f: domain.ReviewFinding{
+				ID:          "finding-1",
+				Kind:        domain.ReviewFindingActionable,
+				Group:       domain.FindingGroup{Title: "Real bug", Sources: []int{0}},
+				Disposition: domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: "Real bug"},
+			},
+		},
+		{
+			name: "informational finding",
+			f: domain.ReviewFinding{
+				ID:          "finding-2",
+				Kind:        domain.ReviewFindingInformational,
+				Group:       domain.FindingGroup{Title: "Style note", Sources: []int{1}},
+				Disposition: domain.Disposition{Kind: domain.DispositionInfo, GroupTitle: "Style note"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema, err := ToReviewFindingSchema(tt.f)
+			if err != nil {
+				t.Fatalf("ToReviewFindingSchema: %v", err)
+			}
+			data, err := json.Marshal(schema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded ReviewFindingV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got, err := decoded.ToDomain()
+			if err != nil {
+				t.Fatalf("ToDomain: %v", err)
+			}
+			if got.ID != tt.f.ID || got.Kind != tt.f.Kind || got.Disposition != tt.f.Disposition {
+				t.Fatalf("round trip mismatch: got %+v, want %+v", got, tt.f)
+			}
+		})
+	}
+}

--- a/internal/store/forget.go
+++ b/internal/store/forget.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type ForgetReport struct {
+	PullRequest          PullRequestKeyV1
+	Existed              bool
+	SnapshotRemoved      bool
+	RunsRemoved          int
+	EventsRemoved        int
+	AdjudicationsRemoved int
+	LoopDecisionsRemoved int
+	EconomicsRemoved     int
+}
+
+func ForgetPullRequest(dataDir string, key PullRequestKeyV1) (ForgetReport, error) {
+	report := ForgetReport{PullRequest: key}
+
+	prDir, err := pullRequestDir(dataDir, key)
+	if err != nil {
+		return report, err
+	}
+
+	if _, err := os.Stat(prDir); err != nil {
+		if os.IsNotExist(err) {
+			return report, nil
+		}
+		return report, fmt.Errorf("stat %s: %w", prDir, err)
+	}
+	report.Existed = true
+
+	if info, err := os.Stat(filepath.Join(prDir, snapshotFileName)); err == nil && !info.IsDir() {
+		report.SnapshotRemoved = true
+	}
+	report.RunsRemoved = countJSONFiles(filepath.Join(prDir, runsDirName))
+	report.EventsRemoved = countJSONFiles(filepath.Join(prDir, eventsDirName))
+	report.AdjudicationsRemoved = countJSONFiles(filepath.Join(prDir, adjudicationsDirName))
+	report.LoopDecisionsRemoved = countJSONFiles(filepath.Join(prDir, loopDecisionsDirName))
+	report.EconomicsRemoved = countJSONFiles(filepath.Join(prDir, economicsDirName))
+
+	if err := os.RemoveAll(prDir); err != nil {
+		return report, fmt.Errorf("remove pull request history for %s: %w", key.String(), err)
+	}
+	return report, nil
+}
+
+func countJSONFiles(dir string) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) == ".json" {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/store/forget_test.go
+++ b/internal/store/forget_test.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func testOtherPullRequestKey() PullRequestKeyV1 {
+	key := testPullRequestKey()
+	key.Number = key.Number + 1
+	return key
+}
+
+func testPRSnapshot(key PullRequestKeyV1) PRSnapshotV1 {
+	return PRSnapshotV1{
+		SchemaVersion: CurrentSchemaVersion,
+		PullRequest:   key,
+		URL:           "https://github.com/richhaase/agentic-code-reviewer/pull/196",
+		Title:         "Test snapshot",
+		Author:        "richhaase",
+		State:         PullRequestStateOpen,
+		HeadObjectID:  "headsha",
+		BaseObjectID:  "basesha",
+		CapturedAt:    time.Date(2026, 7, 22, 9, 5, 0, 0, time.UTC),
+	}
+}
+
+func TestForgetPullRequest_RemovesExactlyTheRequestedHistory(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+	other := testOtherPullRequestKey()
+
+	runStore := NewFilesystemRunStore(dir)
+	eventStore := NewFilesystemEventStore(dir)
+	adjudicationStore := NewFilesystemAdjudicationStore(dir)
+	loopDecisionStore := NewFilesystemLoopDecisionStore(dir)
+	economicsStore := NewFilesystemEconomicsStore(dir)
+	snapshotStore := NewFilesystemSnapshotStore(dir)
+
+	run := buildTestReviewRunSchema(t, "run-forget-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := runStore.SaveRun(run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+	event := testReviewEvent("event-forget-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := eventStore.AppendEvent(event); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	adjudication := testAdjudicationRecord("adjudication-forget-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := adjudicationStore.SaveAdjudication(adjudication); err != nil {
+		t.Fatalf("save adjudication: %v", err)
+	}
+	decision := testLoopDecision("loop-decision-forget-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := loopDecisionStore.SaveLoopDecision(decision); err != nil {
+		t.Fatalf("save loop decision: %v", err)
+	}
+	economics := testReviewEconomics("run-forget-1")
+	if _, err := economicsStore.SaveEconomics(key, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), economics); err != nil {
+		t.Fatalf("save economics: %v", err)
+	}
+	if err := snapshotStore.SaveSnapshot(testPRSnapshot(key)); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	otherRun := buildTestReviewRunSchema(t, "run-forget-other", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	otherRun.Target.PullRequest = &other
+	if _, err := runStore.SaveRun(otherRun); err != nil {
+		t.Fatalf("save other run: %v", err)
+	}
+
+	report, err := ForgetPullRequest(dir, key)
+	if err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+	if !report.Existed {
+		t.Fatal("expected report to indicate the pull request history existed")
+	}
+	if !report.SnapshotRemoved {
+		t.Fatal("expected the snapshot to be reported as removed")
+	}
+	if report.RunsRemoved != 1 || report.EventsRemoved != 1 || report.AdjudicationsRemoved != 1 ||
+		report.LoopDecisionsRemoved != 1 || report.EconomicsRemoved != 1 {
+		t.Fatalf("unexpected removal counts: %+v", report)
+	}
+
+	runs, _, err := runStore.ListRuns(key)
+	if err != nil {
+		t.Fatalf("list runs after forget: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("expected no runs remaining for forgotten pull request, got %+v", runs)
+	}
+	events, _, err := eventStore.ListEvents(key)
+	if err != nil {
+		t.Fatalf("list events after forget: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no events remaining for forgotten pull request, got %+v", events)
+	}
+	if _, err := snapshotStore.LoadSnapshot(key); err == nil {
+		t.Fatal("expected an error loading the snapshot of a forgotten pull request")
+	}
+
+	otherRuns, _, err := runStore.ListRuns(other)
+	if err != nil {
+		t.Fatalf("list other runs: %v", err)
+	}
+	if len(otherRuns) != 1 || otherRuns[0].ID != "run-forget-other" {
+		t.Fatalf("expected the other pull request's history to survive forget, got %+v", otherRuns)
+	}
+}
+
+func TestForgetPullRequest_NoStoredHistoryIsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+
+	report, err := ForgetPullRequest(dir, key)
+	if err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+	if report.Existed {
+		t.Fatalf("expected Existed to be false for a pull request with no stored history, got %+v", report)
+	}
+	if report.RunsRemoved != 0 || report.EventsRemoved != 0 {
+		t.Fatalf("expected zero removal counts, got %+v", report)
+	}
+}
+
+func TestForgetPullRequest_RejectsInvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ForgetPullRequest(dir, PullRequestKeyV1{}); err == nil {
+		t.Fatal("expected an error for an invalid pull request key")
+	}
+}
+
+func TestForgetPullRequest_LeavesDataDirIntact(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+
+	eventStore := NewFilesystemEventStore(dir)
+	event := testReviewEvent("event-forget-2", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := eventStore.AppendEvent(event); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+
+	if _, err := ForgetPullRequest(dir, key); err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected the data directory itself to remain, got %v", err)
+	}
+}

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type PullRequestKeyV1 struct {
+	Host       string `json:"host"`
+	Owner      string `json:"owner"`
+	Repository string `json:"repository"`
+	Number     int    `json:"number"`
+}
+
+func ToPullRequestKeySchema(key domain.PullRequestKey) PullRequestKeyV1 {
+	return PullRequestKeyV1{
+		Host:       key.Host,
+		Owner:      key.Owner,
+		Repository: key.Repository,
+		Number:     key.Number,
+	}
+}
+
+func (k PullRequestKeyV1) ToDomain() domain.PullRequestKey {
+	return domain.PullRequestKey{
+		Host:       k.Host,
+		Owner:      k.Owner,
+		Repository: k.Repository,
+		Number:     k.Number,
+	}
+}
+
+func (k PullRequestKeyV1) Validate() error {
+	return k.ToDomain().Validate()
+}
+
+func (k PullRequestKeyV1) String() string {
+	return k.ToDomain().String()
+}
+
+type RevisionEvidenceV1 struct {
+	RequestedBaseRef string `json:"requested_base_ref"`
+	ResolvedBaseRef  string `json:"resolved_base_ref"`
+	HeadObjectID     string `json:"head_object_id"`
+	BaseObjectID     string `json:"base_object_id"`
+}
+
+func ToRevisionEvidenceSchema(r domain.RevisionEvidence) RevisionEvidenceV1 {
+	return RevisionEvidenceV1{
+		RequestedBaseRef: r.RequestedBaseRef,
+		ResolvedBaseRef:  r.ResolvedBaseRef,
+		HeadObjectID:     r.HeadObjectID,
+		BaseObjectID:     r.BaseObjectID,
+	}
+}
+
+func (r RevisionEvidenceV1) ToDomain() domain.RevisionEvidence {
+	return domain.RevisionEvidence{
+		RequestedBaseRef: r.RequestedBaseRef,
+		ResolvedBaseRef:  r.ResolvedBaseRef,
+		HeadObjectID:     r.HeadObjectID,
+		BaseObjectID:     r.BaseObjectID,
+	}
+}
+
+type ReviewTargetV1 struct {
+	RepositoryRoot string             `json:"repository_root"`
+	WorktreeRoot   string             `json:"worktree_root"`
+	Revision       RevisionEvidenceV1 `json:"revision"`
+	PullRequest    *PullRequestKeyV1  `json:"pull_request,omitempty"`
+}
+
+func ToReviewTargetSchema(t domain.ReviewTarget) ReviewTargetV1 {
+	schema := ReviewTargetV1{
+		RepositoryRoot: t.RepositoryRoot,
+		WorktreeRoot:   t.WorktreeRoot,
+		Revision:       ToRevisionEvidenceSchema(t.Revision),
+	}
+	if t.PullRequest != nil {
+		key := ToPullRequestKeySchema(*t.PullRequest)
+		schema.PullRequest = &key
+	}
+	return schema
+}
+
+func (t ReviewTargetV1) ToDomain() domain.ReviewTarget {
+	target := domain.ReviewTarget{
+		RepositoryRoot: t.RepositoryRoot,
+		WorktreeRoot:   t.WorktreeRoot,
+		Revision:       t.Revision.ToDomain(),
+	}
+	if t.PullRequest != nil {
+		key := t.PullRequest.ToDomain()
+		target.PullRequest = &key
+	}
+	return target
+}
+
+func (t ReviewTargetV1) Validate() error {
+	return t.ToDomain().Validate()
+}
+
+func validateNonEmpty(field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	return nil
+}

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+func TestPullRequestKeyV1_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		key  domain.PullRequestKey
+	}{
+		{
+			name: "github.com PR",
+			key:  domain.PullRequestKey{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 196},
+		},
+		{
+			name: "enterprise host",
+			key:  domain.PullRequestKey{Host: "github.example.com", Owner: "org", Repository: "repo", Number: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := ToPullRequestKeySchema(tt.key)
+
+			data, err := json.Marshal(schema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded PullRequestKeyV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			if decoded != schema {
+				t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, schema)
+			}
+			if got := decoded.ToDomain(); got != tt.key {
+				t.Fatalf("ToDomain mismatch: got %+v, want %+v", got, tt.key)
+			}
+			if err := decoded.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestPullRequestKeyV1_ValidateRejectsInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		key  PullRequestKeyV1
+	}{
+		{name: "empty host", key: PullRequestKeyV1{Owner: "o", Repository: "r", Number: 1}},
+		{name: "host with port", key: PullRequestKeyV1{Host: "github.com:443", Owner: "o", Repository: "r", Number: 1}},
+		{name: "zero number", key: PullRequestKeyV1{Host: "github.com", Owner: "o", Repository: "r", Number: 0}},
+		{name: "negative number", key: PullRequestKeyV1{Host: "github.com", Owner: "o", Repository: "r", Number: -1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.key.Validate(); err == nil {
+				t.Fatalf("expected validation error for %+v", tt.key)
+			}
+		})
+	}
+}
+
+func TestReviewTargetV1_RoundTrip(t *testing.T) {
+	pr := domain.PullRequestKey{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 196}
+	target := domain.ReviewTarget{
+		RepositoryRoot: "/repo",
+		WorktreeRoot:   "/worktree",
+		Revision: domain.RevisionEvidence{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "refs/remotes/origin/main",
+			HeadObjectID:     "headsha",
+			BaseObjectID:     "basesha",
+		},
+		PullRequest: &pr,
+	}
+
+	schema := ToReviewTargetSchema(target)
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ReviewTargetV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got := decoded.ToDomain()
+	if got.RepositoryRoot != target.RepositoryRoot ||
+		got.WorktreeRoot != target.WorktreeRoot ||
+		got.Revision != target.Revision ||
+		got.PullRequest == nil || *got.PullRequest != *target.PullRequest {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, target)
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestReviewTargetV1_RoundTripWithoutPullRequest(t *testing.T) {
+	target := domain.ReviewTarget{
+		RepositoryRoot: "/repo",
+		WorktreeRoot:   "/worktree",
+		Revision: domain.RevisionEvidence{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "refs/remotes/origin/main",
+			HeadObjectID:     "headsha",
+			BaseObjectID:     "basesha",
+		},
+	}
+
+	schema := ToReviewTargetSchema(target)
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ReviewTargetV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.PullRequest != nil {
+		t.Fatalf("expected nil pull request, got %+v", decoded.PullRequest)
+	}
+	got := decoded.ToDomain()
+	if got.PullRequest != nil {
+		t.Fatalf("expected nil pull request in domain target, got %+v", got.PullRequest)
+	}
+}

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const LockFileName = "desk.lock"
+
+var ErrWriterLocked = errors.New("another acr process already owns the desk write lock")
+
+type WriteLock struct {
+	file *os.File
+}
+
+func AcquireWriteLock(dataDir string) (*WriteLock, error) {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create data directory %s: %w", dataDir, err)
+	}
+	path := filepath.Join(dataDir, LockFileName)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open desk lock file %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("acquire desk lock %s: %w", path, ErrWriterLocked)
+		}
+		return nil, fmt.Errorf("acquire desk lock %s: %w", path, err)
+	}
+	return &WriteLock{file: file}, nil
+}
+
+func (l *WriteLock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	l.file = nil
+	if err != nil {
+		return fmt.Errorf("release desk lock: %w", err)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close desk lock file: %w", closeErr)
+	}
+	return nil
+}

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
 const LockFileName = "desk.lock"
@@ -25,9 +24,9 @@ func AcquireWriteLock(dataDir string) (*WriteLock, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open desk lock file %s: %w", path, err)
 	}
-	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+	if err := lockFile(file); err != nil {
 		file.Close()
-		if errors.Is(err, syscall.EWOULDBLOCK) {
+		if errors.Is(err, ErrWriterLocked) {
 			return nil, fmt.Errorf("acquire desk lock %s: %w", path, ErrWriterLocked)
 		}
 		return nil, fmt.Errorf("acquire desk lock %s: %w", path, err)
@@ -39,7 +38,7 @@ func (l *WriteLock) Release() error {
 	if l == nil || l.file == nil {
 		return nil
 	}
-	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	err := unlockFile(l.file)
 	closeErr := l.file.Close()
 	l.file = nil
 	if err != nil {

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -17,11 +17,11 @@ type WriteLock struct {
 }
 
 func AcquireWriteLock(dataDir string) (*WriteLock, error) {
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create data directory %s: %w", dataDir, err)
 	}
 	path := filepath.Join(dataDir, LockFileName)
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open desk lock file %s: %w", path, err)
 	}

--- a/internal/store/lock_test.go
+++ b/internal/store/lock_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAcquireWriteLock_SecondAcquireRefusesCleanly(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireWriteLock(dir)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer first.Release()
+
+	_, err = AcquireWriteLock(dir)
+	if err == nil {
+		t.Fatal("expected second acquire to fail while the first holds the lock")
+	}
+	if !errors.Is(err, ErrWriterLocked) {
+		t.Fatalf("expected ErrWriterLocked, got %v", err)
+	}
+}
+
+func TestAcquireWriteLock_ReleaseAllowsReacquire(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := AcquireWriteLock(dir)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if err := first.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	second, err := AcquireWriteLock(dir)
+	if err != nil {
+		t.Fatalf("second acquire after release: %v", err)
+	}
+	defer second.Release()
+}
+
+func TestWriteLock_ReleaseIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	lock, err := AcquireWriteLock(dir)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatalf("first release: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatalf("second release: %v", err)
+	}
+}
+
+func TestWriteLock_ReleaseOnNilIsNoop(t *testing.T) {
+	var lock *WriteLock
+	if err := lock.Release(); err != nil {
+		t.Fatalf("expected nil release to be a no-op, got %v", err)
+	}
+}

--- a/internal/store/lock_unix.go
+++ b/internal/store/lock_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package store
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func lockFile(file *os.File) error {
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return ErrWriterLocked
+		}
+		return err
+	}
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/store/lock_windows.go
+++ b/internal/store/lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package store
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return ErrWriterLocked
+		}
+		return err
+	}
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+}

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -40,10 +41,14 @@ func (b BudgetStateV1) Validate() error {
 	if b.IterationsUsed < 0 || b.IterationsLimit < 0 {
 		return fmt.Errorf("known budget iteration counts must not be negative")
 	}
-	if b.CostUSDUsed < 0 || b.CostUSDLimit < 0 {
-		return fmt.Errorf("known budget cost must not be negative")
+	if isInvalidKnownCost(b.CostUSDUsed) || isInvalidKnownCost(b.CostUSDLimit) {
+		return fmt.Errorf("known budget cost must be a finite number that is not negative")
 	}
 	return nil
+}
+
+func isInvalidKnownCost(cost float64) bool {
+	return cost < 0 || math.IsNaN(cost) || math.IsInf(cost, 0)
 }
 
 type LoopDecisionV1 struct {

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-// LoopDecisionKindV1 is the outcome of one convergence-loop decision, from
-// issue #223.
 type LoopDecisionKindV1 string
 
 const (
@@ -24,10 +22,6 @@ func (k LoopDecisionKindV1) Validate() error {
 	}
 }
 
-// BudgetStateV1 is the budget counters in effect when a loop decision was
-// made. Known distinguishes a genuinely unmeasured/unbounded budget state
-// from a zero one, matching the same explicit-unavailability contract as
-// ProviderUsageV1.
 type BudgetStateV1 struct {
 	Known           bool    `json:"known"`
 	IterationsUsed  int     `json:"iterations_used"`
@@ -46,9 +40,6 @@ func (b BudgetStateV1) Validate() error {
 	return nil
 }
 
-// LoopDecisionV1 records one continue/stop/escalation decision made by the
-// review convergence loop, with the reason, counters, budget state, and
-// supporting finding adjudications behind it. See issue #223.
 type LoopDecisionV1 struct {
 	SchemaVersion             int                `json:"schema_version"`
 	ID                        string             `json:"id"`

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -31,11 +31,17 @@ type BudgetStateV1 struct {
 }
 
 func (b BudgetStateV1) Validate() error {
-	if b.Known {
+	if !b.Known {
+		if b.IterationsUsed != 0 || b.IterationsLimit != 0 || b.CostUSDUsed != 0 || b.CostUSDLimit != 0 {
+			return fmt.Errorf("budget state marked unknown must not carry nonzero measurements")
+		}
 		return nil
 	}
-	if b.IterationsUsed != 0 || b.IterationsLimit != 0 || b.CostUSDUsed != 0 || b.CostUSDLimit != 0 {
-		return fmt.Errorf("budget state marked unknown must not carry nonzero measurements")
+	if b.IterationsUsed < 0 || b.IterationsLimit < 0 {
+		return fmt.Errorf("known budget iteration counts must not be negative")
+	}
+	if b.CostUSDUsed < 0 || b.CostUSDLimit < 0 {
+		return fmt.Errorf("known budget cost must not be negative")
 	}
 	return nil
 }

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// LoopDecisionKindV1 is the outcome of one convergence-loop decision, from
+// issue #223.
+type LoopDecisionKindV1 string
+
+const (
+	LoopDecisionContinue LoopDecisionKindV1 = "continue"
+	LoopDecisionStop     LoopDecisionKindV1 = "stop"
+	LoopDecisionEscalate LoopDecisionKindV1 = "escalate"
+)
+
+func (k LoopDecisionKindV1) Validate() error {
+	switch k {
+	case LoopDecisionContinue, LoopDecisionStop, LoopDecisionEscalate:
+		return nil
+	default:
+		return fmt.Errorf("unknown loop decision kind %q", k)
+	}
+}
+
+// BudgetStateV1 is the budget counters in effect when a loop decision was
+// made. Known distinguishes a genuinely unmeasured/unbounded budget state
+// from a zero one, matching the same explicit-unavailability contract as
+// ProviderUsageV1.
+type BudgetStateV1 struct {
+	Known           bool    `json:"known"`
+	IterationsUsed  int     `json:"iterations_used"`
+	IterationsLimit int     `json:"iterations_limit"`
+	CostUSDUsed     float64 `json:"cost_usd_used"`
+	CostUSDLimit    float64 `json:"cost_usd_limit"`
+}
+
+func (b BudgetStateV1) Validate() error {
+	if b.Known {
+		return nil
+	}
+	if b.IterationsUsed != 0 || b.IterationsLimit != 0 || b.CostUSDUsed != 0 || b.CostUSDLimit != 0 {
+		return fmt.Errorf("budget state marked unknown must not carry nonzero measurements")
+	}
+	return nil
+}
+
+// LoopDecisionV1 records one continue/stop/escalation decision made by the
+// review convergence loop, with the reason, counters, budget state, and
+// supporting finding adjudications behind it. See issue #223.
+type LoopDecisionV1 struct {
+	SchemaVersion             int                `json:"schema_version"`
+	ID                        string             `json:"id"`
+	PullRequest               PullRequestKeyV1   `json:"pull_request"`
+	RunID                     string             `json:"run_id"`
+	Decision                  LoopDecisionKindV1 `json:"decision"`
+	Reason                    string             `json:"reason"`
+	IterationCount            int                `json:"iteration_count"`
+	Budget                    BudgetStateV1      `json:"budget"`
+	SupportingAdjudicationIDs []string           `json:"supporting_adjudication_ids,omitempty"`
+	DecidedAt                 time.Time          `json:"decided_at"`
+}
+
+func (d LoopDecisionV1) Validate() error {
+	if err := validateSchemaVersion("loop decision", d.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("loop decision id", d.ID); err != nil {
+		return err
+	}
+	if err := d.PullRequest.Validate(); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("loop decision run_id", d.RunID); err != nil {
+		return err
+	}
+	if err := d.Decision.Validate(); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("loop decision reason", d.Reason); err != nil {
+		return err
+	}
+	if d.IterationCount < 0 {
+		return fmt.Errorf("loop decision iteration_count must not be negative")
+	}
+	if err := d.Budget.Validate(); err != nil {
+		return err
+	}
+	if d.DecidedAt.IsZero() {
+		return fmt.Errorf("loop decision decided_at is required")
+	}
+	return nil
+}

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -94,6 +94,7 @@ func TestLoopDecisionV1_Validate(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "valid", mutate: func(d *LoopDecisionV1) {}, wantErr: false},
+		{name: "unsupported schema version", mutate: func(d *LoopDecisionV1) { d.SchemaVersion = 99 }, wantErr: true},
 		{name: "unknown decision kind", mutate: func(d *LoopDecisionV1) { d.Decision = "retry" }, wantErr: true},
 		{name: "missing reason", mutate: func(d *LoopDecisionV1) { d.Reason = "" }, wantErr: true},
 		{name: "negative iteration count", mutate: func(d *LoopDecisionV1) { d.IterationCount = -1 }, wantErr: true},

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestLoopDecisionV1_RoundTripAllKinds(t *testing.T) {
+	kinds := []LoopDecisionKindV1{LoopDecisionContinue, LoopDecisionStop, LoopDecisionEscalate}
+
+	for _, kind := range kinds {
+		t.Run(string(kind), func(t *testing.T) {
+			decision := LoopDecisionV1{
+				SchemaVersion:  CurrentSchemaVersion,
+				ID:             "loop-decision-1",
+				PullRequest:    testPullRequestKey(),
+				RunID:          "run-1",
+				Decision:       kind,
+				Reason:         "clean run",
+				IterationCount: 2,
+				Budget: BudgetStateV1{
+					Known:           true,
+					IterationsUsed:  2,
+					IterationsLimit: 5,
+					CostUSDUsed:     1.5,
+					CostUSDLimit:    10,
+				},
+				SupportingAdjudicationIDs: []string{"adjudication-1", "adjudication-2"},
+				DecidedAt:                 time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC),
+			}
+
+			if err := decision.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+
+			data, err := json.Marshal(decision)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded LoopDecisionV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(decoded, decision) {
+				t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, decision)
+			}
+		})
+	}
+}
+
+func TestBudgetStateV1_KnownZeroDistinguishableFromUnknown(t *testing.T) {
+	known := BudgetStateV1{Known: true}
+	unknown := BudgetStateV1{Known: false}
+
+	if err := known.Validate(); err != nil {
+		t.Fatalf("Validate(known zero budget): %v", err)
+	}
+	if err := unknown.Validate(); err != nil {
+		t.Fatalf("Validate(unknown budget): %v", err)
+	}
+
+	knownData, _ := json.Marshal(known)
+	unknownData, _ := json.Marshal(unknown)
+	if string(knownData) == string(unknownData) {
+		t.Fatalf("known-zero and unknown budget state must serialize differently: %s", knownData)
+	}
+}
+
+func TestBudgetStateV1_ValidateRejectsUnknownWithNonzeroMeasurements(t *testing.T) {
+	unknown := BudgetStateV1{Known: false, IterationsUsed: 1}
+	if err := unknown.Validate(); err == nil {
+		t.Fatal("expected an error for unknown budget state with a nonzero measurement")
+	}
+}
+
+func TestLoopDecisionV1_Validate(t *testing.T) {
+	valid := func() LoopDecisionV1 {
+		return LoopDecisionV1{
+			SchemaVersion: CurrentSchemaVersion,
+			ID:            "loop-decision-1",
+			PullRequest:   testPullRequestKey(),
+			RunID:         "run-1",
+			Decision:      LoopDecisionContinue,
+			Reason:        "not converged",
+			DecidedAt:     time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(d *LoopDecisionV1)
+		wantErr bool
+	}{
+		{name: "valid", mutate: func(d *LoopDecisionV1) {}, wantErr: false},
+		{name: "unknown decision kind", mutate: func(d *LoopDecisionV1) { d.Decision = "retry" }, wantErr: true},
+		{name: "missing reason", mutate: func(d *LoopDecisionV1) { d.Reason = "" }, wantErr: true},
+		{name: "negative iteration count", mutate: func(d *LoopDecisionV1) { d.IterationCount = -1 }, wantErr: true},
+		{name: "zero decided_at", mutate: func(d *LoopDecisionV1) { d.DecidedAt = time.Time{} }, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := valid()
+			tt.mutate(&decision)
+			err := decision.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -84,6 +85,8 @@ func TestBudgetStateV1_ValidateRejectsNegativeKnownMeasurements(t *testing.T) {
 		{name: "negative iterations limit", budget: BudgetStateV1{Known: true, IterationsLimit: -1}},
 		{name: "negative cost used", budget: BudgetStateV1{Known: true, CostUSDUsed: -0.01}},
 		{name: "negative cost limit", budget: BudgetStateV1{Known: true, CostUSDLimit: -0.01}},
+		{name: "NaN cost used", budget: BudgetStateV1{Known: true, CostUSDUsed: math.NaN()}},
+		{name: "infinite cost limit", budget: BudgetStateV1{Known: true, CostUSDLimit: math.Inf(1)}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -75,6 +75,25 @@ func TestBudgetStateV1_ValidateRejectsUnknownWithNonzeroMeasurements(t *testing.
 	}
 }
 
+func TestBudgetStateV1_ValidateRejectsNegativeKnownMeasurements(t *testing.T) {
+	tests := []struct {
+		name   string
+		budget BudgetStateV1
+	}{
+		{name: "negative iterations used", budget: BudgetStateV1{Known: true, IterationsUsed: -1}},
+		{name: "negative iterations limit", budget: BudgetStateV1{Known: true, IterationsLimit: -1}},
+		{name: "negative cost used", budget: BudgetStateV1{Known: true, CostUSDUsed: -0.01}},
+		{name: "negative cost limit", budget: BudgetStateV1{Known: true, CostUSDLimit: -0.01}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.budget.Validate(); err == nil {
+				t.Fatalf("expected an error for known budget state with a negative measurement: %+v", tt.budget)
+			}
+		})
+	}
+}
+
 func TestLoopDecisionV1_Validate(t *testing.T) {
 	valid := func() LoopDecisionV1 {
 		return LoopDecisionV1{

--- a/internal/store/loopdecisionstore.go
+++ b/internal/store/loopdecisionstore.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+type LoopDecisionStore interface {
+	SaveLoopDecision(decision LoopDecisionV1) (string, error)
+	ListLoopDecisions(key PullRequestKeyV1) ([]LoopDecisionV1, []CorruptRecord, error)
+}
+
+type FilesystemLoopDecisionStore struct {
+	dataDir string
+}
+
+func NewFilesystemLoopDecisionStore(dataDir string) *FilesystemLoopDecisionStore {
+	return &FilesystemLoopDecisionStore{dataDir: dataDir}
+}
+
+var _ LoopDecisionStore = (*FilesystemLoopDecisionStore)(nil)
+
+func (s *FilesystemLoopDecisionStore) SaveLoopDecision(decision LoopDecisionV1) (string, error) {
+	if err := decision.Validate(); err != nil {
+		return "", err
+	}
+	dir, err := loopDecisionsDir(s.dataDir, decision.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	name, err := recordFileName("loop decision", decision.ID, decision.DecidedAt)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, name)
+
+	data, err := json.MarshalIndent(decision, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal loop decision %s: %w", decision.ID, err)
+	}
+	if err := writeNewFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("save loop decision %s: %w", decision.ID, err)
+	}
+	return path, nil
+}
+
+func (s *FilesystemLoopDecisionStore) ListLoopDecisions(key PullRequestKeyV1) ([]LoopDecisionV1, []CorruptRecord, error) {
+	dir, err := loopDecisionsDir(s.dataDir, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return listRecords(dir, decodeLoopDecision)
+}

--- a/internal/store/loopdecisionstore.go
+++ b/internal/store/loopdecisionstore.go
@@ -39,7 +39,7 @@ func (s *FilesystemLoopDecisionStore) SaveLoopDecision(decision LoopDecisionV1) 
 	if err != nil {
 		return "", fmt.Errorf("marshal loop decision %s: %w", decision.ID, err)
 	}
-	if err := writeNewFile(path, data, 0o644); err != nil {
+	if err := writeNewFile(path, data, 0o600); err != nil {
 		return "", fmt.Errorf("save loop decision %s: %w", decision.ID, err)
 	}
 	return path, nil

--- a/internal/store/loopdecisionstore.go
+++ b/internal/store/loopdecisionstore.go
@@ -25,6 +25,15 @@ func (s *FilesystemLoopDecisionStore) SaveLoopDecision(decision LoopDecisionV1) 
 	if err := decision.Validate(); err != nil {
 		return "", err
 	}
+	existing, _, err := s.ListLoopDecisions(decision.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range existing {
+		if e.ID == decision.ID {
+			return "", fmt.Errorf("loop decision %s already exists for %s", decision.ID, decision.PullRequest.String())
+		}
+	}
 	dir, err := loopDecisionsDir(s.dataDir, decision.PullRequest)
 	if err != nil {
 		return "", err

--- a/internal/store/loopdecisionstore_test.go
+++ b/internal/store/loopdecisionstore_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testLoopDecision(id string, decidedAt time.Time) LoopDecisionV1 {
+	return LoopDecisionV1{
+		SchemaVersion:  CurrentSchemaVersion,
+		ID:             id,
+		PullRequest:    testPullRequestKey(),
+		RunID:          "run-1",
+		Decision:       LoopDecisionContinue,
+		Reason:         "not converged",
+		IterationCount: 1,
+		DecidedAt:      decidedAt,
+	}
+}
+
+func TestFilesystemLoopDecisionStore_SaveAndList(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemLoopDecisionStore(dir)
+	key := testPullRequestKey()
+
+	d1 := testLoopDecision("loop-decision-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	d2 := testLoopDecision("loop-decision-2", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+
+	if _, err := store.SaveLoopDecision(d1); err != nil {
+		t.Fatalf("save d1: %v", err)
+	}
+	if _, err := store.SaveLoopDecision(d2); err != nil {
+		t.Fatalf("save d2: %v", err)
+	}
+
+	decisions, corrupt, err := store.ListLoopDecisions(key)
+	if err != nil {
+		t.Fatalf("list loop decisions: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(decisions) != 2 || decisions[0].ID != "loop-decision-1" || decisions[1].ID != "loop-decision-2" {
+		t.Fatalf("expected chronological loop-decision-1, loop-decision-2, got %+v", decisions)
+	}
+}
+
+func TestFilesystemLoopDecisionStore_RefusesDuplicateSave(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemLoopDecisionStore(dir)
+	decision := testLoopDecision("loop-decision-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	if _, err := store.SaveLoopDecision(decision); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if _, err := store.SaveLoopDecision(decision); err == nil {
+		t.Fatal("expected an error re-saving the same loop decision id/timestamp")
+	}
+}
+
+func TestFilesystemLoopDecisionStore_RejectsInvalidDecision(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemLoopDecisionStore(dir)
+	invalid := testLoopDecision("loop-decision-invalid", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	invalid.Reason = ""
+
+	if _, err := store.SaveLoopDecision(invalid); err == nil {
+		t.Fatal("expected an error for a missing reason")
+	}
+}
+
+func TestFilesystemLoopDecisionStore_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+	decision := testLoopDecision("loop-decision-restart", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	firstProcessStore := NewFilesystemLoopDecisionStore(dir)
+	if _, err := firstProcessStore.SaveLoopDecision(decision); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	secondProcessStore := NewFilesystemLoopDecisionStore(dir)
+	decisions, _, err := secondProcessStore.ListLoopDecisions(key)
+	if err != nil {
+		t.Fatalf("list after restart: %v", err)
+	}
+	if len(decisions) != 1 || decisions[0].ID != "loop-decision-restart" {
+		t.Fatalf("restart did not preserve loop decision history: got %+v", decisions)
+	}
+}
+
+func TestFilesystemLoopDecisionStore_IsolatesCorruptRecords(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemLoopDecisionStore(dir)
+	key := testPullRequestKey()
+
+	good := testLoopDecision("loop-decision-good", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveLoopDecision(good); err != nil {
+		t.Fatalf("save good decision: %v", err)
+	}
+
+	dirPath, err := loopDecisionsDir(dir, key)
+	if err != nil {
+		t.Fatalf("loopDecisionsDir: %v", err)
+	}
+	corruptPath := filepath.Join(dirPath, "20260722T130000.000000000Z-loop-decision-bad.json")
+	if err := os.WriteFile(corruptPath, []byte(`not json at all`), 0o644); err != nil {
+		t.Fatalf("seed corrupt record: %v", err)
+	}
+
+	decisions, corrupt, err := store.ListLoopDecisions(key)
+	if err != nil {
+		t.Fatalf("list loop decisions: %v", err)
+	}
+	if len(decisions) != 1 || decisions[0].ID != "loop-decision-good" {
+		t.Fatalf("expected the good decision to remain readable, got %+v", decisions)
+	}
+	if len(corrupt) != 1 || corrupt[0].Path != corruptPath {
+		t.Fatalf("expected exactly one corrupt record reported for %s, got %+v", corruptPath, corrupt)
+	}
+}

--- a/internal/store/loopdecisionstore_test.go
+++ b/internal/store/loopdecisionstore_test.go
@@ -60,6 +60,33 @@ func TestFilesystemLoopDecisionStore_RefusesDuplicateSave(t *testing.T) {
 	}
 }
 
+func TestFilesystemLoopDecisionStore_RefusesDuplicateIDWithDifferentTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemLoopDecisionStore(dir)
+	key := testPullRequestKey()
+
+	first := testLoopDecision("loop-decision-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveLoopDecision(first); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	second := testLoopDecision("loop-decision-dup", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+	if _, err := store.SaveLoopDecision(second); err == nil {
+		t.Fatal("expected an error re-saving the same loop decision id under a different timestamp")
+	}
+
+	decisions, corrupt, err := store.ListLoopDecisions(key)
+	if err != nil {
+		t.Fatalf("list loop decisions: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(decisions) != 1 {
+		t.Fatalf("expected exactly one stored decision for the duplicated id, got %d", len(decisions))
+	}
+}
+
 func TestFilesystemLoopDecisionStore_RejectsInvalidDecision(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFilesystemLoopDecisionStore(dir)

--- a/internal/store/paths.go
+++ b/internal/store/paths.go
@@ -85,9 +85,22 @@ func validateRecordID(kind, id string) error {
 
 const recordTimestampFormat = "20060102T150405.000000000Z"
 
+const recordTimestampLen = len(recordTimestampFormat)
+
 func recordFileName(kind, id string, ts time.Time) (string, error) {
 	if err := validateRecordID(kind, id); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%s-%s.json", ts.UTC().Format(recordTimestampFormat), id), nil
+}
+
+func parseRecordTimestamp(name string) (time.Time, error) {
+	if len(name) <= recordTimestampLen || name[recordTimestampLen] != '-' {
+		return time.Time{}, fmt.Errorf("record filename %q does not start with a timestamp", name)
+	}
+	ts, err := time.Parse(recordTimestampFormat, name[:recordTimestampLen])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("record filename %q has an invalid timestamp: %w", name, err)
+	}
+	return ts, nil
 }

--- a/internal/store/paths.go
+++ b/internal/store/paths.go
@@ -9,10 +9,13 @@ import (
 )
 
 const (
-	prsDirName       = "prs"
-	runsDirName      = "runs"
-	eventsDirName    = "events"
-	snapshotFileName = "snapshot.json"
+	prsDirName           = "prs"
+	runsDirName          = "runs"
+	eventsDirName        = "events"
+	snapshotFileName     = "snapshot.json"
+	adjudicationsDirName = "adjudications"
+	loopDecisionsDirName = "loop_decisions"
+	economicsDirName     = "economics"
 )
 
 func pullRequestDir(dataDir string, key PullRequestKeyV1) (string, error) {
@@ -44,6 +47,30 @@ func snapshotFilePath(dataDir string, key PullRequestKeyV1) (string, error) {
 		return "", err
 	}
 	return filepath.Join(prDir, snapshotFileName), nil
+}
+
+func adjudicationsDir(dataDir string, key PullRequestKeyV1) (string, error) {
+	prDir, err := pullRequestDir(dataDir, key)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(prDir, adjudicationsDirName), nil
+}
+
+func loopDecisionsDir(dataDir string, key PullRequestKeyV1) (string, error) {
+	prDir, err := pullRequestDir(dataDir, key)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(prDir, loopDecisionsDirName), nil
+}
+
+func economicsDir(dataDir string, key PullRequestKeyV1) (string, error) {
+	prDir, err := pullRequestDir(dataDir, key)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(prDir, economicsDirName), nil
 }
 
 func validateRecordID(kind, id string) error {

--- a/internal/store/paths.go
+++ b/internal/store/paths.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	prsDirName       = "prs"
+	runsDirName      = "runs"
+	eventsDirName    = "events"
+	snapshotFileName = "snapshot.json"
+)
+
+func pullRequestDir(dataDir string, key PullRequestKeyV1) (string, error) {
+	if err := key.Validate(); err != nil {
+		return "", fmt.Errorf("pull request key: %w", err)
+	}
+	return filepath.Join(dataDir, prsDirName, key.Host, key.Owner, key.Repository, strconv.Itoa(key.Number)), nil
+}
+
+func runsDir(dataDir string, key PullRequestKeyV1) (string, error) {
+	prDir, err := pullRequestDir(dataDir, key)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(prDir, runsDirName), nil
+}
+
+func eventsDir(dataDir string, key PullRequestKeyV1) (string, error) {
+	prDir, err := pullRequestDir(dataDir, key)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(prDir, eventsDirName), nil
+}
+
+func snapshotFilePath(dataDir string, key PullRequestKeyV1) (string, error) {
+	prDir, err := pullRequestDir(dataDir, key)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(prDir, snapshotFileName), nil
+}
+
+func validateRecordID(kind, id string) error {
+	if err := validateNonEmpty(kind+" id", id); err != nil {
+		return err
+	}
+	if id != filepath.Base(id) || id == "." || id == ".." || strings.ContainsAny(id, "/\\") {
+		return fmt.Errorf("%s id %q is not safe to use in a stored record filename", kind, id)
+	}
+	return nil
+}
+
+const recordTimestampFormat = "20060102T150405.000000000Z"
+
+func recordFileName(kind, id string, ts time.Time) (string, error) {
+	if err := validateRecordID(kind, id); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s.json", ts.UTC().Format(recordTimestampFormat), id), nil
+}

--- a/internal/store/policy.go
+++ b/internal/store/policy.go
@@ -1,0 +1,52 @@
+package store
+
+import "fmt"
+
+// BudgetPolicyV1 bounds how much a review convergence loop may spend before
+// it must stop or escalate.
+type BudgetPolicyV1 struct {
+	MaxIterations int     `json:"max_iterations"`
+	MaxCostUSD    float64 `json:"max_cost_usd"`
+}
+
+func (p BudgetPolicyV1) Validate() error {
+	if p.MaxIterations < 0 {
+		return fmt.Errorf("budget policy max_iterations must not be negative")
+	}
+	if p.MaxCostUSD < 0 {
+		return fmt.Errorf("budget policy max_cost_usd must not be negative")
+	}
+	return nil
+}
+
+// StopPolicyV1 defines when the convergence loop is allowed to stop.
+type StopPolicyV1 struct {
+	StopOnCleanRun      bool `json:"stop_on_clean_run"`
+	StopOnNoNewFindings bool `json:"stop_on_no_new_findings"`
+}
+
+// AdjudicationPolicyV1 is the versioned control-plane record carrying budget
+// policy, stop policy, and evaluation guidance used by the review
+// convergence loop (issue #223). Source records where this policy was
+// resolved from, reusing config.SourceIdentity, the exact trust mechanism
+// issue #220 established, rather than inventing a second trust boundary.
+// ValidatePolicySourceOutsideReview must be used together with Validate to
+// confirm Source does not resolve to the head of the pull request under
+// review.
+type AdjudicationPolicyV1 struct {
+	SchemaVersion      int            `json:"schema_version"`
+	Source             PolicySourceV1 `json:"source"`
+	Budget             BudgetPolicyV1 `json:"budget"`
+	Stop               StopPolicyV1   `json:"stop"`
+	EvaluationGuidance string         `json:"evaluation_guidance"`
+}
+
+func (p AdjudicationPolicyV1) Validate() error {
+	if err := validateSchemaVersion("adjudication policy", p.SchemaVersion); err != nil {
+		return err
+	}
+	if err := p.Source.Validate(); err != nil {
+		return err
+	}
+	return p.Budget.Validate()
+}

--- a/internal/store/policy.go
+++ b/internal/store/policy.go
@@ -1,6 +1,9 @@
 package store
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+)
 
 type BudgetPolicyV1 struct {
 	MaxIterations int     `json:"max_iterations"`
@@ -11,8 +14,8 @@ func (p BudgetPolicyV1) Validate() error {
 	if p.MaxIterations < 0 {
 		return fmt.Errorf("budget policy max_iterations must not be negative")
 	}
-	if p.MaxCostUSD < 0 {
-		return fmt.Errorf("budget policy max_cost_usd must not be negative")
+	if p.MaxCostUSD < 0 || math.IsNaN(p.MaxCostUSD) || math.IsInf(p.MaxCostUSD, 0) {
+		return fmt.Errorf("budget policy max_cost_usd must be a finite number that is not negative")
 	}
 	return nil
 }

--- a/internal/store/policy.go
+++ b/internal/store/policy.go
@@ -2,8 +2,6 @@ package store
 
 import "fmt"
 
-// BudgetPolicyV1 bounds how much a review convergence loop may spend before
-// it must stop or escalate.
 type BudgetPolicyV1 struct {
 	MaxIterations int     `json:"max_iterations"`
 	MaxCostUSD    float64 `json:"max_cost_usd"`
@@ -19,20 +17,11 @@ func (p BudgetPolicyV1) Validate() error {
 	return nil
 }
 
-// StopPolicyV1 defines when the convergence loop is allowed to stop.
 type StopPolicyV1 struct {
 	StopOnCleanRun      bool `json:"stop_on_clean_run"`
 	StopOnNoNewFindings bool `json:"stop_on_no_new_findings"`
 }
 
-// AdjudicationPolicyV1 is the versioned control-plane record carrying budget
-// policy, stop policy, and evaluation guidance used by the review
-// convergence loop (issue #223). Source records where this policy was
-// resolved from, reusing config.SourceIdentity, the exact trust mechanism
-// issue #220 established, rather than inventing a second trust boundary.
-// ValidatePolicySourceOutsideReview must be used together with Validate to
-// confirm Source does not resolve to the head of the pull request under
-// review.
 type AdjudicationPolicyV1 struct {
 	SchemaVersion      int            `json:"schema_version"`
 	Source             PolicySourceV1 `json:"source"`

--- a/internal/store/policy_resolve.go
+++ b/internal/store/policy_resolve.go
@@ -7,15 +7,6 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
 )
 
-// ResolveAdjudicationPolicy loads adjudication memory's budget policy, stop
-// policy, and evaluation guidance from source, the same config.Source
-// abstraction issue #220 established for review configuration, and returns
-// the resulting AdjudicationPolicyV1 along with any non-fatal warnings from
-// loading it. It rejects a source whose resolved kind is untrusted or whose
-// resolved revision is the pull request head under review, via
-// PolicySourceV1.Validate and ValidatePolicySourceOutsideReview, so a
-// reviewed pull request's own head or worktree can never supply or alter
-// the returned policy.
 func ResolveAdjudicationPolicy(ctx context.Context, source config.Source, target ReviewTargetV1) (AdjudicationPolicyV1, []string, error) {
 	result, err := source.LoadWithWarnings(ctx)
 	if err != nil {

--- a/internal/store/policy_resolve.go
+++ b/internal/store/policy_resolve.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+)
+
+// ResolveAdjudicationPolicy loads adjudication memory's budget policy, stop
+// policy, and evaluation guidance from source, the same config.Source
+// abstraction issue #220 established for review configuration, and returns
+// the resulting AdjudicationPolicyV1 along with any non-fatal warnings from
+// loading it. It rejects a source whose resolved kind is untrusted or whose
+// resolved revision is the pull request head under review, via
+// PolicySourceV1.Validate and ValidatePolicySourceOutsideReview, so a
+// reviewed pull request's own head or worktree can never supply or alter
+// the returned policy.
+func ResolveAdjudicationPolicy(ctx context.Context, source config.Source, target ReviewTargetV1) (AdjudicationPolicyV1, []string, error) {
+	result, err := source.LoadWithWarnings(ctx)
+	if err != nil {
+		return AdjudicationPolicyV1{}, nil, fmt.Errorf("resolve adjudication policy: %w", err)
+	}
+
+	policySource := ToPolicySourceSchema(result.Source)
+	if err := ValidatePolicySourceOutsideReview(policySource, target); err != nil {
+		return AdjudicationPolicyV1{}, nil, err
+	}
+
+	policy := AdjudicationPolicyV1{
+		SchemaVersion: CurrentSchemaVersion,
+		Source:        policySource,
+	}
+	if result.Config != nil {
+		adjudication := result.Config.Adjudication
+		if adjudication.MaxIterations != nil {
+			policy.Budget.MaxIterations = *adjudication.MaxIterations
+		}
+		if adjudication.MaxCostUSD != nil {
+			policy.Budget.MaxCostUSD = *adjudication.MaxCostUSD
+		}
+		if adjudication.StopOnCleanRun != nil {
+			policy.Stop.StopOnCleanRun = *adjudication.StopOnCleanRun
+		}
+		if adjudication.StopOnNoNewFindings != nil {
+			policy.Stop.StopOnNoNewFindings = *adjudication.StopOnNoNewFindings
+		}
+		if adjudication.EvaluationGuidance != nil {
+			policy.EvaluationGuidance = *adjudication.EvaluationGuidance
+		}
+	}
+
+	if err := policy.Validate(); err != nil {
+		return AdjudicationPolicyV1{}, nil, fmt.Errorf("resolve adjudication policy: %w", err)
+	}
+	return policy, result.Warnings, nil
+}

--- a/internal/store/policy_resolve_test.go
+++ b/internal/store/policy_resolve_test.go
@@ -1,0 +1,166 @@
+package store
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+)
+
+func newPolicyResolveRepository(t *testing.T, trustedAdjudicationConfig string) string {
+	t.Helper()
+	repositoryRoot := t.TempDir()
+	runPolicyResolveGit(t, repositoryRoot, "init", "-b", "main")
+	runPolicyResolveGit(t, repositoryRoot, "config", "user.email", "test@example.com")
+	runPolicyResolveGit(t, repositoryRoot, "config", "user.name", "Test User")
+	writePolicyResolveFile(t, repositoryRoot, config.ConfigFileName, trustedAdjudicationConfig)
+	runPolicyResolveGit(t, repositoryRoot, "add", ".")
+	runPolicyResolveGit(t, repositoryRoot, "commit", "-m", "trusted")
+	return repositoryRoot
+}
+
+func writePolicyResolveFile(t *testing.T, repositoryRoot, relativePath, content string) {
+	t.Helper()
+	filePath := filepath.Join(repositoryRoot, relativePath)
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runPolicyResolveGit(t *testing.T, repositoryRoot string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repositoryRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func policyResolveGitOutput(t *testing.T, repositoryRoot string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repositoryRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+const trustedAdjudicationConfig = `adjudication:
+  max_iterations: 5
+  max_cost_usd: 10
+  stop_on_clean_run: true
+  stop_on_no_new_findings: true
+  evaluation_guidance: trusted guidance
+`
+
+func TestResolveAdjudicationPolicy_IgnoresConflictingWorktreeConfig(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newPolicyResolveRepository(t, trustedAdjudicationConfig)
+
+	runPolicyResolveGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writePolicyResolveFile(t, repositoryRoot, config.ConfigFileName, `adjudication:
+  max_iterations: 999
+  max_cost_usd: 999
+  stop_on_clean_run: false
+  stop_on_no_new_findings: false
+  evaluation_guidance: attacker-supplied guidance
+`)
+	runPolicyResolveGit(t, repositoryRoot, "add", ".")
+	runPolicyResolveGit(t, repositoryRoot, "commit", "-m", "reviewed pr head")
+	reviewedHead := policyResolveGitOutput(t, repositoryRoot, "rev-parse", "HEAD")
+
+	source, err := config.NewRepositoryRevisionSource(ctx, repositoryRoot, "main")
+	if err != nil {
+		t.Fatalf("NewRepositoryRevisionSource: %v", err)
+	}
+
+	target := ReviewTargetV1{
+		WorktreeRoot: repositoryRoot,
+		Revision:     RevisionEvidenceV1{HeadObjectID: reviewedHead},
+	}
+
+	policy, _, err := ResolveAdjudicationPolicy(ctx, source, target)
+	if err != nil {
+		t.Fatalf("ResolveAdjudicationPolicy: %v", err)
+	}
+
+	if policy.Budget.MaxIterations != 5 || policy.Budget.MaxCostUSD != 10 {
+		t.Fatalf("expected trusted budget policy, got %+v; the reviewed head's worktree config must never supply this data", policy.Budget)
+	}
+	if !policy.Stop.StopOnCleanRun || !policy.Stop.StopOnNoNewFindings {
+		t.Fatalf("expected trusted stop policy, got %+v", policy.Stop)
+	}
+	if policy.EvaluationGuidance != "trusted guidance" {
+		t.Fatalf("expected trusted evaluation guidance, got %q", policy.EvaluationGuidance)
+	}
+}
+
+func TestResolveAdjudicationPolicy_RejectsSourcePinnedToReviewedHead(t *testing.T) {
+	ctx := context.Background()
+	repositoryRoot := newPolicyResolveRepository(t, trustedAdjudicationConfig)
+
+	runPolicyResolveGit(t, repositoryRoot, "checkout", "-b", "incoming")
+	writePolicyResolveFile(t, repositoryRoot, config.ConfigFileName, `adjudication:
+  max_iterations: 999
+  evaluation_guidance: attacker-supplied guidance via own head
+`)
+	runPolicyResolveGit(t, repositoryRoot, "add", ".")
+	runPolicyResolveGit(t, repositoryRoot, "commit", "-m", "reviewed pr head")
+	reviewedHead := policyResolveGitOutput(t, repositoryRoot, "rev-parse", "HEAD")
+
+	source, err := config.NewRepositoryRevisionSource(ctx, repositoryRoot, "incoming")
+	if err != nil {
+		t.Fatalf("NewRepositoryRevisionSource: %v", err)
+	}
+
+	target := ReviewTargetV1{
+		WorktreeRoot: repositoryRoot,
+		Revision:     RevisionEvidenceV1{HeadObjectID: reviewedHead},
+	}
+
+	if _, _, err := ResolveAdjudicationPolicy(ctx, source, target); err == nil {
+		t.Fatal("expected an error resolving adjudication policy from a source pinned to the reviewed pull request's own head")
+	}
+}
+
+type filesystemPolicySource struct {
+	config *config.Config
+}
+
+func (s filesystemPolicySource) LoadWithWarnings(_ context.Context) (*config.LoadResult, error) {
+	return &config.LoadResult{
+		Config: s.config,
+		Source: config.SourceIdentity{
+			Kind:    config.SourceKindFilesystem,
+			Locator: "/reviewed/pr/worktree/.acr.yaml",
+		},
+	}, nil
+}
+
+func TestResolveAdjudicationPolicy_RejectsFilesystemSourcedConfiguration(t *testing.T) {
+	maxIterations := 999
+	guidance := "attacker-supplied guidance via raw worktree read"
+	source := filesystemPolicySource{
+		config: &config.Config{
+			Adjudication: config.AdjudicationConfig{
+				MaxIterations:      &maxIterations,
+				EvaluationGuidance: &guidance,
+			},
+		},
+	}
+
+	target := ReviewTargetV1{Revision: RevisionEvidenceV1{HeadObjectID: "some-head"}}
+
+	if _, _, err := ResolveAdjudicationPolicy(context.Background(), source, target); err == nil {
+		t.Fatal("expected an error resolving adjudication policy from a filesystem-kind source; a reviewed PR's own worktree must never supply this data")
+	}
+}

--- a/internal/store/policy_test.go
+++ b/internal/store/policy_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"math"
 	"reflect"
 	"testing"
 
@@ -61,6 +62,8 @@ func TestAdjudicationPolicyV1_Validate(t *testing.T) {
 		{name: "empty source kind rejected", mutate: func(p *AdjudicationPolicyV1) { p.Source = PolicySourceV1{} }, wantErr: true},
 		{name: "negative max iterations", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxIterations = -1 }, wantErr: true},
 		{name: "negative max cost", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxCostUSD = -1 }, wantErr: true},
+		{name: "NaN max cost", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxCostUSD = math.NaN() }, wantErr: true},
+		{name: "infinite max cost", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxCostUSD = math.Inf(1) }, wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/store/policy_test.go
+++ b/internal/store/policy_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+)
+
+func TestAdjudicationPolicyV1_RoundTrip(t *testing.T) {
+	policy := AdjudicationPolicyV1{
+		SchemaVersion: CurrentSchemaVersion,
+		Source: PolicySourceV1{
+			Kind:          config.SourceKindRepositoryRevision,
+			Locator:       "/repo",
+			Ref:           "refs/acr/trusted-config/origin/main",
+			Revision:      "trustedsha",
+			ConfigPresent: true,
+			ConfigDigest:  "digest",
+		},
+		Budget:             BudgetPolicyV1{MaxIterations: 5, MaxCostUSD: 10},
+		Stop:               StopPolicyV1{StopOnCleanRun: true, StopOnNoNewFindings: true},
+		EvaluationGuidance: "prefer precision over recall",
+	}
+
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	data, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded AdjudicationPolicyV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, policy) {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, policy)
+	}
+}
+
+func TestAdjudicationPolicyV1_Validate(t *testing.T) {
+	valid := func() AdjudicationPolicyV1 {
+		return AdjudicationPolicyV1{
+			SchemaVersion: CurrentSchemaVersion,
+			Source:        PolicySourceV1{Kind: config.SourceKindDefaults},
+			Budget:        BudgetPolicyV1{MaxIterations: 3, MaxCostUSD: 5},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(p *AdjudicationPolicyV1)
+		wantErr bool
+	}{
+		{name: "valid", mutate: func(p *AdjudicationPolicyV1) {}, wantErr: false},
+		{name: "unsupported schema version", mutate: func(p *AdjudicationPolicyV1) { p.SchemaVersion = 99 }, wantErr: true},
+		{name: "filesystem source rejected", mutate: func(p *AdjudicationPolicyV1) { p.Source = PolicySourceV1{Kind: config.SourceKindFilesystem} }, wantErr: true},
+		{name: "empty source kind rejected", mutate: func(p *AdjudicationPolicyV1) { p.Source = PolicySourceV1{} }, wantErr: true},
+		{name: "negative max iterations", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxIterations = -1 }, wantErr: true},
+		{name: "negative max cost", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxCostUSD = -1 }, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := valid()
+			tt.mutate(&policy)
+			err := policy.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/store/race_test.go
+++ b/internal/store/race_test.go
@@ -1,0 +1,132 @@
+package store
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestConcurrentWriterAndReader_NoRaceAndNoTornReads(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+
+	writeLock, err := AcquireWriteLock(dir)
+	if err != nil {
+		t.Fatalf("acquire write lock: %v", err)
+	}
+	defer writeLock.Release()
+
+	runStore := NewFilesystemRunStore(dir)
+	eventStore := NewFilesystemEventStore(dir)
+
+	const writes = 40
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		base := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+		for i := 0; i < writes; i++ {
+			run := buildTestReviewRunSchema(t, fmt.Sprintf("run-race-%d", i), base.Add(time.Duration(i)*time.Second))
+			if _, err := runStore.SaveRun(run); err != nil {
+				t.Errorf("save run %d: %v", i, err)
+				return
+			}
+			event := testReviewEvent(fmt.Sprintf("event-race-%d", i), base.Add(time.Duration(i)*time.Second))
+			if _, err := eventStore.AppendEvent(event); err != nil {
+				t.Errorf("append event %d: %v", i, err)
+				return
+			}
+		}
+	}()
+
+	readerStore := NewFilesystemRunStore(dir)
+	readerEvents := NewFilesystemEventStore(dir)
+	stop := make(chan struct{})
+	var readerWG sync.WaitGroup
+	readerWG.Add(2)
+	go func() {
+		defer readerWG.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			runs, corrupt, err := readerStore.ListRuns(key)
+			if err != nil {
+				t.Errorf("concurrent list runs: %v", err)
+				return
+			}
+			if len(corrupt) != 0 {
+				t.Errorf("concurrent reader observed corrupt runs: %+v", corrupt)
+				return
+			}
+			for _, run := range runs {
+				if run.ID == "" {
+					t.Errorf("concurrent reader observed a torn run record")
+					return
+				}
+			}
+		}
+	}()
+	go func() {
+		defer readerWG.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			events, corrupt, err := readerEvents.ListEvents(key)
+			if err != nil {
+				t.Errorf("concurrent list events: %v", err)
+				return
+			}
+			if len(corrupt) != 0 {
+				t.Errorf("concurrent reader observed corrupt events: %+v", corrupt)
+				return
+			}
+			for _, event := range events {
+				if event.ID == "" {
+					t.Errorf("concurrent reader observed a torn event record")
+					return
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	readerWG.Wait()
+
+	runs, corrupt, err := readerStore.ListRuns(key)
+	if err != nil {
+		t.Fatalf("final list runs: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt runs, got %+v", corrupt)
+	}
+	if len(runs) != writes {
+		t.Fatalf("expected %d runs, got %d", writes, len(runs))
+	}
+}
+
+func TestSecondWriterRefusesWhileFirstHoldsLock(t *testing.T) {
+	dir := t.TempDir()
+
+	firstWriter, err := AcquireWriteLock(dir)
+	if err != nil {
+		t.Fatalf("first writer acquire: %v", err)
+	}
+	defer firstWriter.Release()
+
+	readerStore := NewFilesystemRunStore(dir)
+	if _, _, err := readerStore.ListRuns(testPullRequestKey()); err != nil {
+		t.Fatalf("read-only access must not require the writer lock: %v", err)
+	}
+
+	if _, err := AcquireWriteLock(dir); err == nil {
+		t.Fatal("expected a second writer to refuse cleanly while the first holds the lock")
+	}
+}

--- a/internal/store/reviewer.go
+++ b/internal/store/reviewer.go
@@ -1,0 +1,286 @@
+package store
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type ReviewerFailureKindV1 string
+
+const (
+	ReviewerFailureKindExecution   ReviewerFailureKindV1 = "execution"
+	ReviewerFailureKindExit        ReviewerFailureKindV1 = "exit"
+	ReviewerFailureKindTimeout     ReviewerFailureKindV1 = "timeout"
+	ReviewerFailureKindAuth        ReviewerFailureKindV1 = "authentication"
+	ReviewerFailureKindInterrupted ReviewerFailureKindV1 = "interrupted"
+	ReviewerFailureKindParser      ReviewerFailureKindV1 = "parser"
+)
+
+func toReviewerFailureKindSchema(kind domain.ReviewerFailureKind) (ReviewerFailureKindV1, error) {
+	switch kind {
+	case domain.ReviewerFailureExecution:
+		return ReviewerFailureKindExecution, nil
+	case domain.ReviewerFailureExit:
+		return ReviewerFailureKindExit, nil
+	case domain.ReviewerFailureTimeout:
+		return ReviewerFailureKindTimeout, nil
+	case domain.ReviewerFailureAuth:
+		return ReviewerFailureKindAuth, nil
+	case domain.ReviewerFailureInterrupted:
+		return ReviewerFailureKindInterrupted, nil
+	case domain.ReviewerFailureParser:
+		return ReviewerFailureKindParser, nil
+	default:
+		return "", fmt.Errorf("unknown reviewer failure kind %q", kind)
+	}
+}
+
+func (k ReviewerFailureKindV1) ToDomain() (domain.ReviewerFailureKind, error) {
+	switch k {
+	case ReviewerFailureKindExecution:
+		return domain.ReviewerFailureExecution, nil
+	case ReviewerFailureKindExit:
+		return domain.ReviewerFailureExit, nil
+	case ReviewerFailureKindTimeout:
+		return domain.ReviewerFailureTimeout, nil
+	case ReviewerFailureKindAuth:
+		return domain.ReviewerFailureAuth, nil
+	case ReviewerFailureKindInterrupted:
+		return domain.ReviewerFailureInterrupted, nil
+	case ReviewerFailureKindParser:
+		return domain.ReviewerFailureParser, nil
+	default:
+		return "", fmt.Errorf("unknown stored reviewer failure kind %q", k)
+	}
+}
+
+type ReviewerFailureV1 struct {
+	Kind    ReviewerFailureKindV1 `json:"kind"`
+	Message string                `json:"message"`
+}
+
+func ToReviewerFailureSchema(f *domain.ReviewerFailure) (*ReviewerFailureV1, error) {
+	if f == nil {
+		return nil, nil
+	}
+	kind, err := toReviewerFailureKindSchema(f.Kind)
+	if err != nil {
+		return nil, err
+	}
+	return &ReviewerFailureV1{Kind: kind, Message: f.Message}, nil
+}
+
+func (f *ReviewerFailureV1) ToDomain() (*domain.ReviewerFailure, error) {
+	if f == nil {
+		return nil, nil
+	}
+	kind, err := f.Kind.ToDomain()
+	if err != nil {
+		return nil, err
+	}
+	return &domain.ReviewerFailure{Kind: kind, Message: f.Message}, nil
+}
+
+const ReviewerWarningKindCleanupV1 = "cleanup"
+
+type ReviewerWarningV1 struct {
+	Kind    string `json:"kind"`
+	Message string `json:"message"`
+}
+
+func ToReviewerWarningSchema(w domain.ReviewerWarning) (ReviewerWarningV1, error) {
+	if w.Kind != domain.ReviewerWarningCleanup {
+		return ReviewerWarningV1{}, fmt.Errorf("unknown reviewer warning kind %q", w.Kind)
+	}
+	return ReviewerWarningV1{Kind: ReviewerWarningKindCleanupV1, Message: w.Message}, nil
+}
+
+func (w ReviewerWarningV1) ToDomain() (domain.ReviewerWarning, error) {
+	if w.Kind != ReviewerWarningKindCleanupV1 {
+		return domain.ReviewerWarning{}, fmt.Errorf("unknown stored reviewer warning kind %q", w.Kind)
+	}
+	return domain.ReviewerWarning{Kind: domain.ReviewerWarningCleanup, Message: w.Message}, nil
+}
+
+func toReviewerWarningSchemaSlice(warnings []domain.ReviewerWarning) ([]ReviewerWarningV1, error) {
+	out := make([]ReviewerWarningV1, 0, len(warnings))
+	for _, w := range warnings {
+		schema, err := ToReviewerWarningSchema(w)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, schema)
+	}
+	return out, nil
+}
+
+func toReviewerWarningDomainSlice(warnings []ReviewerWarningV1) ([]domain.ReviewerWarning, error) {
+	out := make([]domain.ReviewerWarning, 0, len(warnings))
+	for _, w := range warnings {
+		d, err := w.ToDomain()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+type ReviewerResultV1 struct {
+	ReviewerID  int                 `json:"reviewer_id"`
+	AgentName   string              `json:"agent_name"`
+	Findings    []FindingV1         `json:"findings"`
+	ExitCode    int                 `json:"exit_code"`
+	Attempts    int                 `json:"attempts"`
+	ParseErrors int                 `json:"parse_errors"`
+	TimedOut    bool                `json:"timed_out"`
+	AuthFailed  bool                `json:"auth_failed"`
+	Duration    time.Duration       `json:"duration"`
+	Failure     *ReviewerFailureV1  `json:"failure,omitempty"`
+	Warnings    []ReviewerWarningV1 `json:"warnings,omitempty"`
+}
+
+func ToReviewerResultSchema(r domain.ReviewerResult) (ReviewerResultV1, error) {
+	failure, err := ToReviewerFailureSchema(r.Failure)
+	if err != nil {
+		return ReviewerResultV1{}, fmt.Errorf("reviewer %d: %w", r.ReviewerID, err)
+	}
+	warnings, err := toReviewerWarningSchemaSlice(r.Warnings)
+	if err != nil {
+		return ReviewerResultV1{}, fmt.Errorf("reviewer %d: %w", r.ReviewerID, err)
+	}
+	return ReviewerResultV1{
+		ReviewerID:  r.ReviewerID,
+		AgentName:   r.AgentName,
+		Findings:    toFindingSchemaSlice(r.Findings),
+		ExitCode:    r.ExitCode,
+		Attempts:    r.Attempts,
+		ParseErrors: r.ParseErrors,
+		TimedOut:    r.TimedOut,
+		AuthFailed:  r.AuthFailed,
+		Duration:    r.Duration,
+		Failure:     failure,
+		Warnings:    warnings,
+	}, nil
+}
+
+func (r ReviewerResultV1) ToDomain() (domain.ReviewerResult, error) {
+	failure, err := r.Failure.ToDomain()
+	if err != nil {
+		return domain.ReviewerResult{}, fmt.Errorf("reviewer %d: %w", r.ReviewerID, err)
+	}
+	warnings, err := toReviewerWarningDomainSlice(r.Warnings)
+	if err != nil {
+		return domain.ReviewerResult{}, fmt.Errorf("reviewer %d: %w", r.ReviewerID, err)
+	}
+	return domain.ReviewerResult{
+		ReviewerID:  r.ReviewerID,
+		AgentName:   r.AgentName,
+		Findings:    toFindingDomainSlice(r.Findings),
+		ExitCode:    r.ExitCode,
+		Attempts:    r.Attempts,
+		ParseErrors: r.ParseErrors,
+		TimedOut:    r.TimedOut,
+		AuthFailed:  r.AuthFailed,
+		Duration:    r.Duration,
+		Failure:     failure,
+		Warnings:    warnings,
+	}, nil
+}
+
+func toReviewerResultSchemaSlice(results []domain.ReviewerResult) ([]ReviewerResultV1, error) {
+	out := make([]ReviewerResultV1, 0, len(results))
+	for _, r := range results {
+		schema, err := ToReviewerResultSchema(r)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, schema)
+	}
+	return out, nil
+}
+
+func toReviewerResultDomainSlice(results []ReviewerResultV1) ([]domain.ReviewerResult, error) {
+	out := make([]domain.ReviewerResult, 0, len(results))
+	for _, r := range results {
+		d, err := r.ToDomain()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+type ReviewStatsV1 struct {
+	TotalReviewers      int                   `json:"total_reviewers"`
+	SuccessfulReviewers int                   `json:"successful_reviewers"`
+	FailedReviewers     []int                 `json:"failed_reviewers"`
+	TimedOutReviewers   []int                 `json:"timed_out_reviewers"`
+	AuthFailedReviewers []int                 `json:"auth_failed_reviewers"`
+	ParseErrors         int                   `json:"parse_errors"`
+	ReviewerDurations   map[int]time.Duration `json:"reviewer_durations"`
+	ReviewerAgentNames  map[int]string        `json:"reviewer_agent_names"`
+	WallClockDuration   time.Duration         `json:"wall_clock_duration"`
+	SummarizerDuration  time.Duration         `json:"summarizer_duration"`
+	FPFilterDuration    time.Duration         `json:"fp_filter_duration"`
+	FPFilteredCount     int                   `json:"fp_filtered_count"`
+}
+
+func cloneIntDurationMap(m map[int]time.Duration) map[int]time.Duration {
+	if m == nil {
+		return nil
+	}
+	out := make(map[int]time.Duration, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneIntStringMap(m map[int]string) map[int]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[int]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func ToReviewStatsSchema(s domain.ReviewStats) ReviewStatsV1 {
+	return ReviewStatsV1{
+		TotalReviewers:      s.TotalReviewers,
+		SuccessfulReviewers: s.SuccessfulReviewers,
+		FailedReviewers:     append([]int(nil), s.FailedReviewers...),
+		TimedOutReviewers:   append([]int(nil), s.TimedOutReviewers...),
+		AuthFailedReviewers: append([]int(nil), s.AuthFailedReviewers...),
+		ParseErrors:         s.ParseErrors,
+		ReviewerDurations:   cloneIntDurationMap(s.ReviewerDurations),
+		ReviewerAgentNames:  cloneIntStringMap(s.ReviewerAgentNames),
+		WallClockDuration:   s.WallClockDuration,
+		SummarizerDuration:  s.SummarizerDuration,
+		FPFilterDuration:    s.FPFilterDuration,
+		FPFilteredCount:     s.FPFilteredCount,
+	}
+}
+
+func (s ReviewStatsV1) ToDomain() domain.ReviewStats {
+	return domain.ReviewStats{
+		TotalReviewers:      s.TotalReviewers,
+		SuccessfulReviewers: s.SuccessfulReviewers,
+		FailedReviewers:     append([]int(nil), s.FailedReviewers...),
+		TimedOutReviewers:   append([]int(nil), s.TimedOutReviewers...),
+		AuthFailedReviewers: append([]int(nil), s.AuthFailedReviewers...),
+		ParseErrors:         s.ParseErrors,
+		ReviewerDurations:   cloneIntDurationMap(s.ReviewerDurations),
+		ReviewerAgentNames:  cloneIntStringMap(s.ReviewerAgentNames),
+		WallClockDuration:   s.WallClockDuration,
+		SummarizerDuration:  s.SummarizerDuration,
+		FPFilterDuration:    s.FPFilterDuration,
+		FPFilteredCount:     s.FPFilteredCount,
+	}
+}

--- a/internal/store/reviewer_test.go
+++ b/internal/store/reviewer_test.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+func TestReviewerResultV1_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		result domain.ReviewerResult
+	}{
+		{
+			name: "successful reviewer",
+			result: domain.ReviewerResult{
+				ReviewerID: 0,
+				AgentName:  "claude",
+				Findings:   []domain.Finding{{Text: "issue", ReviewerID: 0}},
+				ExitCode:   0,
+				Attempts:   1,
+				Duration:   3 * time.Second,
+			},
+		},
+		{
+			name: "failed reviewer with warnings",
+			result: domain.ReviewerResult{
+				ReviewerID:  1,
+				AgentName:   "codex",
+				ExitCode:    1,
+				Attempts:    2,
+				ParseErrors: 1,
+				TimedOut:    true,
+				Duration:    30 * time.Second,
+				Failure:     &domain.ReviewerFailure{Kind: domain.ReviewerFailureTimeout, Message: "deadline exceeded"},
+				Warnings:    []domain.ReviewerWarning{{Kind: domain.ReviewerWarningCleanup, Message: "temp dir cleanup failed"}},
+			},
+		},
+		{
+			name: "interrupted reviewer retains agent identity",
+			result: domain.ReviewerResult{
+				ReviewerID: 2,
+				AgentName:  "antigravity",
+				Failure:    &domain.ReviewerFailure{Kind: domain.ReviewerFailureInterrupted, Message: "canceled"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema, err := ToReviewerResultSchema(tt.result)
+			if err != nil {
+				t.Fatalf("ToReviewerResultSchema: %v", err)
+			}
+			data, err := json.Marshal(schema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded ReviewerResultV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got, err := decoded.ToDomain()
+			if err != nil {
+				t.Fatalf("ToDomain: %v", err)
+			}
+			if got.ReviewerID != tt.result.ReviewerID || got.AgentName != tt.result.AgentName {
+				t.Fatalf("identity mismatch: got %+v, want %+v", got, tt.result)
+			}
+			if (got.Failure == nil) != (tt.result.Failure == nil) {
+				t.Fatalf("failure presence mismatch: got %+v, want %+v", got.Failure, tt.result.Failure)
+			}
+			if got.Failure != nil && *got.Failure != *tt.result.Failure {
+				t.Fatalf("failure mismatch: got %+v, want %+v", *got.Failure, *tt.result.Failure)
+			}
+			if len(got.Warnings) != len(tt.result.Warnings) {
+				t.Fatalf("warnings length mismatch: got %d, want %d", len(got.Warnings), len(tt.result.Warnings))
+			}
+		})
+	}
+}
+
+func TestReviewStatsV1_RoundTrip(t *testing.T) {
+	stats := domain.ReviewStats{
+		TotalReviewers:      3,
+		SuccessfulReviewers: 2,
+		FailedReviewers:     []int{2},
+		TimedOutReviewers:   []int{},
+		AuthFailedReviewers: []int{},
+		ParseErrors:         1,
+		ReviewerDurations:   map[int]time.Duration{0: time.Second, 1: 2 * time.Second},
+		ReviewerAgentNames:  map[int]string{0: "claude", 1: "codex", 2: "antigravity"},
+		WallClockDuration:   5 * time.Second,
+		SummarizerDuration:  time.Second,
+		FPFilterDuration:    time.Second,
+		FPFilteredCount:     1,
+	}
+
+	schema := ToReviewStatsSchema(stats)
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ReviewStatsV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := decoded.ToDomain()
+	if got.TotalReviewers != stats.TotalReviewers || got.ReviewerAgentNames[1] != "codex" || got.ReviewerDurations[0] != time.Second {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, stats)
+	}
+}

--- a/internal/store/run.go
+++ b/internal/store/run.go
@@ -112,30 +112,24 @@ func (f *RunFailureV1) ToDomain() (*domain.ReviewFailure, error) {
 }
 
 type SummarizerOutcomeV1 struct {
-	ExitCode         int           `json:"exit_code"`
-	Stderr           string        `json:"stderr"`
-	DiagnosticOutput string        `json:"diagnostic_output"`
-	Duration         time.Duration `json:"duration"`
-	Warnings         []string      `json:"warnings,omitempty"`
+	ExitCode int           `json:"exit_code"`
+	Duration time.Duration `json:"duration"`
+	Warnings []string      `json:"warnings,omitempty"`
 }
 
 func ToSummarizerOutcomeSchema(s domain.SummarizerOutcome) SummarizerOutcomeV1 {
 	return SummarizerOutcomeV1{
-		ExitCode:         s.ExitCode,
-		Stderr:           s.Stderr,
-		DiagnosticOutput: s.DiagnosticOutput,
-		Duration:         s.Duration,
-		Warnings:         append([]string(nil), s.Warnings...),
+		ExitCode: s.ExitCode,
+		Duration: s.Duration,
+		Warnings: append([]string(nil), s.Warnings...),
 	}
 }
 
 func (s SummarizerOutcomeV1) ToDomain() domain.SummarizerOutcome {
 	return domain.SummarizerOutcome{
-		ExitCode:         s.ExitCode,
-		Stderr:           s.Stderr,
-		DiagnosticOutput: s.DiagnosticOutput,
-		Duration:         s.Duration,
-		Warnings:         append([]string(nil), s.Warnings...),
+		ExitCode: s.ExitCode,
+		Duration: s.Duration,
+		Warnings: append([]string(nil), s.Warnings...),
 	}
 }
 
@@ -216,14 +210,6 @@ type RenderedOutcomeV1 struct {
 	LGTMBody   string `json:"lgtm_body"`
 }
 
-type RunLifecycleV1 struct {
-	Stale             bool      `json:"stale"`
-	StaleReason       string    `json:"stale_reason,omitempty"`
-	StaleAt           time.Time `json:"stale_at,omitempty"`
-	SupersededByRunID string    `json:"superseded_by_run_id,omitempty"`
-	SupersededAt      time.Time `json:"superseded_at,omitempty"`
-}
-
 type ReviewRunV1 struct {
 	SchemaVersion            int                           `json:"schema_version"`
 	ID                       string                        `json:"id"`
@@ -251,7 +237,6 @@ type ReviewRunV1 struct {
 	ExcludeFilter            ExcludeFilterOutcomeV1        `json:"exclude_filter"`
 	Dispositions             map[int]DispositionV1         `json:"dispositions"`
 	Rendered                 RenderedOutcomeV1             `json:"rendered"`
-	Lifecycle                RunLifecycleV1                `json:"lifecycle"`
 }
 
 func ToReviewRunSchema(run domain.ReviewRun, rendered RenderedOutcomeV1) (ReviewRunV1, error) {
@@ -348,6 +333,12 @@ func FromReviewRunSchema(schema ReviewRunV1) (domain.ReviewRun, RenderedOutcomeV
 	configuration, err := schema.Configuration.ToDomain()
 	if err != nil {
 		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	if schema.ConfigurationFingerprint != configuration.Fingerprint() {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf(
+			"run %s: top-level configuration_fingerprint %q does not match configuration fingerprint %q; record may be corrupt",
+			schema.ID, schema.ConfigurationFingerprint, configuration.Fingerprint(),
+		)
 	}
 
 	configurationSource := schema.ConfigurationSource.ToDomain()

--- a/internal/store/run.go
+++ b/internal/store/run.go
@@ -112,24 +112,30 @@ func (f *RunFailureV1) ToDomain() (*domain.ReviewFailure, error) {
 }
 
 type SummarizerOutcomeV1 struct {
-	ExitCode int           `json:"exit_code"`
-	Duration time.Duration `json:"duration"`
-	Warnings []string      `json:"warnings,omitempty"`
+	ExitCode         int           `json:"exit_code"`
+	Stderr           string        `json:"stderr,omitempty"`
+	DiagnosticOutput string        `json:"diagnostic_output,omitempty"`
+	Duration         time.Duration `json:"duration"`
+	Warnings         []string      `json:"warnings,omitempty"`
 }
 
 func ToSummarizerOutcomeSchema(s domain.SummarizerOutcome) SummarizerOutcomeV1 {
 	return SummarizerOutcomeV1{
-		ExitCode: s.ExitCode,
-		Duration: s.Duration,
-		Warnings: append([]string(nil), s.Warnings...),
+		ExitCode:         s.ExitCode,
+		Stderr:           s.Stderr,
+		DiagnosticOutput: s.DiagnosticOutput,
+		Duration:         s.Duration,
+		Warnings:         append([]string(nil), s.Warnings...),
 	}
 }
 
 func (s SummarizerOutcomeV1) ToDomain() domain.SummarizerOutcome {
 	return domain.SummarizerOutcome{
-		ExitCode: s.ExitCode,
-		Duration: s.Duration,
-		Warnings: append([]string(nil), s.Warnings...),
+		ExitCode:         s.ExitCode,
+		Stderr:           s.Stderr,
+		DiagnosticOutput: s.DiagnosticOutput,
+		Duration:         s.Duration,
+		Warnings:         append([]string(nil), s.Warnings...),
 	}
 }
 

--- a/internal/store/run.go
+++ b/internal/store/run.go
@@ -1,0 +1,448 @@
+package store
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+type ReviewPhaseV1 string
+
+const (
+	ReviewPhaseInitializationV1      ReviewPhaseV1 = "initialization"
+	ReviewPhaseRevisionsV1           ReviewPhaseV1 = "revisions"
+	ReviewPhaseDiffV1                ReviewPhaseV1 = "diff"
+	ReviewPhaseReviewersV1           ReviewPhaseV1 = "reviewers"
+	ReviewPhaseFeedbackV1            ReviewPhaseV1 = "feedback"
+	ReviewPhaseSummarizationV1       ReviewPhaseV1 = "summarization"
+	ReviewPhaseFalsePositiveFilterV1 ReviewPhaseV1 = "false_positive_filter"
+	ReviewPhaseExcludeFilterV1       ReviewPhaseV1 = "exclude_filter"
+	ReviewPhaseCompleteV1            ReviewPhaseV1 = "complete"
+)
+
+func toReviewPhaseSchema(phase domain.ReviewPhase) (ReviewPhaseV1, error) {
+	switch phase {
+	case domain.ReviewPhaseInitialization:
+		return ReviewPhaseInitializationV1, nil
+	case domain.ReviewPhaseRevisions:
+		return ReviewPhaseRevisionsV1, nil
+	case domain.ReviewPhaseDiff:
+		return ReviewPhaseDiffV1, nil
+	case domain.ReviewPhaseReviewers:
+		return ReviewPhaseReviewersV1, nil
+	case domain.ReviewPhaseFeedback:
+		return ReviewPhaseFeedbackV1, nil
+	case domain.ReviewPhaseSummarization:
+		return ReviewPhaseSummarizationV1, nil
+	case domain.ReviewPhaseFalsePositiveFilter:
+		return ReviewPhaseFalsePositiveFilterV1, nil
+	case domain.ReviewPhaseExcludeFilter:
+		return ReviewPhaseExcludeFilterV1, nil
+	case domain.ReviewPhaseComplete:
+		return ReviewPhaseCompleteV1, nil
+	default:
+		return "", fmt.Errorf("unknown review phase %q", phase)
+	}
+}
+
+func (p ReviewPhaseV1) ToDomain() (domain.ReviewPhase, error) {
+	switch p {
+	case ReviewPhaseInitializationV1:
+		return domain.ReviewPhaseInitialization, nil
+	case ReviewPhaseRevisionsV1:
+		return domain.ReviewPhaseRevisions, nil
+	case ReviewPhaseDiffV1:
+		return domain.ReviewPhaseDiff, nil
+	case ReviewPhaseReviewersV1:
+		return domain.ReviewPhaseReviewers, nil
+	case ReviewPhaseFeedbackV1:
+		return domain.ReviewPhaseFeedback, nil
+	case ReviewPhaseSummarizationV1:
+		return domain.ReviewPhaseSummarization, nil
+	case ReviewPhaseFalsePositiveFilterV1:
+		return domain.ReviewPhaseFalsePositiveFilter, nil
+	case ReviewPhaseExcludeFilterV1:
+		return domain.ReviewPhaseExcludeFilter, nil
+	case ReviewPhaseCompleteV1:
+		return domain.ReviewPhaseComplete, nil
+	default:
+		return "", fmt.Errorf("unknown stored review phase %q", p)
+	}
+}
+
+type EngineV1 struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func ToEngineSchema(e domain.ReviewEngine) EngineV1 {
+	return EngineV1{Name: e.Name, Version: e.Version}
+}
+
+func (e EngineV1) ToDomain() domain.ReviewEngine {
+	return domain.ReviewEngine{Name: e.Name, Version: e.Version}
+}
+
+type RunFailureV1 struct {
+	Phase   ReviewPhaseV1 `json:"phase"`
+	Message string        `json:"message"`
+}
+
+func ToRunFailureSchema(f *domain.ReviewFailure) (*RunFailureV1, error) {
+	if f == nil {
+		return nil, nil
+	}
+	phase, err := toReviewPhaseSchema(f.Phase)
+	if err != nil {
+		return nil, err
+	}
+	return &RunFailureV1{Phase: phase, Message: f.Message}, nil
+}
+
+func (f *RunFailureV1) ToDomain() (*domain.ReviewFailure, error) {
+	if f == nil {
+		return nil, nil
+	}
+	phase, err := f.Phase.ToDomain()
+	if err != nil {
+		return nil, err
+	}
+	return &domain.ReviewFailure{Phase: phase, Message: f.Message}, nil
+}
+
+type SummarizerOutcomeV1 struct {
+	ExitCode         int           `json:"exit_code"`
+	Stderr           string        `json:"stderr"`
+	DiagnosticOutput string        `json:"diagnostic_output"`
+	Duration         time.Duration `json:"duration"`
+	Warnings         []string      `json:"warnings,omitempty"`
+}
+
+func ToSummarizerOutcomeSchema(s domain.SummarizerOutcome) SummarizerOutcomeV1 {
+	return SummarizerOutcomeV1{
+		ExitCode:         s.ExitCode,
+		Stderr:           s.Stderr,
+		DiagnosticOutput: s.DiagnosticOutput,
+		Duration:         s.Duration,
+		Warnings:         append([]string(nil), s.Warnings...),
+	}
+}
+
+func (s SummarizerOutcomeV1) ToDomain() domain.SummarizerOutcome {
+	return domain.SummarizerOutcome{
+		ExitCode:         s.ExitCode,
+		Stderr:           s.Stderr,
+		DiagnosticOutput: s.DiagnosticOutput,
+		Duration:         s.Duration,
+		Warnings:         append([]string(nil), s.Warnings...),
+	}
+}
+
+type FalsePositiveFilterOutcomeV1 struct {
+	Enabled    bool              `json:"enabled"`
+	Applied    bool              `json:"applied"`
+	Skipped    bool              `json:"skipped"`
+	SkipReason string            `json:"skip_reason"`
+	EvalErrors int               `json:"eval_errors"`
+	Duration   time.Duration     `json:"duration"`
+	Warnings   []string          `json:"warnings,omitempty"`
+	Removed    []ReviewFindingV1 `json:"removed"`
+}
+
+func ToFalsePositiveFilterOutcomeSchema(o domain.FalsePositiveFilterOutcome) (FalsePositiveFilterOutcomeV1, error) {
+	removed, err := toReviewFindingSchemaSlice(o.Removed)
+	if err != nil {
+		return FalsePositiveFilterOutcomeV1{}, fmt.Errorf("false positive filter outcome: %w", err)
+	}
+	return FalsePositiveFilterOutcomeV1{
+		Enabled:    o.Enabled,
+		Applied:    o.Applied,
+		Skipped:    o.Skipped,
+		SkipReason: o.SkipReason,
+		EvalErrors: o.EvalErrors,
+		Duration:   o.Duration,
+		Warnings:   append([]string(nil), o.Warnings...),
+		Removed:    removed,
+	}, nil
+}
+
+func (o FalsePositiveFilterOutcomeV1) ToDomain() (domain.FalsePositiveFilterOutcome, error) {
+	removed, err := toReviewFindingDomainSlice(o.Removed)
+	if err != nil {
+		return domain.FalsePositiveFilterOutcome{}, fmt.Errorf("false positive filter outcome: %w", err)
+	}
+	return domain.FalsePositiveFilterOutcome{
+		Enabled:    o.Enabled,
+		Applied:    o.Applied,
+		Skipped:    o.Skipped,
+		SkipReason: o.SkipReason,
+		EvalErrors: o.EvalErrors,
+		Duration:   o.Duration,
+		Warnings:   append([]string(nil), o.Warnings...),
+		Removed:    removed,
+	}, nil
+}
+
+type ExcludeFilterOutcomeV1 struct {
+	Patterns []string          `json:"patterns"`
+	Removed  []ReviewFindingV1 `json:"removed"`
+}
+
+func ToExcludeFilterOutcomeSchema(o domain.ExcludeFilterOutcome) (ExcludeFilterOutcomeV1, error) {
+	removed, err := toReviewFindingSchemaSlice(o.Removed)
+	if err != nil {
+		return ExcludeFilterOutcomeV1{}, fmt.Errorf("exclude filter outcome: %w", err)
+	}
+	return ExcludeFilterOutcomeV1{
+		Patterns: append([]string(nil), o.Patterns...),
+		Removed:  removed,
+	}, nil
+}
+
+func (o ExcludeFilterOutcomeV1) ToDomain() (domain.ExcludeFilterOutcome, error) {
+	removed, err := toReviewFindingDomainSlice(o.Removed)
+	if err != nil {
+		return domain.ExcludeFilterOutcome{}, fmt.Errorf("exclude filter outcome: %w", err)
+	}
+	return domain.ExcludeFilterOutcome{
+		Patterns: append([]string(nil), o.Patterns...),
+		Removed:  removed,
+	}, nil
+}
+
+// RenderedOutcomeV1 preserves the exact review and LGTM bodies that were
+// rendered for this run, if any were rendered. Text is preserved verbatim
+// rather than being re-derived from other stored fields on read, so a later
+// change to rendering logic cannot rewrite what a user actually saw or
+// posted. Both fields are commonly empty: many runs are never rendered for
+// posting (for example a clean run, or a run inspected only in history).
+type RenderedOutcomeV1 struct {
+	ReviewBody string `json:"review_body"`
+	LGTMBody   string `json:"lgtm_body"`
+}
+
+// RunLifecycleV1 records desk-level transitions applied to an already
+// completed, failed, or interrupted run after the fact. These transitions
+// never rewrite the original terminal outcome; they are recorded alongside
+// it so history stays honest about both what happened during execution and
+// what the desk later learned (for example, that the head moved and the
+// result is now stale).
+type RunLifecycleV1 struct {
+	Stale             bool      `json:"stale"`
+	StaleReason       string    `json:"stale_reason,omitempty"`
+	StaleAt           time.Time `json:"stale_at,omitempty"`
+	SupersededByRunID string    `json:"superseded_by_run_id,omitempty"`
+	SupersededAt      time.Time `json:"superseded_at,omitempty"`
+}
+
+type ReviewRunV1 struct {
+	SchemaVersion            int                           `json:"schema_version"`
+	ID                       string                        `json:"id"`
+	Target                   ReviewTargetV1                `json:"target"`
+	Trigger                  string                        `json:"trigger"`
+	Engine                   EngineV1                      `json:"engine"`
+	StartedAt                time.Time                     `json:"started_at"`
+	CompletedAt              time.Time                     `json:"completed_at"`
+	Configuration            ReviewConfigurationV1         `json:"configuration"`
+	ConfigurationSource      ConfigurationSourceIdentityV1 `json:"configuration_source"`
+	ConfigurationFingerprint string                        `json:"configuration_fingerprint"`
+	Status                   string                        `json:"status"`
+	Conclusion               string                        `json:"conclusion"`
+	Failure                  *RunFailureV1                 `json:"failure,omitempty"`
+	ReviewerResults          []ReviewerResultV1            `json:"reviewer_results"`
+	Stats                    ReviewStatsV1                 `json:"stats"`
+	Summarizer               SummarizerOutcomeV1           `json:"summarizer"`
+	RawFindings              []FindingV1                   `json:"raw_findings"`
+	AggregatedFindings       []AggregatedFindingV1         `json:"aggregated_findings"`
+	PreFilterSummary         GroupedFindingsV1             `json:"pre_filter_summary"`
+	FindingRecords           []ReviewFindingV1             `json:"finding_records"`
+	Findings                 []ReviewFindingV1             `json:"findings"`
+	Info                     []ReviewFindingV1             `json:"info"`
+	FalsePositiveFilter      FalsePositiveFilterOutcomeV1  `json:"false_positive_filter"`
+	ExcludeFilter            ExcludeFilterOutcomeV1        `json:"exclude_filter"`
+	Dispositions             map[int]DispositionV1         `json:"dispositions"`
+	Rendered                 RenderedOutcomeV1             `json:"rendered"`
+	Lifecycle                RunLifecycleV1                `json:"lifecycle"`
+}
+
+func ToReviewRunSchema(run domain.ReviewRun, rendered RenderedOutcomeV1) (ReviewRunV1, error) {
+	failure, err := ToRunFailureSchema(run.Failure)
+	if err != nil {
+		return ReviewRunV1{}, fmt.Errorf("run %s: %w", run.ID, err)
+	}
+	reviewerResults, err := toReviewerResultSchemaSlice(run.ReviewerResults)
+	if err != nil {
+		return ReviewRunV1{}, fmt.Errorf("run %s: %w", run.ID, err)
+	}
+	findingRecords, err := toReviewFindingSchemaSlice(run.FindingRecords)
+	if err != nil {
+		return ReviewRunV1{}, fmt.Errorf("run %s: %w", run.ID, err)
+	}
+	findings, err := toReviewFindingSchemaSlice(run.Findings)
+	if err != nil {
+		return ReviewRunV1{}, fmt.Errorf("run %s: %w", run.ID, err)
+	}
+	info, err := toReviewFindingSchemaSlice(run.Info)
+	if err != nil {
+		return ReviewRunV1{}, fmt.Errorf("run %s: %w", run.ID, err)
+	}
+	fpFilter, err := ToFalsePositiveFilterOutcomeSchema(run.FalsePositiveFilter)
+	if err != nil {
+		return ReviewRunV1{}, fmt.Errorf("run %s: %w", run.ID, err)
+	}
+	excludeFilter, err := ToExcludeFilterOutcomeSchema(run.ExcludeFilter)
+	if err != nil {
+		return ReviewRunV1{}, fmt.Errorf("run %s: %w", run.ID, err)
+	}
+	dispositions := make(map[int]DispositionV1, len(run.Dispositions))
+	for id, disposition := range run.Dispositions {
+		schema, err := ToDispositionSchema(disposition)
+		if err != nil {
+			return ReviewRunV1{}, fmt.Errorf("run %s: disposition %d: %w", run.ID, id, err)
+		}
+		dispositions[id] = schema
+	}
+
+	return ReviewRunV1{
+		SchemaVersion:            CurrentSchemaVersion,
+		ID:                       run.ID,
+		Target:                   ToReviewTargetSchema(run.Target),
+		Trigger:                  string(run.Trigger),
+		Engine:                   ToEngineSchema(run.Engine),
+		StartedAt:                run.StartedAt,
+		CompletedAt:              run.CompletedAt,
+		Configuration:            ToReviewConfigurationSchema(run.Configuration),
+		ConfigurationSource:      ToConfigurationSourceIdentitySchema(run.ConfigurationSource),
+		ConfigurationFingerprint: run.ConfigurationFingerprint,
+		Status:                   string(run.Status),
+		Conclusion:               string(run.Conclusion),
+		Failure:                  failure,
+		ReviewerResults:          reviewerResults,
+		Stats:                    ToReviewStatsSchema(run.Stats),
+		Summarizer:               ToSummarizerOutcomeSchema(run.Summarizer),
+		RawFindings:              toFindingSchemaSlice(run.RawFindings),
+		AggregatedFindings:       toAggregatedFindingSchemaSlice(run.AggregatedFindings),
+		PreFilterSummary:         ToGroupedFindingsSchema(run.PreFilterSummary),
+		FindingRecords:           findingRecords,
+		Findings:                 findings,
+		Info:                     info,
+		FalsePositiveFilter:      fpFilter,
+		ExcludeFilter:            excludeFilter,
+		Dispositions:             dispositions,
+		Rendered:                 rendered,
+	}, nil
+}
+
+func FromReviewRunSchema(schema ReviewRunV1) (domain.ReviewRun, RenderedOutcomeV1, error) {
+	if err := validateSchemaVersion("review run", schema.SchemaVersion); err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, err
+	}
+	if err := validateNonEmpty("review run id", schema.ID); err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, err
+	}
+
+	target := schema.Target.ToDomain()
+	if err := target.Validate(); err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+
+	trigger := domain.ReviewTrigger(schema.Trigger)
+	if err := trigger.Validate(); err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+
+	engine := schema.Engine.ToDomain()
+	if err := engine.Validate(); err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+
+	configuration, err := schema.Configuration.ToDomain()
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+
+	configurationSource := schema.ConfigurationSource.ToDomain()
+	if err := configurationSource.Validate(); err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+
+	status := domain.ReviewStatus(schema.Status)
+	switch status {
+	case domain.ReviewStatusCompleted, domain.ReviewStatusFailed, domain.ReviewStatusInterrupted:
+	default:
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: unknown stored review status %q", schema.ID, schema.Status)
+	}
+
+	conclusion := domain.ReviewConclusion(schema.Conclusion)
+	switch conclusion {
+	case domain.ReviewConclusionNone, domain.ReviewConclusionNoChanges, domain.ReviewConclusionClean, domain.ReviewConclusionFindings:
+	default:
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: unknown stored review conclusion %q", schema.ID, schema.Conclusion)
+	}
+
+	failure, err := schema.Failure.ToDomain()
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	reviewerResults, err := toReviewerResultDomainSlice(schema.ReviewerResults)
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	findingRecords, err := toReviewFindingDomainSlice(schema.FindingRecords)
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	findings, err := toReviewFindingDomainSlice(schema.Findings)
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	info, err := toReviewFindingDomainSlice(schema.Info)
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	fpFilter, err := schema.FalsePositiveFilter.ToDomain()
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	excludeFilter, err := schema.ExcludeFilter.ToDomain()
+	if err != nil {
+		return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: %w", schema.ID, err)
+	}
+	dispositions := make(map[int]domain.Disposition, len(schema.Dispositions))
+	for id, disposition := range schema.Dispositions {
+		d, err := disposition.ToDomain()
+		if err != nil {
+			return domain.ReviewRun{}, RenderedOutcomeV1{}, fmt.Errorf("run %s: disposition %d: %w", schema.ID, id, err)
+		}
+		dispositions[id] = d
+	}
+
+	run := domain.ReviewRun{
+		ID:                       schema.ID,
+		Target:                   target,
+		Trigger:                  trigger,
+		Engine:                   engine,
+		StartedAt:                schema.StartedAt,
+		CompletedAt:              schema.CompletedAt,
+		Configuration:            configuration,
+		ConfigurationSource:      configurationSource,
+		ConfigurationFingerprint: schema.ConfigurationFingerprint,
+		Status:                   status,
+		Conclusion:               conclusion,
+		Failure:                  failure,
+		ReviewerResults:          reviewerResults,
+		Stats:                    schema.Stats.ToDomain(),
+		Summarizer:               schema.Summarizer.ToDomain(),
+		RawFindings:              toFindingDomainSlice(schema.RawFindings),
+		AggregatedFindings:       toAggregatedFindingDomainSlice(schema.AggregatedFindings),
+		PreFilterSummary:         schema.PreFilterSummary.ToDomain(),
+		FindingRecords:           findingRecords,
+		Findings:                 findings,
+		Info:                     info,
+		FalsePositiveFilter:      fpFilter,
+		ExcludeFilter:            excludeFilter,
+		Dispositions:             dispositions,
+	}
+	return run, schema.Rendered, nil
+}

--- a/internal/store/run.go
+++ b/internal/store/run.go
@@ -211,23 +211,11 @@ func (o ExcludeFilterOutcomeV1) ToDomain() (domain.ExcludeFilterOutcome, error) 
 	}, nil
 }
 
-// RenderedOutcomeV1 preserves the exact review and LGTM bodies that were
-// rendered for this run, if any were rendered. Text is preserved verbatim
-// rather than being re-derived from other stored fields on read, so a later
-// change to rendering logic cannot rewrite what a user actually saw or
-// posted. Both fields are commonly empty: many runs are never rendered for
-// posting (for example a clean run, or a run inspected only in history).
 type RenderedOutcomeV1 struct {
 	ReviewBody string `json:"review_body"`
 	LGTMBody   string `json:"lgtm_body"`
 }
 
-// RunLifecycleV1 records desk-level transitions applied to an already
-// completed, failed, or interrupted run after the fact. These transitions
-// never rewrite the original terminal outcome; they are recorded alongside
-// it so history stays honest about both what happened during execution and
-// what the desk later learned (for example, that the head moved and the
-// result is now stale).
 type RunLifecycleV1 struct {
 	Stale             bool      `json:"stale"`
 	StaleReason       string    `json:"stale_reason,omitempty"`

--- a/internal/store/run_test.go
+++ b/internal/store/run_test.go
@@ -194,6 +194,43 @@ func TestReviewRunV1_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestReviewRunV1_PreservesSummarizerDiagnosticsForFailedRuns(t *testing.T) {
+	run := buildTestReviewRun(t, domain.ReviewStatusFailed)
+	run.Summarizer.Stderr = "summarizer stderr: connection reset\n[truncated]"
+	run.Summarizer.DiagnosticOutput = "partial summarizer stdout before failure\n[truncated]"
+
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	if schema.Summarizer.Stderr != run.Summarizer.Stderr {
+		t.Fatalf("schema stderr = %q, want %q", schema.Summarizer.Stderr, run.Summarizer.Stderr)
+	}
+	if schema.Summarizer.DiagnosticOutput != run.Summarizer.DiagnosticOutput {
+		t.Fatalf("schema diagnostic output = %q, want %q", schema.Summarizer.DiagnosticOutput, run.Summarizer.DiagnosticOutput)
+	}
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ReviewRunV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	gotRun, _, err := FromReviewRunSchema(decoded)
+	if err != nil {
+		t.Fatalf("FromReviewRunSchema: %v", err)
+	}
+	if gotRun.Summarizer.Stderr != run.Summarizer.Stderr {
+		t.Fatalf("a failed run's stored summarizer stderr must survive a restart: got %q, want %q", gotRun.Summarizer.Stderr, run.Summarizer.Stderr)
+	}
+	if gotRun.Summarizer.DiagnosticOutput != run.Summarizer.DiagnosticOutput {
+		t.Fatalf("a failed run's stored summarizer diagnostic output must survive a restart: got %q, want %q", gotRun.Summarizer.DiagnosticOutput, run.Summarizer.DiagnosticOutput)
+	}
+}
+
 func TestReviewRunV1_RejectsUnsupportedSchemaVersion(t *testing.T) {
 	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
 	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})

--- a/internal/store/run_test.go
+++ b/internal/store/run_test.go
@@ -1,0 +1,280 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+func buildTestReviewRun(t *testing.T, status domain.ReviewStatus) domain.ReviewRun {
+	t.Helper()
+
+	pr := domain.PullRequestKey{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 196}
+	cfg := newTestReviewConfiguration(t)
+
+	run := domain.ReviewRun{
+		ID:      "run-1",
+		Trigger: domain.ReviewTriggerManual,
+		Target: domain.ReviewTarget{
+			RepositoryRoot: "/repo",
+			WorktreeRoot:   "/worktree",
+			Revision: domain.RevisionEvidence{
+				RequestedBaseRef: "main",
+				ResolvedBaseRef:  "refs/remotes/origin/main",
+				HeadObjectID:     "headsha",
+				BaseObjectID:     "basesha",
+			},
+			PullRequest: &pr,
+		},
+		Engine:        domain.ReviewEngine{Name: "acr", Version: "1.2.3"},
+		StartedAt:     time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+		Configuration: cfg,
+		ConfigurationSource: domain.ConfigurationSourceIdentity{
+			Kind:          "repository-revision",
+			Locator:       "/repo",
+			Ref:           "refs/acr/trusted-config/origin/main",
+			Revision:      "trustedsha",
+			ConfigPresent: true,
+			ConfigDigest:  "digest",
+		},
+		ConfigurationFingerprint: cfg.Fingerprint(),
+		ReviewerResults: []domain.ReviewerResult{
+			{
+				ReviewerID: 0,
+				AgentName:  "claude",
+				Findings:   []domain.Finding{{Text: "possible nil deref", ReviewerID: 0}},
+				ExitCode:   0,
+				Attempts:   1,
+				Duration:   3 * time.Second,
+			},
+			{
+				ReviewerID: 1,
+				AgentName:  "codex",
+				Findings:   []domain.Finding{{Text: "possible nil deref", ReviewerID: 1}},
+				ExitCode:   0,
+				Attempts:   1,
+				Duration:   4 * time.Second,
+			},
+		},
+		Stats: domain.ReviewStats{
+			TotalReviewers:      2,
+			SuccessfulReviewers: 2,
+			ReviewerDurations:   map[int]time.Duration{0: 3 * time.Second, 1: 4 * time.Second},
+			ReviewerAgentNames:  map[int]string{0: "claude", 1: "codex"},
+			WallClockDuration:   4 * time.Second,
+			SummarizerDuration:  time.Second,
+			FPFilterDuration:    time.Second,
+		},
+		Summarizer: domain.SummarizerOutcome{
+			ExitCode: 0,
+			Duration: time.Second,
+			Warnings: []string{"cleanup warning"},
+		},
+		RawFindings: []domain.Finding{
+			{Text: "possible nil deref", ReviewerID: 0},
+			{Text: "possible nil deref", ReviewerID: 1},
+		},
+		AggregatedFindings: []domain.AggregatedFinding{
+			{Text: "possible nil deref", Reviewers: []int{0, 1}},
+		},
+		PreFilterSummary: domain.GroupedFindings{
+			Findings: []domain.FindingGroup{{Title: "Possible nil deref", ReviewerCount: 2, Sources: []int{0}}},
+		},
+		FindingRecords: []domain.ReviewFinding{
+			{
+				ID:          "finding-1",
+				Kind:        domain.ReviewFindingActionable,
+				Group:       domain.FindingGroup{Title: "Possible nil deref", ReviewerCount: 2, Sources: []int{0}},
+				Disposition: domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: "Possible nil deref"},
+			},
+		},
+		Findings: []domain.ReviewFinding{
+			{
+				ID:          "finding-1",
+				Kind:        domain.ReviewFindingActionable,
+				Group:       domain.FindingGroup{Title: "Possible nil deref", ReviewerCount: 2, Sources: []int{0}},
+				Disposition: domain.Disposition{Kind: domain.DispositionSurvived, GroupTitle: "Possible nil deref"},
+			},
+		},
+		FalsePositiveFilter: domain.FalsePositiveFilterOutcome{
+			Enabled:  true,
+			Applied:  true,
+			Duration: time.Second,
+		},
+		ExcludeFilter: domain.ExcludeFilterOutcome{
+			Patterns: []string{"vendor/.*"},
+		},
+		Dispositions: map[int]domain.Disposition{
+			0: {Kind: domain.DispositionSurvived, GroupTitle: "Possible nil deref"},
+		},
+	}
+
+	switch status {
+	case domain.ReviewStatusCompleted:
+		run.Status = domain.ReviewStatusCompleted
+		run.Conclusion = domain.ReviewConclusionFindings
+		run.CompletedAt = run.StartedAt.Add(10 * time.Second)
+	case domain.ReviewStatusFailed:
+		run.Status = domain.ReviewStatusFailed
+		run.CompletedAt = run.StartedAt.Add(2 * time.Second)
+		run.Failure = &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: "all reviewers failed"}
+	case domain.ReviewStatusInterrupted:
+		run.Status = domain.ReviewStatusInterrupted
+		run.CompletedAt = run.StartedAt.Add(1 * time.Second)
+	}
+
+	return run
+}
+
+func TestReviewRunV1_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		status domain.ReviewStatus
+	}{
+		{name: "completed run with findings", status: domain.ReviewStatusCompleted},
+		{name: "failed run", status: domain.ReviewStatusFailed},
+		{name: "interrupted run", status: domain.ReviewStatusInterrupted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run := buildTestReviewRun(t, tt.status)
+			rendered := RenderedOutcomeV1{ReviewBody: "review body", LGTMBody: "lgtm body"}
+
+			schema, err := ToReviewRunSchema(run, rendered)
+			if err != nil {
+				t.Fatalf("ToReviewRunSchema: %v", err)
+			}
+
+			data, err := json.Marshal(schema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded ReviewRunV1
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			gotRun, gotRendered, err := FromReviewRunSchema(decoded)
+			if err != nil {
+				t.Fatalf("FromReviewRunSchema: %v", err)
+			}
+
+			if gotRendered != rendered {
+				t.Fatalf("rendered outcome mismatch: got %+v, want %+v", gotRendered, rendered)
+			}
+			if gotRun.ID != run.ID || gotRun.Status != run.Status || gotRun.Conclusion != run.Conclusion {
+				t.Fatalf("run identity mismatch: got %+v, want %+v", gotRun, run)
+			}
+			if (gotRun.Failure == nil) != (run.Failure == nil) {
+				t.Fatalf("failure presence mismatch: got %+v, want %+v", gotRun.Failure, run.Failure)
+			}
+			if gotRun.Failure != nil && *gotRun.Failure != *run.Failure {
+				t.Fatalf("failure mismatch: got %+v, want %+v", *gotRun.Failure, *run.Failure)
+			}
+			if gotRun.ConfigurationFingerprint != run.ConfigurationFingerprint {
+				t.Fatalf("configuration fingerprint mismatch: got %s, want %s", gotRun.ConfigurationFingerprint, run.ConfigurationFingerprint)
+			}
+			if gotRun.ConfigurationSource != run.ConfigurationSource {
+				t.Fatalf("configuration source mismatch: got %+v, want %+v", gotRun.ConfigurationSource, run.ConfigurationSource)
+			}
+			if !reflect.DeepEqual(gotRun.FinalGroupedFindings(), run.FinalGroupedFindings()) {
+				t.Fatalf("rendered findings differ after round trip:\ngot  %+v\nwant %+v", gotRun.FinalGroupedFindings(), run.FinalGroupedFindings())
+			}
+			if len(gotRun.ReviewerResults) != len(run.ReviewerResults) {
+				t.Fatalf("reviewer results length mismatch: got %d, want %d", len(gotRun.ReviewerResults), len(run.ReviewerResults))
+			}
+			if !reflect.DeepEqual(gotRun.Dispositions, run.Dispositions) {
+				t.Fatalf("dispositions mismatch: got %+v, want %+v", gotRun.Dispositions, run.Dispositions)
+			}
+		})
+	}
+}
+
+func TestReviewRunV1_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	schema.SchemaVersion = CurrentSchemaVersion + 1
+
+	if _, _, err := FromReviewRunSchema(schema); err == nil {
+		t.Fatal("expected an explicit error for an unsupported schema version")
+	}
+
+	schema.SchemaVersion = 0
+	if _, _, err := FromReviewRunSchema(schema); err == nil {
+		t.Fatal("expected an explicit error for a zero schema version")
+	}
+}
+
+func TestReviewRunV1_RejectsCorruptedConfigurationFingerprint(t *testing.T) {
+	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	schema.Configuration.Fingerprint = "sha256:corrupted"
+
+	if _, _, err := FromReviewRunSchema(schema); err == nil {
+		t.Fatal("expected an explicit error for a corrupted configuration fingerprint")
+	}
+}
+
+func TestReviewRunV1_RejectsUnknownStatus(t *testing.T) {
+	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	schema.Status = "abandoned"
+
+	if _, _, err := FromReviewRunSchema(schema); err == nil {
+		t.Fatal("expected an explicit error for an unknown stored review status")
+	}
+}
+
+func TestRunLifecycleV1_PreservesOriginalOutcomeWhenMarkedStaleOrSuperseded(t *testing.T) {
+	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+
+	staleAt := run.CompletedAt.Add(time.Hour)
+	schema.Lifecycle = RunLifecycleV1{
+		Stale:             true,
+		StaleReason:       "head moved",
+		StaleAt:           staleAt,
+		SupersededByRunID: "run-2",
+		SupersededAt:      staleAt,
+	}
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded ReviewRunV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Lifecycle.Stale != true || decoded.Lifecycle.SupersededByRunID != "run-2" {
+		t.Fatalf("lifecycle round trip mismatch: got %+v", decoded.Lifecycle)
+	}
+	if decoded.Status != string(domain.ReviewStatusCompleted) {
+		t.Fatalf("marking a run stale must not rewrite its original terminal status: got %q", decoded.Status)
+	}
+
+	gotRun, _, err := FromReviewRunSchema(decoded)
+	if err != nil {
+		t.Fatalf("FromReviewRunSchema: %v", err)
+	}
+	if gotRun.Status != domain.ReviewStatusCompleted {
+		t.Fatalf("original outcome not preserved: got %q", gotRun.Status)
+	}
+}

--- a/internal/store/run_test.go
+++ b/internal/store/run_test.go
@@ -225,6 +225,19 @@ func TestReviewRunV1_RejectsCorruptedConfigurationFingerprint(t *testing.T) {
 	}
 }
 
+func TestReviewRunV1_RejectsMismatchedTopLevelConfigurationFingerprint(t *testing.T) {
+	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	schema.ConfigurationFingerprint = "sha256:top-level-mismatch"
+
+	if _, _, err := FromReviewRunSchema(schema); err == nil {
+		t.Fatal("expected an explicit error when the top-level configuration_fingerprint disagrees with the nested configuration fingerprint")
+	}
+}
+
 func TestReviewRunV1_RejectsUnknownStatus(t *testing.T) {
 	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
 	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
@@ -238,20 +251,24 @@ func TestReviewRunV1_RejectsUnknownStatus(t *testing.T) {
 	}
 }
 
-func TestRunLifecycleV1_PreservesOriginalOutcomeWhenMarkedStaleOrSuperseded(t *testing.T) {
+func TestReviewRunV1_StaleAndSupersededTransitionsAreSeparateEventsNotRunMutations(t *testing.T) {
 	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
 	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
 	if err != nil {
 		t.Fatalf("ToReviewRunSchema: %v", err)
 	}
 
-	staleAt := run.CompletedAt.Add(time.Hour)
-	schema.Lifecycle = RunLifecycleV1{
-		Stale:             true,
-		StaleReason:       "head moved",
-		StaleAt:           staleAt,
-		SupersededByRunID: "run-2",
-		SupersededAt:      staleAt,
+	staleEvent := ReviewEventV1{
+		SchemaVersion: CurrentSchemaVersion,
+		ID:            "event-stale-1",
+		PullRequest:   testPullRequestKey(),
+		Type:          EventTypeReviewStale,
+		OccurredAt:    run.CompletedAt.Add(time.Hour),
+		RunID:         schema.ID,
+		Reason:        "head moved",
+	}
+	if err := staleEvent.Validate(); err != nil {
+		t.Fatalf("stale event Validate: %v", err)
 	}
 
 	data, err := json.Marshal(schema)
@@ -262,12 +279,8 @@ func TestRunLifecycleV1_PreservesOriginalOutcomeWhenMarkedStaleOrSuperseded(t *t
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-
-	if decoded.Lifecycle.Stale != true || decoded.Lifecycle.SupersededByRunID != "run-2" {
-		t.Fatalf("lifecycle round trip mismatch: got %+v", decoded.Lifecycle)
-	}
 	if decoded.Status != string(domain.ReviewStatusCompleted) {
-		t.Fatalf("marking a run stale must not rewrite its original terminal status: got %q", decoded.Status)
+		t.Fatalf("a later stale/superseded event must not rewrite the run's original terminal status: got %q", decoded.Status)
 	}
 
 	gotRun, _, err := FromReviewRunSchema(decoded)

--- a/internal/store/runstore.go
+++ b/internal/store/runstore.go
@@ -23,8 +23,8 @@ func NewFilesystemRunStore(dataDir string) *FilesystemRunStore {
 var _ RunStore = (*FilesystemRunStore)(nil)
 
 func (s *FilesystemRunStore) SaveRun(run ReviewRunV1) (string, error) {
-	if err := validateSchemaVersion("review run", run.SchemaVersion); err != nil {
-		return "", err
+	if _, _, err := FromReviewRunSchema(run); err != nil {
+		return "", fmt.Errorf("review run %s: %w", run.ID, err)
 	}
 	if run.Target.PullRequest == nil {
 		return "", fmt.Errorf("review run %s: target has no pull request key; runs can only be stored for pull request reviews", run.ID)
@@ -47,7 +47,7 @@ func (s *FilesystemRunStore) SaveRun(run ReviewRunV1) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal review run %s: %w", run.ID, err)
 	}
-	if err := writeNewFile(path, data, 0o644); err != nil {
+	if err := writeNewFile(path, data, 0o600); err != nil {
 		return "", fmt.Errorf("save review run %s: %w", run.ID, err)
 	}
 	return path, nil

--- a/internal/store/runstore.go
+++ b/internal/store/runstore.go
@@ -29,6 +29,15 @@ func (s *FilesystemRunStore) SaveRun(run ReviewRunV1) (string, error) {
 	if run.Target.PullRequest == nil {
 		return "", fmt.Errorf("review run %s: target has no pull request key; runs can only be stored for pull request reviews", run.ID)
 	}
+	existing, _, err := s.ListRuns(*run.Target.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range existing {
+		if e.ID == run.ID {
+			return "", fmt.Errorf("review run %s already exists for %s", run.ID, run.Target.PullRequest.String())
+		}
+	}
 	dir, err := runsDir(s.dataDir, *run.Target.PullRequest)
 	if err != nil {
 		return "", err

--- a/internal/store/runstore.go
+++ b/internal/store/runstore.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+type RunStore interface {
+	SaveRun(run ReviewRunV1) (string, error)
+	ListRuns(key PullRequestKeyV1) ([]ReviewRunV1, []CorruptRecord, error)
+	LoadRun(key PullRequestKeyV1, runID string) (ReviewRunV1, error)
+}
+
+type FilesystemRunStore struct {
+	dataDir string
+}
+
+func NewFilesystemRunStore(dataDir string) *FilesystemRunStore {
+	return &FilesystemRunStore{dataDir: dataDir}
+}
+
+var _ RunStore = (*FilesystemRunStore)(nil)
+
+func (s *FilesystemRunStore) SaveRun(run ReviewRunV1) (string, error) {
+	if err := validateSchemaVersion("review run", run.SchemaVersion); err != nil {
+		return "", err
+	}
+	if run.Target.PullRequest == nil {
+		return "", fmt.Errorf("review run %s: target has no pull request key; runs can only be stored for pull request reviews", run.ID)
+	}
+	dir, err := runsDir(s.dataDir, *run.Target.PullRequest)
+	if err != nil {
+		return "", err
+	}
+	ts := run.CompletedAt
+	if ts.IsZero() {
+		ts = run.StartedAt
+	}
+	name, err := recordFileName("review run", run.ID, ts)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, name)
+
+	data, err := json.MarshalIndent(run, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal review run %s: %w", run.ID, err)
+	}
+	if err := writeNewFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("save review run %s: %w", run.ID, err)
+	}
+	return path, nil
+}
+
+func (s *FilesystemRunStore) ListRuns(key PullRequestKeyV1) ([]ReviewRunV1, []CorruptRecord, error) {
+	dir, err := runsDir(s.dataDir, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return listRecords(dir, decodeReviewRun)
+}
+
+func (s *FilesystemRunStore) LoadRun(key PullRequestKeyV1, runID string) (ReviewRunV1, error) {
+	runs, corrupt, err := s.ListRuns(key)
+	if err != nil {
+		return ReviewRunV1{}, err
+	}
+	for _, run := range runs {
+		if run.ID == runID {
+			return run, nil
+		}
+	}
+	if len(corrupt) > 0 {
+		return ReviewRunV1{}, fmt.Errorf("review run %s not found for %s (%d unreadable record(s) also present in history)", runID, key.String(), len(corrupt))
+	}
+	return ReviewRunV1{}, fmt.Errorf("review run %s not found for %s", runID, key.String())
+}

--- a/internal/store/runstore_test.go
+++ b/internal/store/runstore_test.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+func buildTestReviewRunSchema(t *testing.T, id string, completedAt time.Time) ReviewRunV1 {
+	t.Helper()
+	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
+	run.ID = id
+	run.CompletedAt = completedAt
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{ReviewBody: "body for " + id})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	return schema
+}
+
+func TestFilesystemRunStore_SaveListLoad(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+	key := testPullRequestKey()
+
+	run1 := buildTestReviewRunSchema(t, "run-1", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	run2 := buildTestReviewRunSchema(t, "run-2", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+
+	if _, err := store.SaveRun(run1); err != nil {
+		t.Fatalf("save run1: %v", err)
+	}
+	if _, err := store.SaveRun(run2); err != nil {
+		t.Fatalf("save run2: %v", err)
+	}
+
+	runs, corrupt, err := store.ListRuns(key)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(runs))
+	}
+	if runs[0].ID != "run-1" || runs[1].ID != "run-2" {
+		t.Fatalf("expected chronological order run-1, run-2, got %s, %s", runs[0].ID, runs[1].ID)
+	}
+
+	loaded, err := store.LoadRun(key, "run-2")
+	if err != nil {
+		t.Fatalf("load run2: %v", err)
+	}
+	if loaded.Rendered.ReviewBody != "body for run-2" {
+		t.Fatalf("unexpected loaded run body: %q", loaded.Rendered.ReviewBody)
+	}
+}
+
+func TestFilesystemRunStore_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	key := testPullRequestKey()
+	run := buildTestReviewRunSchema(t, "run-restart", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	firstProcessStore := NewFilesystemRunStore(dir)
+	if _, err := firstProcessStore.SaveRun(run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	secondProcessStore := NewFilesystemRunStore(dir)
+	loaded, err := secondProcessStore.LoadRun(key, "run-restart")
+	if err != nil {
+		t.Fatalf("load after restart: %v", err)
+	}
+	if loaded.ID != run.ID || loaded.ConfigurationFingerprint != run.ConfigurationFingerprint {
+		t.Fatalf("restart did not preserve run data: got %+v", loaded)
+	}
+}
+
+func TestFilesystemRunStore_RefusesDuplicateSave(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+	run := buildTestReviewRunSchema(t, "run-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+
+	if _, err := store.SaveRun(run); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if _, err := store.SaveRun(run); err == nil {
+		t.Fatal("expected second save of the same run id/timestamp to fail")
+	}
+}
+
+func TestFilesystemRunStore_IsolatesCorruptRecords(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+	key := testPullRequestKey()
+
+	good := buildTestReviewRunSchema(t, "run-good", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveRun(good); err != nil {
+		t.Fatalf("save good run: %v", err)
+	}
+
+	runsDirPath, err := runsDir(dir, key)
+	if err != nil {
+		t.Fatalf("runsDir: %v", err)
+	}
+	corruptPath := filepath.Join(runsDirPath, "20260722T130000.000000000Z-run-bad.json")
+	if err := os.WriteFile(corruptPath, []byte(`{"schema_version": 1, "id": "run-bad", "truncated`), 0o644); err != nil {
+		t.Fatalf("seed corrupt record: %v", err)
+	}
+
+	runs, corrupt, err := store.ListRuns(key)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != "run-good" {
+		t.Fatalf("expected the good run to remain readable, got %+v", runs)
+	}
+	if len(corrupt) != 1 || corrupt[0].Path != corruptPath {
+		t.Fatalf("expected exactly one corrupt record reported for %s, got %+v", corruptPath, corrupt)
+	}
+
+	loaded, err := store.LoadRun(key, "run-good")
+	if err != nil {
+		t.Fatalf("load good run despite corrupt sibling: %v", err)
+	}
+	if loaded.ID != "run-good" {
+		t.Fatalf("unexpected loaded run: %+v", loaded)
+	}
+}
+
+func TestFilesystemRunStore_IgnoresStrayTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+	key := testPullRequestKey()
+
+	good := buildTestReviewRunSchema(t, "run-good", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveRun(good); err != nil {
+		t.Fatalf("save good run: %v", err)
+	}
+
+	runsDirPath, err := runsDir(dir, key)
+	if err != nil {
+		t.Fatalf("runsDir: %v", err)
+	}
+	strayPath := filepath.Join(runsDirPath, ".tmp-20260722T130000.000000000Z-run-killed.json-xyz")
+	if err := os.WriteFile(strayPath, []byte(`{"schema_vers`), 0o644); err != nil {
+		t.Fatalf("seed stray temp file: %v", err)
+	}
+
+	runs, corrupt, err := store.ListRuns(key)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != "run-good" {
+		t.Fatalf("expected only the good run, got %+v", runs)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected the stray temp file to be silently ignored, got %+v", corrupt)
+	}
+}
+
+func TestFilesystemRunStore_LoadRunNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+	key := testPullRequestKey()
+
+	if _, err := store.LoadRun(key, "missing"); err == nil {
+		t.Fatal("expected an error for a missing run")
+	}
+}
+
+func TestFilesystemRunStore_SaveRunRequiresPullRequestTarget(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+
+	run := buildTestReviewRun(t, domain.ReviewStatusCompleted)
+	run.Target.PullRequest = nil
+	schema, err := ToReviewRunSchema(run, RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+
+	if _, err := store.SaveRun(schema); err == nil {
+		t.Fatal("expected an error saving a run with no pull request target")
+	}
+}

--- a/internal/store/runstore_test.go
+++ b/internal/store/runstore_test.go
@@ -172,6 +172,26 @@ func TestFilesystemRunStore_LoadRunNotFound(t *testing.T) {
 	}
 }
 
+func TestFilesystemRunStore_SaveRunRejectsInvalidRecord(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+	schema := buildTestReviewRunSchema(t, "run-invalid", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	schema.ConfigurationFingerprint = "sha256:corrupted-before-save"
+
+	if _, err := store.SaveRun(schema); err == nil {
+		t.Fatal("expected SaveRun to reject a record ListRuns would later consider corrupt")
+	}
+
+	key := testPullRequestKey()
+	runs, corrupt, err := store.ListRuns(key)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 0 || len(corrupt) != 0 {
+		t.Fatalf("expected nothing to have been written for a rejected save, got runs=%v corrupt=%v", runs, corrupt)
+	}
+}
+
 func TestFilesystemRunStore_SaveRunRequiresPullRequestTarget(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFilesystemRunStore(dir)

--- a/internal/store/runstore_test.go
+++ b/internal/store/runstore_test.go
@@ -92,6 +92,33 @@ func TestFilesystemRunStore_RefusesDuplicateSave(t *testing.T) {
 	}
 }
 
+func TestFilesystemRunStore_RefusesDuplicateRunIDWithDifferentTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemRunStore(dir)
+	key := testPullRequestKey()
+
+	first := buildTestReviewRunSchema(t, "run-dup", time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveRun(first); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	second := buildTestReviewRunSchema(t, "run-dup", time.Date(2026, 7, 22, 13, 0, 0, 0, time.UTC))
+	if _, err := store.SaveRun(second); err == nil {
+		t.Fatal("expected a second save of the same run id under a different timestamp to fail")
+	}
+
+	runs, corrupt, err := store.ListRuns(key)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("expected no corrupt records, got %v", corrupt)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected exactly one stored run for the duplicated id, got %d", len(runs))
+	}
+}
+
 func TestFilesystemRunStore_IsolatesCorruptRecords(t *testing.T) {
 	dir := t.TempDir()
 	store := NewFilesystemRunStore(dir)

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -1,0 +1,127 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+type PullRequestStateV1 string
+
+const (
+	PullRequestStateOpen   PullRequestStateV1 = "open"
+	PullRequestStateClosed PullRequestStateV1 = "closed"
+	PullRequestStateMerged PullRequestStateV1 = "merged"
+)
+
+func (s PullRequestStateV1) Validate() error {
+	switch s {
+	case PullRequestStateOpen, PullRequestStateClosed, PullRequestStateMerged:
+		return nil
+	default:
+		return fmt.Errorf("unknown pull request state %q", s)
+	}
+}
+
+type ReviewRequestKindV1 string
+
+const (
+	ReviewRequestKindUser ReviewRequestKindV1 = "user"
+	ReviewRequestKindTeam ReviewRequestKindV1 = "team"
+)
+
+func (k ReviewRequestKindV1) Validate() error {
+	switch k {
+	case ReviewRequestKindUser, ReviewRequestKindTeam:
+		return nil
+	default:
+		return fmt.Errorf("unknown review request kind %q", k)
+	}
+}
+
+// ReviewRequestV1 is a pending reviewer or team requested on the pull
+// request, as observed at snapshot time.
+type ReviewRequestV1 struct {
+	Kind  ReviewRequestKindV1 `json:"kind"`
+	Login string              `json:"login"`
+}
+
+func (r ReviewRequestV1) Validate() error {
+	if err := r.Kind.Validate(); err != nil {
+		return err
+	}
+	return validateNonEmpty("review request login", r.Login)
+}
+
+// LatestReviewV1 is one submitted GitHub review, as observed at snapshot
+// time. State follows GitHub's pull-request review states (for example
+// APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING).
+type LatestReviewV1 struct {
+	Author      string    `json:"author"`
+	State       string    `json:"state"`
+	SubmittedAt time.Time `json:"submitted_at"`
+}
+
+func (r LatestReviewV1) Validate() error {
+	if err := validateNonEmpty("review author", r.Author); err != nil {
+		return err
+	}
+	return validateNonEmpty("review state", r.State)
+}
+
+// PRSnapshotV1 is a timestamped, immutable observation of GitHub pull-request
+// state, used as input to classification and history. It has no domain
+// in-memory counterpart yet; the desk workspace/discovery phase that
+// consumes it is introduced by a later issue in this epic.
+type PRSnapshotV1 struct {
+	SchemaVersion    int                `json:"schema_version"`
+	PullRequest      PullRequestKeyV1   `json:"pull_request"`
+	URL              string             `json:"url"`
+	Title            string             `json:"title"`
+	Author           string             `json:"author"`
+	State            PullRequestStateV1 `json:"state"`
+	Draft            bool               `json:"draft"`
+	HeadObjectID     string             `json:"head_object_id"`
+	BaseObjectID     string             `json:"base_object_id"`
+	ReviewRequests   []ReviewRequestV1  `json:"review_requests"`
+	ReviewDecision   string             `json:"review_decision"`
+	LatestReviews    []LatestReviewV1   `json:"latest_reviews"`
+	CheckRollupState string             `json:"check_rollup_state"`
+	MergeState       string             `json:"merge_state"`
+	UpdatedAt        time.Time          `json:"updated_at"`
+	CapturedAt       time.Time          `json:"captured_at"`
+}
+
+func (s PRSnapshotV1) Validate() error {
+	if err := validateSchemaVersion("pull request snapshot", s.SchemaVersion); err != nil {
+		return err
+	}
+	if err := s.PullRequest.Validate(); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("pull request url", s.URL); err != nil {
+		return err
+	}
+	if err := s.State.Validate(); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("pull request head object id", s.HeadObjectID); err != nil {
+		return err
+	}
+	if err := validateNonEmpty("pull request base object id", s.BaseObjectID); err != nil {
+		return err
+	}
+	for i, request := range s.ReviewRequests {
+		if err := request.Validate(); err != nil {
+			return fmt.Errorf("review request %d: %w", i, err)
+		}
+	}
+	for i, review := range s.LatestReviews {
+		if err := review.Validate(); err != nil {
+			return fmt.Errorf("latest review %d: %w", i, err)
+		}
+	}
+	if s.CapturedAt.IsZero() {
+		return fmt.Errorf("pull request snapshot captured_at is required")
+	}
+	return nil
+}

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -38,8 +38,6 @@ func (k ReviewRequestKindV1) Validate() error {
 	}
 }
 
-// ReviewRequestV1 is a pending reviewer or team requested on the pull
-// request, as observed at snapshot time.
 type ReviewRequestV1 struct {
 	Kind  ReviewRequestKindV1 `json:"kind"`
 	Login string              `json:"login"`
@@ -52,9 +50,6 @@ func (r ReviewRequestV1) Validate() error {
 	return validateNonEmpty("review request login", r.Login)
 }
 
-// LatestReviewV1 is one submitted GitHub review, as observed at snapshot
-// time. State follows GitHub's pull-request review states (for example
-// APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING).
 type LatestReviewV1 struct {
 	Author      string    `json:"author"`
 	State       string    `json:"state"`
@@ -68,10 +63,6 @@ func (r LatestReviewV1) Validate() error {
 	return validateNonEmpty("review state", r.State)
 }
 
-// PRSnapshotV1 is a timestamped, immutable observation of GitHub pull-request
-// state, used as input to classification and history. It has no domain
-// in-memory counterpart yet; the desk workspace/discovery phase that
-// consumes it is introduced by a later issue in this epic.
 type PRSnapshotV1 struct {
 	SchemaVersion    int                `json:"schema_version"`
 	PullRequest      PullRequestKeyV1   `json:"pull_request"`

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -91,6 +91,17 @@ type PRSnapshotV1 struct {
 	CapturedAt       time.Time          `json:"captured_at"`
 }
 
+func (s PRSnapshotV1) Age(now time.Time) time.Duration {
+	if s.CapturedAt.IsZero() {
+		return 0
+	}
+	age := now.Sub(s.CapturedAt)
+	if age < 0 {
+		return 0
+	}
+	return age
+}
+
 func (s PRSnapshotV1) Validate() error {
 	if err := validateSchemaVersion("pull request snapshot", s.SchemaVersion); err != nil {
 		return err

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -1,0 +1,84 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func validSnapshot() PRSnapshotV1 {
+	return PRSnapshotV1{
+		SchemaVersion: CurrentSchemaVersion,
+		PullRequest:   PullRequestKeyV1{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 196},
+		URL:           "https://github.com/richhaase/agentic-code-reviewer/pull/196",
+		Title:         "Define versioned persistence schemas",
+		Author:        "richhaase",
+		State:         PullRequestStateOpen,
+		Draft:         false,
+		HeadObjectID:  "headsha",
+		BaseObjectID:  "basesha",
+		ReviewRequests: []ReviewRequestV1{
+			{Kind: ReviewRequestKindUser, Login: "reviewer1"},
+			{Kind: ReviewRequestKindTeam, Login: "org/reviewers"},
+		},
+		ReviewDecision: "REVIEW_REQUIRED",
+		LatestReviews: []LatestReviewV1{
+			{Author: "reviewer2", State: "COMMENTED", SubmittedAt: time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)},
+		},
+		CheckRollupState: "PENDING",
+		MergeState:       "CLEAN",
+		UpdatedAt:        time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC),
+		CapturedAt:       time.Date(2026, 7, 22, 9, 5, 0, 0, time.UTC),
+	}
+}
+
+func TestPRSnapshotV1_RoundTrip(t *testing.T) {
+	snapshot := validSnapshot()
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded PRSnapshotV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, snapshot) {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, snapshot)
+	}
+}
+
+func TestPRSnapshotV1_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(s *PRSnapshotV1)
+		wantErr bool
+	}{
+		{name: "valid snapshot", mutate: func(s *PRSnapshotV1) {}, wantErr: false},
+		{name: "unsupported schema version", mutate: func(s *PRSnapshotV1) { s.SchemaVersion = 99 }, wantErr: true},
+		{name: "invalid pull request key", mutate: func(s *PRSnapshotV1) { s.PullRequest.Number = 0 }, wantErr: true},
+		{name: "missing url", mutate: func(s *PRSnapshotV1) { s.URL = "" }, wantErr: true},
+		{name: "unknown state", mutate: func(s *PRSnapshotV1) { s.State = "archived" }, wantErr: true},
+		{name: "missing head object id", mutate: func(s *PRSnapshotV1) { s.HeadObjectID = "" }, wantErr: true},
+		{name: "missing captured_at", mutate: func(s *PRSnapshotV1) { s.CapturedAt = time.Time{} }, wantErr: true},
+		{name: "unknown review request kind", mutate: func(s *PRSnapshotV1) { s.ReviewRequests[0].Kind = "org" }, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := validSnapshot()
+			tt.mutate(&snapshot)
+			err := snapshot.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/store/snapshotstore.go
+++ b/internal/store/snapshotstore.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type SnapshotStore interface {
+	SaveSnapshot(snapshot PRSnapshotV1) error
+	LoadSnapshot(key PullRequestKeyV1) (PRSnapshotV1, error)
+}
+
+type FilesystemSnapshotStore struct {
+	dataDir string
+}
+
+func NewFilesystemSnapshotStore(dataDir string) *FilesystemSnapshotStore {
+	return &FilesystemSnapshotStore{dataDir: dataDir}
+}
+
+var _ SnapshotStore = (*FilesystemSnapshotStore)(nil)
+
+func (s *FilesystemSnapshotStore) SaveSnapshot(snapshot PRSnapshotV1) error {
+	if err := snapshot.Validate(); err != nil {
+		return err
+	}
+	path, err := snapshotFilePath(s.dataDir, snapshot.PullRequest)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal pull request snapshot: %w", err)
+	}
+	if err := atomicWriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("save pull request snapshot for %s: %w", snapshot.PullRequest.String(), err)
+	}
+	return nil
+}
+
+func (s *FilesystemSnapshotStore) LoadSnapshot(key PullRequestKeyV1) (PRSnapshotV1, error) {
+	path, err := snapshotFilePath(s.dataDir, key)
+	if err != nil {
+		return PRSnapshotV1{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PRSnapshotV1{}, fmt.Errorf("no stored snapshot for %s: %w", key.String(), err)
+		}
+		return PRSnapshotV1{}, fmt.Errorf("read pull request snapshot for %s: %w", key.String(), err)
+	}
+	snapshot, err := decodePRSnapshot(data)
+	if err != nil {
+		return PRSnapshotV1{}, fmt.Errorf("stored snapshot for %s is corrupt: %w", key.String(), err)
+	}
+	return snapshot, nil
+}

--- a/internal/store/snapshotstore.go
+++ b/internal/store/snapshotstore.go
@@ -33,7 +33,7 @@ func (s *FilesystemSnapshotStore) SaveSnapshot(snapshot PRSnapshotV1) error {
 	if err != nil {
 		return fmt.Errorf("marshal pull request snapshot: %w", err)
 	}
-	if err := atomicWriteFile(path, data, 0o644); err != nil {
+	if err := atomicWriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("save pull request snapshot for %s: %w", snapshot.PullRequest.String(), err)
 	}
 	return nil

--- a/internal/store/snapshotstore_test.go
+++ b/internal/store/snapshotstore_test.go
@@ -1,0 +1,107 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFilesystemSnapshotStore_SaveLoadOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemSnapshotStore(dir)
+
+	snapshot := validSnapshot()
+	if err := store.SaveSnapshot(snapshot); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := store.LoadSnapshot(snapshot.PullRequest)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Title != snapshot.Title {
+		t.Fatalf("unexpected loaded snapshot: %+v", loaded)
+	}
+
+	snapshot.Title = "Updated title"
+	snapshot.CapturedAt = snapshot.CapturedAt.Add(time.Hour)
+	if err := store.SaveSnapshot(snapshot); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	loaded, err = store.LoadSnapshot(snapshot.PullRequest)
+	if err != nil {
+		t.Fatalf("load after overwrite: %v", err)
+	}
+	if loaded.Title != "Updated title" {
+		t.Fatalf("expected latest snapshot to win, got %q", loaded.Title)
+	}
+}
+
+func TestFilesystemSnapshotStore_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	snapshot := validSnapshot()
+
+	firstProcessStore := NewFilesystemSnapshotStore(dir)
+	if err := firstProcessStore.SaveSnapshot(snapshot); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	secondProcessStore := NewFilesystemSnapshotStore(dir)
+	loaded, err := secondProcessStore.LoadSnapshot(snapshot.PullRequest)
+	if err != nil {
+		t.Fatalf("load after restart: %v", err)
+	}
+	if loaded.HeadObjectID != snapshot.HeadObjectID {
+		t.Fatalf("restart did not preserve snapshot data: got %+v", loaded)
+	}
+}
+
+func TestFilesystemSnapshotStore_CorruptSnapshotReportedNotPanicked(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemSnapshotStore(dir)
+	key := testPullRequestKey()
+
+	path, err := snapshotFilePath(dir, key)
+	if err != nil {
+		t.Fatalf("snapshotFilePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt snapshot: %v", err)
+	}
+
+	if _, err := store.LoadSnapshot(key); err == nil {
+		t.Fatal("expected an error loading a corrupt snapshot")
+	}
+}
+
+func TestFilesystemSnapshotStore_LoadMissingReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemSnapshotStore(dir)
+
+	if _, err := store.LoadSnapshot(testPullRequestKey()); err == nil {
+		t.Fatal("expected an error loading a snapshot that was never saved")
+	}
+}
+
+func TestPRSnapshotV1_Age(t *testing.T) {
+	snapshot := validSnapshot()
+	now := snapshot.CapturedAt.Add(5 * time.Minute)
+
+	age := snapshot.Age(now)
+	if age != 5*time.Minute {
+		t.Fatalf("expected age of 5m, got %v", age)
+	}
+
+	if got := snapshot.Age(snapshot.CapturedAt.Add(-time.Minute)); got != 0 {
+		t.Fatalf("expected non-negative age when now precedes captured_at, got %v", got)
+	}
+
+	var zero PRSnapshotV1
+	if got := zero.Age(now); got != 0 {
+		t.Fatalf("expected zero age for a snapshot with no captured_at, got %v", got)
+	}
+}

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -1,0 +1,12 @@
+package store
+
+import "fmt"
+
+const CurrentSchemaVersion = 1
+
+func validateSchemaVersion(recordKind string, version int) error {
+	if version != CurrentSchemaVersion {
+		return fmt.Errorf("unsupported %s schema version %d (this build supports version %d)", recordKind, version, CurrentSchemaVersion)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add an `internal/store` schema layer (#196): versioned, `SchemaVersion`-tagged JSON record types for PR snapshots, review runs, review events, adjudications, loop decisions, and review economics, each with its own `Validate()` and a shared `validateSchemaVersion()` that rejects unsupported versions
- add atomic filesystem stores with single-writer locking (#197): `internal/store/atomic.go` writes via temp-file-in-same-dir + write + fsync + chmod + atomic rename; `internal/store/lock.go` implements real `flock(LOCK_EX|LOCK_NB)` single-writer coordination (`AcquireWriteLock`/`ErrWriterLocked`); readers skip dotfiles/temp files and isolate individually corrupt records (`CorruptRecord`) instead of aborting a whole listing
- add adjudication, economics, and loop-decision logic plus a trust boundary around them (#223): `AdjudicationRecordV1` is an append-only decision record where reopen/correct/supersede are new records referencing the prior one, never a mutation; `ResolveFindingAdjudication` resolves the latest matching decision under an exact-match scope (PR + head + config fingerprint); `PolicySourceV1.Validate` is a fail-closed switch accepting only disabled/defaults/repository-revision sources and rejecting raw filesystem sources; `ValidatePolicySourceOutsideReview` separately rejects a policy source pinned to the PR head under review; `ResolveAdjudicationPolicy` wires both checks together so a reviewed PR's own head/worktree can never supply or alter budget/stop policy or evaluation guidance; `ProviderUsageV1`/`BudgetStateV1` carry a `Known` flag and reject `Known:false` with nonzero fields, so unavailable usage/cost/budget data can never collapse into a fabricated zero
- add `acr desk history`/`acr desk forget` commands (#198): `internal/desk` (`pr_ref.go`, `history.go`) provides `ParsePullRequestRef` and `BuildTimeline`/`LoadHistory`, merging all five record kinds into one chronologically sorted timeline; `internal/store/forget.go` provides `ForgetPullRequest` (`os.RemoveAll` scoped to exactly one PR's directory, with before/after counts); `cmd/acr/desk.go` registers `acr desk history` (read-only, never takes the write lock) and `acr desk forget` (takes `AcquireWriteLock`, refuses cleanly on conflict); `EconomicsStore.ListEconomics` now returns `[]EconomicsRecordV1{RecordedAt, Economics}`, recovering the timestamp from the store's filename convention
- remove all comments introduced during this work (repo-wide no-comments rule): stripped ~109 lines of godoc-style comments added across `internal/config/config.go` and 9 `internal/store` files, verified with `git diff origin/main...HEAD -- '*.go' | grep -nE '^\+.*(//|/\*)'` returning nothing but pre-existing `https://` string literals in test fixtures
- add missing "unsupported schema version" regression cases to `TestLoopDecisionV1_Validate` and the renamed `TestReviewEconomicsV1_ValidateRejectsInvalidFields`, matching the pattern already used by the other four record types' schema-version tests

## Behavior

Everything ACR now knows about a PR — its snapshots, review runs, append-only events, finding adjudications, review economics, and loop (continue/stop/escalate) decisions — is stored as versioned JSON records under the OS application-data directory (or `ACR_DATA_DIR`), written atomically and coordinated by a single-writer flock so a second `acr desk` process refuses cleanly instead of corrupting state. Readers tolerate individually corrupt records without losing the rest of a PR's history. Adjudications are append-only: reopening, correcting, or superseding a prior decision creates a new record referencing it, never overwrites it, and resolution is scoped exactly to PR + head + configuration fingerprint so a stale or mismatched decision never silently applies. Budget, stop-policy, and evaluation-guidance sources are validated through two independent checks — one that rejects raw filesystem sources outright, and one that rejects a source pinned to the very PR head under review — so the reviewed worktree can never become its own adjudication memory or policy. Provider usage and cost are tracked with an explicit `Known` flag rather than defaulting missing data to zero, keeping "unavailable" and "zero" distinguishable everywhere downstream. `acr desk history <owner/repo#number>` merges all five record kinds into one chronological, human-readable timeline without taking the write lock; `acr desk forget <owner/repo#number>` deletes exactly one PR's stored history under the write lock and reports what was removed.

## Validation

All commands run inside the `claude/phase2-persistence` worktree:

- `go build -o /tmp/acr-phase2-fix-build ./cmd/acr`
- `go test -race -count=10 ./internal/... ./cmd/acr/...` (all packages pass, race detector on)
- `make vet`
- `make staticcheck`
- `make lint`
- `git diff --check`
- `gofmt -l .`
- `git diff origin/main...HEAD -- '*.go' | grep -nE '^\+.*(//|/\*)' | grep -v 'https://'` — confirms zero remaining comment lines in the branch's Go diff

Closes #196
Closes #197
Closes #223
Closes #198
Part of #191
