### PR TITLE
[P3] Add workspace configuration and identity and posting policy

### DIFF
--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -20,6 +20,7 @@ func newDeskCmd() *cobra.Command {
 
 	cmd.AddCommand(newDeskHistoryCmd())
 	cmd.AddCommand(newDeskForgetCmd())
+	cmd.AddCommand(newDeskConfigCmd())
 
 	return cmd
 }

--- a/cmd/acr/desk_config.go
+++ b/cmd/acr/desk_config.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func newDeskConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage the persistent review workspace configuration",
+		Long:  "Initialize, display, and validate workspace-level identity, scope, and posting policy configuration.",
+	}
+
+	cmd.AddCommand(newDeskConfigInitCmd())
+	cmd.AddCommand(newDeskConfigShowCmd())
+	cmd.AddCommand(newDeskConfigValidateCmd())
+
+	return cmd
+}
+
+func newDeskConfigInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Generate a starter workspace configuration file",
+		Long:  "Create a workspace.yaml file in the OS-appropriate configuration directory (override with ACR_CONFIG_DIR). Posting and own-PR review are disabled by default.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configDir, err := workspace.ConfigDir()
+			if err != nil {
+				return err
+			}
+
+			defaultUser := github.GetCurrentUser(context.Background())
+			path, err := workspace.Init(configDir, defaultUser)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Created %s with default settings.\n", path)
+			if defaultUser == "" {
+				fmt.Println("Could not determine the authenticated GitHub user; set identity.expected_user before using the desk.")
+			}
+			return nil
+		},
+	}
+}
+
+func newDeskConfigShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Display the resolved workspace configuration",
+		Long:  "Show the workspace-level identity, scope, behavior, posting, and notification configuration.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configDir, err := workspace.ConfigDir()
+			if err != nil {
+				return err
+			}
+			cfg, err := workspace.Load(configDir)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Resolved workspace configuration:")
+			fmt.Println()
+			fmt.Printf("  %-24s %s\n", "identity.expected_user:", orNone(cfg.Identity.ExpectedUser))
+			fmt.Printf("  %-24s %s\n", "scope.organizations:", strings.Join(cfg.Scope.Organizations, ", "))
+			fmt.Printf("  %-24s %s\n", "scope.teams:", strings.Join(cfg.Scope.Teams, ", "))
+			fmt.Printf("  %-24s %s\n", "scope.repository_roots:", strings.Join(cfg.Scope.RepositoryRoots, ", "))
+			fmt.Printf("  %-24s %s\n", "scope.include:", strings.Join(cfg.Scope.Include, ", "))
+			fmt.Printf("  %-24s %s\n", "scope.exclude:", strings.Join(cfg.Scope.Exclude, ", "))
+			fmt.Printf("  %-24s %d\n", "scope.path_overrides:", len(cfg.Scope.PathOverrides))
+			fmt.Printf("  %-24s %s\n", "behavior.poll_interval:", cfg.Behavior.PollInterval.AsDuration())
+			fmt.Printf("  %-24s %s\n", "behavior.settle_time:", cfg.Behavior.SettleTime.AsDuration())
+			fmt.Printf("  %-24s %d\n", "behavior.concurrency:", cfg.Behavior.Concurrency)
+			fmt.Printf("  %-24s %t\n", "behavior.auto_review:", cfg.Behavior.AutoReview)
+			fmt.Printf("  %-24s %t\n", "behavior.re_review:", cfg.Behavior.ReReview)
+			fmt.Printf("  %-24s %s\n", "behavior.own_pr_policy:", cfg.Behavior.OwnPRPolicy)
+			fmt.Printf("  %-24s %t\n", "posting.enabled:", cfg.Posting.Enabled)
+			fmt.Printf("  %-24s %t\n", "notifications.enabled:", cfg.Notifications.Enabled)
+
+			return nil
+		},
+	}
+}
+
+func newDeskConfigValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate",
+		Short: "Validate workspace configuration and GitHub identity",
+		Long:  "Load and validate the workspace configuration, reporting any errors, and confirm the authenticated GitHub user matches the configured identity.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !terminal.IsStdoutTTY() {
+				terminal.DisableColors()
+			}
+			logger := terminal.NewLogger()
+
+			configDir, err := workspace.ConfigDir()
+			if err != nil {
+				return err
+			}
+			cfg, err := workspace.Load(configDir)
+			if err != nil {
+				return err
+			}
+
+			var errs []string
+			errs = append(errs, cfg.Validate()...)
+
+			if identityErr := workspace.CheckIdentity(context.Background(), *cfg); identityErr != nil {
+				errs = append(errs, identityErr.Error())
+			}
+
+			for _, e := range errs {
+				logger.Logf(terminal.StyleError, "%s", e)
+			}
+
+			if len(errs) > 0 {
+				return fmt.Errorf("workspace configuration has %d error(s)", len(errs))
+			}
+
+			logger.Log("Workspace configuration is valid.", terminal.StyleSuccess)
+			return nil
+		},
+	}
+}

--- a/cmd/acr/desk_config_test.go
+++ b/cmd/acr/desk_config_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func TestDeskConfigInit_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, dir)
+
+	cmd := newDeskConfigCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, workspace.ConfigFileName)); err != nil {
+		t.Fatalf("expected workspace.yaml to be created: %v", err)
+	}
+}
+
+func TestDeskConfigInit_FailsIfExists(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, dir)
+
+	if _, err := workspace.Init(dir, "octocat"); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newDeskConfigCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when workspace.yaml already exists")
+	}
+}
+
+func TestDeskConfigShow_MissingConfigIsError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, dir)
+
+	cmd := newDeskConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"show"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when workspace configuration does not exist")
+	}
+}
+
+func TestDeskConfigShow_PrintsResolvedConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, dir)
+	if _, err := workspace.Init(dir, "octocat"); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newDeskConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"show"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeskConfigValidate_DetectsInvalidOwnPRPolicy(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, dir)
+	if err := os.WriteFile(filepath.Join(dir, workspace.ConfigFileName), []byte(
+		"schema_version: 1\nidentity:\n  expected_user: octocat\nbehavior:\n  own_pr_policy: approve\n"),
+		0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newDeskConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"validate"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid own_pr_policy")
+	}
+	if !strings.Contains(err.Error(), "error") {
+		t.Errorf("expected error message to mention errors, got: %v", err)
+	}
+}
+
+func TestDeskConfigValidate_MissingConfigIsError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, dir)
+
+	cmd := newDeskConfigCmd()
+	cmd.SetArgs([]string{"validate"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when workspace configuration does not exist")
+	}
+}

--- a/internal/workspace/policy.go
+++ b/internal/workspace/policy.go
@@ -1,0 +1,94 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+)
+
+var ErrPostingDisabled = errors.New("posting is disabled in workspace configuration")
+
+func (c Config) Validate() []string {
+	var problems []string
+
+	if c.SchemaVersion != CurrentSchemaVersion {
+		problems = append(problems, fmt.Sprintf("schema_version: unsupported version %d (this build supports version %d)", c.SchemaVersion, CurrentSchemaVersion))
+	}
+
+	if strings.TrimSpace(c.Identity.ExpectedUser) == "" {
+		problems = append(problems, "identity.expected_user is required")
+	}
+
+	switch c.Behavior.OwnPRPolicy {
+	case OwnPRPolicyDisabled, OwnPRPolicyCommentOnly:
+	default:
+		problems = append(problems, fmt.Sprintf("behavior.own_pr_policy: invalid value %q (must be %q or %q)", c.Behavior.OwnPRPolicy, OwnPRPolicyDisabled, OwnPRPolicyCommentOnly))
+	}
+
+	if c.Behavior.Concurrency < 0 {
+		problems = append(problems, "behavior.concurrency must not be negative")
+	}
+	if c.Behavior.PollInterval.AsDuration() < 0 {
+		problems = append(problems, "behavior.poll_interval must not be negative")
+	}
+	if c.Behavior.SettleTime.AsDuration() < 0 {
+		problems = append(problems, "behavior.settle_time must not be negative")
+	}
+
+	problems = append(problems, validateNonEmptyEntries("scope.organizations", c.Scope.Organizations)...)
+	problems = append(problems, validateNonEmptyEntries("scope.teams", c.Scope.Teams)...)
+	problems = append(problems, validateNonEmptyEntries("scope.repository_roots", c.Scope.RepositoryRoots)...)
+	problems = append(problems, validateNonEmptyEntries("scope.include", c.Scope.Include)...)
+	problems = append(problems, validateNonEmptyEntries("scope.exclude", c.Scope.Exclude)...)
+
+	for key, value := range c.Scope.PathOverrides {
+		if strings.TrimSpace(key) == "" {
+			problems = append(problems, "scope.path_overrides must not contain an empty owner/repo key")
+		}
+		if strings.TrimSpace(value) == "" {
+			problems = append(problems, fmt.Sprintf("scope.path_overrides[%q] must not be empty", key))
+		}
+	}
+
+	return problems
+}
+
+func validateNonEmptyEntries(field string, entries []string) []string {
+	for _, entry := range entries {
+		if strings.TrimSpace(entry) == "" {
+			return []string{fmt.Sprintf("%s must not contain empty entries", field)}
+		}
+	}
+	return nil
+}
+
+func (c Config) RequirePosting() error {
+	if !c.Posting.Enabled {
+		return ErrPostingDisabled
+	}
+	return nil
+}
+
+func CheckIdentity(ctx context.Context, c Config) error {
+	return matchIdentity(github.GetCurrentUser(ctx), c.Identity.ExpectedUser)
+}
+
+func matchIdentity(actual, expected string) error {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return fmt.Errorf("workspace identity check failed: identity.expected_user is not configured")
+	}
+
+	if actual == "" {
+		return fmt.Errorf("workspace identity check failed: unable to determine the authenticated GitHub user (is gh installed and authenticated?)")
+	}
+
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("workspace identity check failed: authenticated GitHub user %q does not match configured identity.expected_user %q", actual, expected)
+	}
+
+	return nil
+}

--- a/internal/workspace/policy_test.go
+++ b/internal/workspace/policy_test.go
@@ -1,0 +1,139 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+)
+
+func validConfig() Config {
+	return Config{
+		SchemaVersion: CurrentSchemaVersion,
+		Identity:      IdentityConfig{ExpectedUser: "octocat"},
+		Behavior:      BehaviorConfig{OwnPRPolicy: OwnPRPolicyDisabled},
+	}
+}
+
+func TestValidate_AcceptsMinimalValidConfig(t *testing.T) {
+	if problems := validConfig().Validate(); len(problems) != 0 {
+		t.Fatalf("expected no problems, got: %v", problems)
+	}
+}
+
+func TestValidate_RequiresExpectedUser(t *testing.T) {
+	cfg := validConfig()
+	cfg.Identity.ExpectedUser = ""
+
+	if !containsSubstring(cfg.Validate(), "expected_user") {
+		t.Fatal("expected a problem for missing identity.expected_user")
+	}
+}
+
+func TestValidate_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	cfg := validConfig()
+	cfg.SchemaVersion = 999
+
+	if !containsSubstring(cfg.Validate(), "schema_version") {
+		t.Fatal("expected a schema_version problem")
+	}
+}
+
+func TestValidate_RejectsInvalidOwnPRPolicy(t *testing.T) {
+	cfg := validConfig()
+	cfg.Behavior.OwnPRPolicy = "approve"
+
+	if !containsSubstring(cfg.Validate(), "own_pr_policy") {
+		t.Fatal("expected an own_pr_policy problem")
+	}
+}
+
+func TestValidate_AcceptsCommentOnlyOwnPRPolicy(t *testing.T) {
+	cfg := validConfig()
+	cfg.Behavior.OwnPRPolicy = OwnPRPolicyCommentOnly
+
+	if problems := cfg.Validate(); len(problems) != 0 {
+		t.Fatalf("expected no problems, got: %v", problems)
+	}
+}
+
+func TestValidate_RejectsNegativeConcurrency(t *testing.T) {
+	cfg := validConfig()
+	cfg.Behavior.Concurrency = -1
+
+	if !containsSubstring(cfg.Validate(), "concurrency") {
+		t.Fatal("expected a concurrency problem")
+	}
+}
+
+func TestValidate_RejectsEmptyScopeEntries(t *testing.T) {
+	cfg := validConfig()
+	cfg.Scope.Organizations = []string{"acme", ""}
+
+	if !containsSubstring(cfg.Validate(), "scope.organizations") {
+		t.Fatal("expected a scope.organizations problem")
+	}
+}
+
+func TestValidate_RejectsEmptyPathOverrideValue(t *testing.T) {
+	cfg := validConfig()
+	cfg.Scope.PathOverrides = map[string]string{"acme/widgets": ""}
+
+	if !containsSubstring(cfg.Validate(), "path_overrides") {
+		t.Fatal("expected a path_overrides problem")
+	}
+}
+
+func TestRequirePosting_DisabledByDefault(t *testing.T) {
+	cfg := validConfig()
+
+	if err := cfg.RequirePosting(); err != ErrPostingDisabled {
+		t.Fatalf("expected ErrPostingDisabled, got: %v", err)
+	}
+}
+
+func TestRequirePosting_AllowsWhenEnabled(t *testing.T) {
+	cfg := validConfig()
+	cfg.Posting.Enabled = true
+
+	if err := cfg.RequirePosting(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestMatchIdentity_MatchingSameCase(t *testing.T) {
+	if err := matchIdentity("octocat", "octocat"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestMatchIdentity_MatchingDifferentCase(t *testing.T) {
+	if err := matchIdentity("OctoCat", "octocat"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestMatchIdentity_Mismatch(t *testing.T) {
+	if err := matchIdentity("hubot", "octocat"); err == nil {
+		t.Fatal("expected error for mismatched identity")
+	}
+}
+
+func TestMatchIdentity_FailsClosedWhenActualUnknown(t *testing.T) {
+	if err := matchIdentity("", "octocat"); err == nil {
+		t.Fatal("expected error when the authenticated user cannot be determined")
+	}
+}
+
+func TestMatchIdentity_FailsClosedWhenExpectedUnconfigured(t *testing.T) {
+	if err := matchIdentity("octocat", ""); err == nil {
+		t.Fatal("expected error when identity.expected_user is not configured")
+	}
+}
+
+func containsSubstring(problems []string, substr string) bool {
+	for _, p := range problems {
+		if strings.Contains(p, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,139 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+)
+
+const (
+	ConfigDirEnvVar      = "ACR_CONFIG_DIR"
+	ConfigFileName       = "workspace.yaml"
+	CurrentSchemaVersion = 1
+)
+
+type OwnPRPolicy string
+
+const (
+	OwnPRPolicyDisabled    OwnPRPolicy = "disabled"
+	OwnPRPolicyCommentOnly OwnPRPolicy = "comment-only"
+)
+
+type IdentityConfig struct {
+	ExpectedUser string `yaml:"expected_user"`
+}
+
+type ScopeConfig struct {
+	Organizations   []string          `yaml:"organizations"`
+	Teams           []string          `yaml:"teams"`
+	RepositoryRoots []string          `yaml:"repository_roots"`
+	Include         []string          `yaml:"include"`
+	Exclude         []string          `yaml:"exclude"`
+	PathOverrides   map[string]string `yaml:"path_overrides"`
+}
+
+type BehaviorConfig struct {
+	PollInterval config.Duration `yaml:"poll_interval"`
+	SettleTime   config.Duration `yaml:"settle_time"`
+	Concurrency  int             `yaml:"concurrency"`
+	AutoReview   bool            `yaml:"auto_review"`
+	ReReview     bool            `yaml:"re_review"`
+	OwnPRPolicy  OwnPRPolicy     `yaml:"own_pr_policy"`
+}
+
+type PostingConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type NotificationsConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type Config struct {
+	SchemaVersion int                 `yaml:"schema_version"`
+	Identity      IdentityConfig      `yaml:"identity"`
+	Scope         ScopeConfig         `yaml:"scope"`
+	Behavior      BehaviorConfig      `yaml:"behavior"`
+	Posting       PostingConfig       `yaml:"posting"`
+	Notifications NotificationsConfig `yaml:"notifications"`
+}
+
+func ConfigDir() (string, error) {
+	if dir := os.Getenv(ConfigDirEnvVar); dir != "" {
+		return dir, nil
+	}
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace configuration directory: %w", err)
+	}
+	return filepath.Join(base, "acr"), nil
+}
+
+func ConfigPath(configDir string) string {
+	return filepath.Join(configDir, ConfigFileName)
+}
+
+func Load(configDir string) (*Config, error) {
+	path := ConfigPath(configDir)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("workspace configuration not found at %s; run `acr desk config init` first", path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read workspace configuration: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", ConfigFileName, err)
+	}
+	return &cfg, nil
+}
+
+func Init(configDir string, defaultUser string) (string, error) {
+	path := ConfigPath(configDir)
+	if _, err := os.Stat(path); err == nil {
+		return "", fmt.Errorf("%s already exists; remove it first or edit it directly", path)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("failed to check %s: %w", path, err)
+	}
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create workspace configuration directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(starterYAML(defaultUser)), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return path, nil
+}
+
+func starterYAML(defaultUser string) string {
+	return fmt.Sprintf(`schema_version: %d
+identity:
+  expected_user: %q
+scope:
+  organizations: []
+  teams: []
+  repository_roots: []
+  include: []
+  exclude: []
+  path_overrides: {}
+behavior:
+  poll_interval: 1m
+  settle_time: 10m
+  concurrency: 0
+  auto_review: false
+  re_review: false
+  own_pr_policy: disabled
+posting:
+  enabled: false
+notifications:
+  enabled: false
+`, CurrentSchemaVersion, defaultUser)
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,119 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigDir_UsesEnvOverride(t *testing.T) {
+	t.Setenv(ConfigDirEnvVar, "/custom/config/dir")
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != "/custom/config/dir" {
+		t.Fatalf("expected env override, got %q", dir)
+	}
+}
+
+func TestConfigDir_DefaultsUnderOSConfigDir(t *testing.T) {
+	t.Setenv(ConfigDirEnvVar, "")
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filepath.Base(dir) != "acr" {
+		t.Fatalf("expected default config dir to end in acr, got %q", dir)
+	}
+}
+
+func TestInit_CreatesFileWithSafeDefaults(t *testing.T) {
+	dir := t.TempDir()
+
+	path, err := Init(dir, "octocat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != filepath.Join(dir, ConfigFileName) {
+		t.Fatalf("unexpected path: %q", path)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read created file: %v", err)
+	}
+	text := string(content)
+
+	for _, want := range []string{
+		"schema_version: 1",
+		`expected_user: "octocat"`,
+		"posting:\n  enabled: false",
+		"own_pr_policy: disabled",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("expected starter config to contain %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestInit_FailsIfExists(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := Init(dir, "octocat"); err != nil {
+		t.Fatalf("unexpected error on first init: %v", err)
+	}
+	if _, err := Init(dir, "octocat"); err == nil {
+		t.Fatal("expected error when workspace.yaml already exists")
+	}
+}
+
+func TestLoad_MissingFileMentionsInit(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected error for missing workspace configuration")
+	}
+	if !strings.Contains(err.Error(), "acr desk config init") {
+		t.Errorf("expected error to reference init command, got: %v", err)
+	}
+}
+
+func TestLoad_InvalidYAMLIsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ConfigFileName), []byte("not: [valid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(dir); err == nil {
+		t.Fatal("expected error for invalid yaml")
+	}
+}
+
+func TestInitThenLoad_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Init(dir, "octocat"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Identity.ExpectedUser != "octocat" {
+		t.Errorf("expected identity.expected_user to round-trip, got %q", cfg.Identity.ExpectedUser)
+	}
+	if cfg.Posting.Enabled {
+		t.Error("expected posting to be disabled by default")
+	}
+	if cfg.Behavior.OwnPRPolicy != OwnPRPolicyDisabled {
+		t.Errorf("expected own_pr_policy to default to disabled, got %q", cfg.Behavior.OwnPRPolicy)
+	}
+	if len(cfg.Validate()) != 0 {
+		t.Errorf("expected freshly initialized config to be valid, got problems: %v", cfg.Validate())
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/workspace`: a versioned `workspace.yaml` (`schema_version: 1`) loaded from an OS-appropriate config directory (`ACR_CONFIG_DIR` override, mirroring `store.DataDir()`'s pattern) that is independent of per-repository review configuration. Covers `identity.expected_user`, `scope` (organizations/teams/repository_roots/include/exclude/path_overrides), `behavior` (poll_interval/settle_time/concurrency/auto_review/re_review/own_pr_policy), `posting.enabled` (disabled by default), and `notifications.enabled`.
- `Config.Validate()` returns actionable problem strings (unsupported schema version, missing `expected_user`, invalid `own_pr_policy`, negative concurrency/durations, empty scope entries or path-override values).
- `Config.RequirePosting()` returns a sentinel `ErrPostingDisabled` unless posting is explicitly enabled, so discovery/local-review/history/inspection are unaffected by posting being off.
- `CheckIdentity`/`matchIdentity` fail closed on any mismatch between the authenticated `gh` user and `identity.expected_user`, or when either is unavailable/unconfigured. `matchIdentity` is a pure function unit-tested directly, following the same pattern as `checkSelfReview` in `internal/github`.
- `own_pr_policy` is restricted to `disabled`/`comment-only` only — no configuration path can produce anything other than a comment on the user's own PRs.
- Add `acr desk config init/show/validate`, mirroring the structure of the existing `acr config` command.

Ordinary `acr` and `acr watch` are untouched — `internal/workspace` isn't imported anywhere in their code paths, so desk identity/posting policy can't affect them.

Note: the AC "identity mismatch prevents desk discovery and every desk mutation" can only be partially satisfied here since discovery (#202) and GitHub mutation actions (#206) don't exist yet. This PR delivers `CheckIdentity`/`RequirePosting` as the reusable, tested primitives those issues are expected to call.

## Test plan

- [x] `make check` (fmt, lint, vet, staticcheck, full unit test suite) passes
- [x] Manual smoke test: `acr desk config init` / `show` / `validate` against a temp `ACR_CONFIG_DIR`
- [x] New table-driven tests in `internal/workspace` and `cmd/acr`

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)