### PR TITLE
[P3] Make worktree, review, and GitHub operations repository-scoped

### DIFF
--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -180,7 +180,15 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 			return result, exitCode(domain.ExitError)
 		}
 
-		if err := github.ValidatePR(ctx, prNumber); err != nil {
+		repoRoot, err := git.GetRoot()
+		if err != nil {
+			logger.Logf(terminal.StyleError, "%v", err)
+			return result, exitCode(domain.ExitError)
+		}
+		result.prRepoRoot = repoRoot
+		result.repositoryRoot = repoRoot
+
+		if err := github.ValidatePR(ctx, repoRoot, prNumber); err != nil {
 			if errors.Is(err, github.ErrNoPRFound) {
 				logger.Logf(terminal.StyleError, "PR #%s not found", prNumber)
 			} else if errors.Is(err, github.ErrAuthFailed) {
@@ -196,20 +204,12 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 
 		explicitBaseSet := cmd.Flags().Changed("base") || os.Getenv("ACR_BASE_REF") != ""
 		if !explicitBaseSet {
-			if detectedBase, err := github.GetPRBaseRef(ctx, prNumber); err == nil && detectedBase != "" {
+			if detectedBase, err := github.GetPRBaseRef(ctx, repoRoot, prNumber); err == nil && detectedBase != "" {
 				result.detectedBase = detectedBase
 				result.baseAutoDetected = true
 				logger.Logf(terminal.StyleDim, "Auto-detected base: %s", detectedBase)
 			}
 		}
-
-		repoRoot, err := git.GetRoot()
-		if err != nil {
-			logger.Logf(terminal.StyleError, "%v", err)
-			return result, exitCode(domain.ExitError)
-		}
-		result.prRepoRoot = repoRoot
-		result.repositoryRoot = repoRoot
 
 		remote, err := github.FindRepoRemote(ctx, repoRoot)
 		if err != nil {
@@ -218,7 +218,7 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 		}
 		result.prRemote = remote
 
-		wt, err := git.CreateWorktreeFromPR(repoRoot, remote, prNumber)
+		wt, err := git.CreateWorktreeFromPR(ctx, repoRoot, remote, prNumber)
 		if err != nil {
 			logger.Logf(terminal.StyleError, "%v", err)
 			return result, exitCode(domain.ExitError)
@@ -238,6 +238,13 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 		var actualRef string
 		var cleanupRemote func()
 
+		repoRoot, err := git.GetRoot()
+		if err != nil {
+			logger.Logf(terminal.StyleError, "Error getting repo root: %v", err)
+			return result, exitCode(domain.ExitError)
+		}
+		result.repositoryRoot = repoRoot
+
 		forkRef, err := github.ResolveForkRef(ctx, worktreeBranch)
 		if err != nil {
 			logger.Logf(terminal.StyleError, "%v", err)
@@ -248,13 +255,6 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 
 			logger.Logf(terminal.StyleInfo, "Resolved fork PR #%d from %s",
 				forkRef.PRNumber, forkRef.Username)
-
-			repoRoot, err := git.GetRoot()
-			if err != nil {
-				logger.Logf(terminal.StyleError, "Error getting repo root: %v", err)
-				return result, exitCode(domain.ExitError)
-			}
-			result.repositoryRoot = repoRoot
 
 			if err := git.AddRemote(repoRoot, forkRef.RemoteName, forkRef.RepoURL); err != nil {
 				logger.Logf(terminal.StyleError, "Error adding remote: %v", err)
@@ -277,7 +277,7 @@ func setupWorktree(ctx context.Context, cmd *cobra.Command, logger *terminal.Log
 			actualRef = worktreeBranch
 		}
 
-		wt, err := git.CreateWorktree(actualRef)
+		wt, err := git.CreateWorktree(ctx, repoRoot, actualRef)
 		if err != nil {
 			if cleanupRemote != nil {
 				cleanupRemote()
@@ -467,8 +467,12 @@ func runReview(cmd *cobra.Command, _ []string) error {
 
 	logger := terminal.NewLogger()
 
-	if err := git.PruneStaleWorktrees(); err != nil && verbose {
-		logger.Logf(terminal.StyleDim, "Worktree prune: %v", err)
+	if repoRoot, err := git.GetRoot(); err == nil {
+		if err := git.PruneStaleWorktrees(repoRoot); err != nil && verbose {
+			logger.Logf(terminal.StyleDim, "Worktree prune: %v", err)
+		}
+	} else if verbose {
+		logger.Logf(terminal.StyleDim, "Worktree prune skipped: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -517,7 +521,7 @@ func runReview(cmd *cobra.Command, _ []string) error {
 
 	detectedPR := prNumber
 	if detectedPR == "" && !local && cfgResult.resolved.PRFeedbackEnabled && github.IsGHAvailable() {
-		if detected, err := github.GetCurrentPRNumber(ctx, worktreeBranch); err == nil {
+		if detected, err := github.GetCurrentPRNumber(ctx, repositoryRoot, worktreeBranch); err == nil {
 			detectedPR = detected
 			if verbose {
 				logger.Logf(terminal.StyleDim, "Auto-detected PR #%s for current branch", detectedPR)

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -31,17 +31,17 @@ func getPRContext(ctx context.Context, opts ReviewOpts) prContext {
 	if opts.PRNumber != "" {
 		return prContext{
 			number:       opts.PRNumber,
-			isSelfReview: github.IsSelfReview(ctx, opts.PRNumber),
+			isSelfReview: github.IsSelfReview(ctx, opts.RepositoryRoot, opts.PRNumber),
 		}
 	}
 
-	foundPR, err := github.GetCurrentPRNumber(ctx, opts.WorktreeBranch)
+	foundPR, err := github.GetCurrentPRNumber(ctx, opts.RepositoryRoot, opts.WorktreeBranch)
 	if err != nil {
 		return prContext{err: err}
 	}
 	return prContext{
 		number:       foundPR,
-		isSelfReview: github.IsSelfReview(ctx, foundPR),
+		isSelfReview: github.IsSelfReview(ctx, opts.RepositoryRoot, foundPR),
 	}
 }
 
@@ -257,7 +257,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 	}
 
 	if err := retrySubmission(ctx, func() error {
-		return github.SubmitPRReview(ctx, pr.number, body, requestChanges)
+		return github.SubmitPRReview(ctx, opts.RepositoryRoot, pr.number, body, requestChanges)
 	}, opts.Outcome != nil, logger); err != nil {
 		logger.Logf(terminal.StyleError, "Failed: %v", err)
 		return err
@@ -342,7 +342,7 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 	}
 
 	if err := retrySubmission(ctx, func() error {
-		return executeLGTMAction(ctx, action, pr.number, body, logger)
+		return executeLGTMAction(ctx, opts.RepositoryRoot, action, pr.number, body, logger)
 	}, opts.Outcome != nil, logger); err != nil {
 		return err
 	}
@@ -419,7 +419,7 @@ func headMovedSinceReview(ctx context.Context, opts ReviewOpts, prNumber string,
 	if opts.ExpectedHeadSHA == "" {
 		return false
 	}
-	st, err := github.GetPRWatchState(ctx, prNumber)
+	st, err := github.GetPRWatchState(ctx, opts.RepositoryRoot, prNumber)
 	if err != nil || st.HeadSHA == "" {
 		return false
 	}
@@ -441,7 +441,7 @@ func logCIChecks(logger *terminal.Logger, checks []string) {
 }
 
 func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmAction, opts ReviewOpts, logger *terminal.Logger) (lgtmAction, error) {
-	ciStatus := github.CheckCIStatus(ctx, prNum)
+	ciStatus := github.CheckCIStatus(ctx, opts.RepositoryRoot, prNum)
 
 	if ciStatus.Error != "" {
 		if opts.Outcome == nil {
@@ -505,16 +505,16 @@ func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmActi
 	}
 }
 
-func executeLGTMAction(ctx context.Context, action lgtmAction, prNumber, body string, logger *terminal.Logger) error {
+func executeLGTMAction(ctx context.Context, repositoryRoot string, action lgtmAction, prNumber, body string, logger *terminal.Logger) error {
 	switch action {
 	case actionApprove:
-		if err := github.ApprovePR(ctx, prNumber, body); err != nil {
+		if err := github.ApprovePR(ctx, repositoryRoot, prNumber, body); err != nil {
 			logger.Logf(terminal.StyleError, "Failed: %v", err)
 			return err
 		}
 		logger.Logf(terminal.StyleSuccess, "Approved PR #%s.", prNumber)
 	case actionComment:
-		if err := github.SubmitPRReview(ctx, prNumber, body, false); err != nil {
+		if err := github.SubmitPRReview(ctx, repositoryRoot, prNumber, body, false); err != nil {
 			logger.Logf(terminal.StyleError, "Failed: %v", err)
 			return err
 		}

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -86,7 +86,13 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		return exitCode(domain.ExitError)
 	}
 
-	if err := git.PruneStaleWorktrees(); err != nil && verbose {
+	repoRoot, err := git.GetRoot()
+	if err != nil {
+		logger.Logf(terminal.StyleError, "%v", err)
+		return exitCode(domain.ExitError)
+	}
+
+	if err := git.PruneStaleWorktrees(repoRoot); err != nil && verbose {
 		logger.Logf(terminal.StyleDim, "Worktree prune: %v", err)
 	}
 
@@ -104,7 +110,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 
 	watchPR := prNumber
 	if watchPR == "" {
-		detected, err := github.GetCurrentPRNumber(ctx, "")
+		detected, err := github.GetCurrentPRNumber(ctx, repoRoot, "")
 		switch {
 		case errors.Is(err, github.ErrAuthFailed):
 			logger.Log("GitHub authentication failed. Run 'gh auth login' to authenticate.", terminal.StyleError)
@@ -119,7 +125,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		watchPR = detected
 		logger.Logf(terminal.StyleDim, "Detected PR #%s for current branch", watchPR)
 	}
-	if err := github.ValidatePR(ctx, watchPR); err != nil {
+	if err := github.ValidatePR(ctx, repoRoot, watchPR); err != nil {
 		logger.Logf(terminal.StyleError, "Failed to access PR #%s: %v", watchPR, err)
 		return exitCode(domain.ExitError)
 	}
@@ -172,7 +178,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 			logger.Logf(terminal.StyleInfo, format, args...)
 		},
 		State: func(ctx context.Context) (watch.PRState, error) {
-			st, err := github.GetPRWatchState(ctx, watchPR)
+			st, err := github.GetPRWatchState(ctx, repoRoot, watchPR)
 			if err != nil {
 				return watch.PRState{}, err
 			}
@@ -184,14 +190,14 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 			}, nil
 		},
 		CIGreen: func(ctx context.Context) (bool, error) {
-			status := github.CheckCIStatus(ctx, watchPR)
+			status := github.CheckCIStatus(ctx, repoRoot, watchPR)
 			if status.Error != "" {
 				return false, fmt.Errorf("%s", status.Error)
 			}
 			return status.AllPassed, nil
 		},
 		Approve: func(ctx context.Context, body string) error {
-			return github.ApprovePR(ctx, watchPR, body)
+			return github.ApprovePR(ctx, repoRoot, watchPR, body)
 		},
 		RunCycle: func(ctx context.Context, _ int, _ string) (watch.Cycle, error) {
 			return runWatchCycle(ctx, cmd, watchPR, mode, logger)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -51,14 +51,6 @@ func GetHeadSHA(dir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func GetCommonDir() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get current directory: %w", err)
-	}
-	return GetCommonDirAt(context.Background(), dir)
-}
-
 func GetCommonDirAt(ctx context.Context, dir string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
 	cmd.Dir = dir
@@ -145,12 +137,7 @@ func ensureWorktreesExcluded(commonDir string) error {
 
 const staleWorktreeAge = 2 * time.Hour
 
-func PruneStaleWorktrees() error {
-	root, err := GetRoot()
-	if err != nil {
-		return err
-	}
-
+func PruneStaleWorktrees(root string) error {
 	worktreesDir := filepath.Join(root, ".worktrees")
 	entries, err := os.ReadDir(worktreesDir)
 	if err != nil {
@@ -193,8 +180,8 @@ func PruneStaleWorktrees() error {
 	return nil
 }
 
-func CreateWorktree(branch string) (*Worktree, error) {
-	commonDir, err := GetCommonDir()
+func CreateWorktree(ctx context.Context, repositoryRoot, branch string) (*Worktree, error) {
+	commonDir, err := GetCommonDirAt(ctx, repositoryRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -409,13 +396,12 @@ func fetchPRRef(repoRoot, remote, prNumber string) error {
 	return nil
 }
 
-func CreateWorktreeFromPR(repoRoot, remote, prNumber string) (*Worktree, error) {
-
+func CreateWorktreeFromPR(ctx context.Context, repoRoot, remote, prNumber string) (*Worktree, error) {
 	if err := fetchPRRef(repoRoot, remote, prNumber); err != nil {
 		return nil, err
 	}
 
-	commonDir, err := GetCommonDir()
+	commonDir, err := GetCommonDirAt(ctx, repoRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/worktree_prune_test.go
+++ b/internal/git/worktree_prune_test.go
@@ -8,30 +8,27 @@ import (
 )
 
 func TestPruneStaleWorktrees_NoWorktreesDir(t *testing.T) {
+	root := setupTestRepo(t)
 
-	err := PruneStaleWorktrees()
+	err := PruneStaleWorktrees(root)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestPruneStaleWorktrees_SkipsNonReviewDirs(t *testing.T) {
-	root, err := GetRoot()
-	if err != nil {
-		t.Skip("not in a git repo")
-	}
+	root := setupTestRepo(t)
 
 	worktreesDir := filepath.Join(root, ".worktrees")
 	testDir := filepath.Join(worktreesDir, "my-custom-worktree")
 	if err := os.MkdirAll(testDir, 0755); err != nil {
 		t.Fatalf("failed to create test dir: %v", err)
 	}
-	defer os.RemoveAll(testDir)
 
 	oldTime := time.Now().Add(-24 * time.Hour)
 	os.Chtimes(testDir, oldTime, oldTime)
 
-	err = PruneStaleWorktrees()
+	err := PruneStaleWorktrees(root)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -42,19 +39,15 @@ func TestPruneStaleWorktrees_SkipsNonReviewDirs(t *testing.T) {
 }
 
 func TestPruneStaleWorktrees_SkipsRecentReviewDirs(t *testing.T) {
-	root, err := GetRoot()
-	if err != nil {
-		t.Skip("not in a git repo")
-	}
+	root := setupTestRepo(t)
 
 	worktreesDir := filepath.Join(root, ".worktrees")
 	testDir := filepath.Join(worktreesDir, "review-test-recent")
 	if err := os.MkdirAll(testDir, 0755); err != nil {
 		t.Fatalf("failed to create test dir: %v", err)
 	}
-	defer os.RemoveAll(testDir)
 
-	err = PruneStaleWorktrees()
+	err := PruneStaleWorktrees(root)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -62,15 +55,10 @@ func TestPruneStaleWorktrees_SkipsRecentReviewDirs(t *testing.T) {
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
 		t.Error("PruneStaleWorktrees removed a recent review directory")
 	}
-
-	os.RemoveAll(testDir)
 }
 
 func TestPruneStaleWorktrees_RemovesOldReviewDirs(t *testing.T) {
-	root, err := GetRoot()
-	if err != nil {
-		t.Skip("not in a git repo")
-	}
+	root := setupTestRepo(t)
 
 	worktreesDir := filepath.Join(root, ".worktrees")
 	testDir := filepath.Join(worktreesDir, "review-test-stale-abc123")
@@ -81,13 +69,12 @@ func TestPruneStaleWorktrees_RemovesOldReviewDirs(t *testing.T) {
 	oldTime := time.Now().Add(-3 * time.Hour)
 	os.Chtimes(testDir, oldTime, oldTime)
 
-	err = PruneStaleWorktrees()
+	err := PruneStaleWorktrees(root)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if _, err := os.Stat(testDir); !os.IsNotExist(err) {
 		t.Error("PruneStaleWorktrees did not remove stale review directory")
-		os.RemoveAll(testDir)
 	}
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -102,22 +102,13 @@ func TestWorktree_Remove_ValidWorktree(t *testing.T) {
 func TestCreateWorktree_Success(t *testing.T) {
 	repoDir := setupTestRepo(t)
 
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current dir: %v", err)
-	}
-	if err := os.Chdir(repoDir); err != nil {
-		t.Fatalf("failed to change to repo dir: %v", err)
-	}
-	defer os.Chdir(origDir)
-
 	cmd := exec.Command("git", "branch", "feature-branch")
 	cmd.Dir = repoDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to create branch: %v\n%s", err, out)
 	}
 
-	wt, err := CreateWorktree("feature-branch")
+	wt, err := CreateWorktree(context.Background(), repoDir, "feature-branch")
 	if err != nil {
 		t.Fatalf("CreateWorktree failed: %v", err)
 	}
@@ -138,16 +129,7 @@ func TestCreateWorktree_Success(t *testing.T) {
 func TestCreateWorktree_InvalidBranch(t *testing.T) {
 	repoDir := setupTestRepo(t)
 
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current dir: %v", err)
-	}
-	if err := os.Chdir(repoDir); err != nil {
-		t.Fatalf("failed to change to repo dir: %v", err)
-	}
-	defer os.Chdir(origDir)
-
-	_, err = CreateWorktree("nonexistent-branch")
+	_, err := CreateWorktree(context.Background(), repoDir, "nonexistent-branch")
 	if err == nil {
 		t.Error("expected error for non-existent branch")
 	}
@@ -156,22 +138,13 @@ func TestCreateWorktree_InvalidBranch(t *testing.T) {
 func TestCreateWorktree_BranchWithSlashes(t *testing.T) {
 	repoDir := setupTestRepo(t)
 
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current dir: %v", err)
-	}
-	if err := os.Chdir(repoDir); err != nil {
-		t.Fatalf("failed to change to repo dir: %v", err)
-	}
-	defer os.Chdir(origDir)
-
 	cmd := exec.Command("git", "branch", "feature/test/branch")
 	cmd.Dir = repoDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to create branch: %v\n%s", err, out)
 	}
 
-	wt, err := CreateWorktree("feature/test/branch")
+	wt, err := CreateWorktree(context.Background(), repoDir, "feature/test/branch")
 	if err != nil {
 		t.Fatalf("CreateWorktree failed: %v", err)
 	}
@@ -182,6 +155,59 @@ func TestCreateWorktree_BranchWithSlashes(t *testing.T) {
 	}
 	if !strings.Contains(wt.Path, "review-feature-test-branch-") {
 		t.Errorf("worktree path format unexpected: %s", wt.Path)
+	}
+}
+
+func TestCreateWorktree_NoChdirRequired(t *testing.T) {
+	repoA := setupTestRepo(t)
+	repoB := setupTestRepo(t)
+
+	for _, repo := range []string{repoA, repoB} {
+		cmd := exec.Command("git", "branch", "feature-branch")
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("failed to create branch in %s: %v\n%s", repo, err, out)
+		}
+	}
+
+	startDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current dir: %v", err)
+	}
+
+	wtA, err := CreateWorktree(context.Background(), repoA, "feature-branch")
+	if err != nil {
+		t.Fatalf("CreateWorktree(repoA) failed: %v", err)
+	}
+	defer wtA.Remove()
+
+	wtB, err := CreateWorktree(context.Background(), repoB, "feature-branch")
+	if err != nil {
+		t.Fatalf("CreateWorktree(repoB) failed: %v", err)
+	}
+	defer wtB.Remove()
+
+	endDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current dir: %v", err)
+	}
+	if startDir != endDir {
+		t.Fatalf("process working directory changed: %s -> %s", startDir, endDir)
+	}
+
+	resolvedRepoA, err := filepath.EvalSymlinks(repoA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedRepoB, err := filepath.EvalSymlinks(repoB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(wtA.Path, resolvedRepoA) {
+		t.Errorf("expected worktree A under %s, got %s", resolvedRepoA, wtA.Path)
+	}
+	if !strings.HasPrefix(wtB.Path, resolvedRepoB) {
+		t.Errorf("expected worktree B under %s, got %s", resolvedRepoB, wtB.Path)
 	}
 }
 
@@ -231,28 +257,6 @@ func TestGetRoot_NotInGitRepo(t *testing.T) {
 	_, err = GetRoot()
 	if err == nil {
 		t.Error("expected error when not in git repo")
-	}
-}
-
-func TestGetCommonDir_InGitRepo(t *testing.T) {
-	repoDir := setupTestRepo(t)
-
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current dir: %v", err)
-	}
-	if err := os.Chdir(repoDir); err != nil {
-		t.Fatalf("failed to change to repo dir: %v", err)
-	}
-	defer os.Chdir(origDir)
-
-	commonDir, err := GetCommonDir()
-	if err != nil {
-		t.Fatalf("GetCommonDir failed: %v", err)
-	}
-
-	if !strings.HasSuffix(commonDir, ".git") {
-		t.Errorf("common dir should end with .git, got %s", commonDir)
 	}
 }
 
@@ -377,19 +381,9 @@ func TestFetchPRRef_UsesRemoteParameter(t *testing.T) {
 }
 
 func TestCreateWorktreeFromPR_SignatureAndErrorMessage(t *testing.T) {
-
 	repoDir := setupTestRepo(t)
 
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current dir: %v", err)
-	}
-	if err := os.Chdir(repoDir); err != nil {
-		t.Fatalf("failed to change to repo dir: %v", err)
-	}
-	defer os.Chdir(origDir)
-
-	_, err = CreateWorktreeFromPR(repoDir, "origin", "999")
+	_, err := CreateWorktreeFromPR(context.Background(), repoDir, "origin", "999")
 
 	if err == nil {
 		t.Error("expected error when fetching from non-existent remote")

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -23,7 +23,7 @@ type CIStatus struct {
 	Error     string
 }
 
-func GetCurrentPRNumber(ctx context.Context, branch string) (string, error) {
+func GetCurrentPRNumber(ctx context.Context, repositoryRoot, branch string) (string, error) {
 	args := []string{"pr", "view"}
 	if branch != "" {
 		args = append(args, branch)
@@ -31,6 +31,7 @@ func GetCurrentPRNumber(ctx context.Context, branch string) (string, error) {
 	args = append(args, "--json", "number", "--jq", ".number")
 
 	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = repositoryRoot
 	out, err := cmd.Output()
 	if err != nil {
 		return "", classifyGHError(err)
@@ -51,18 +52,9 @@ func parsePRViewJSON(data []byte) (head, base string, err error) {
 	return resp.HeadRefName, resp.BaseRefName, nil
 }
 
-func GetPRBranch(ctx context.Context, prNumber string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "headRefName")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", classifyGHError(err)
-	}
-	head, _, err := parsePRViewJSON(out)
-	return head, err
-}
-
-func GetPRBaseRef(ctx context.Context, prNumber string) (string, error) {
+func GetPRBaseRef(ctx context.Context, repositoryRoot, prNumber string) (string, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "baseRefName")
+	cmd.Dir = repositoryRoot
 	out, err := cmd.Output()
 	if err != nil {
 		return "", classifyGHError(err)
@@ -71,9 +63,9 @@ func GetPRBaseRef(ctx context.Context, prNumber string) (string, error) {
 	return base, err
 }
 
-func ValidatePR(ctx context.Context, prNumber string) error {
-
+func ValidatePR(ctx context.Context, repositoryRoot, prNumber string) error {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "number")
+	cmd.Dir = repositoryRoot
 	_, err := cmd.Output()
 	if err != nil {
 		return classifyGHError(err)
@@ -279,8 +271,9 @@ func classifyGHError(err error) error {
 	return fmt.Errorf("gh command failed: %w", err)
 }
 
-func ApprovePR(ctx context.Context, prNumber, body string) error {
+func ApprovePR(ctx context.Context, repositoryRoot, prNumber, body string) error {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "review", prNumber, "--approve", "--body-file", "-")
+	cmd.Dir = repositoryRoot
 	cmd.Stdin = strings.NewReader(body)
 
 	var stderr bytes.Buffer
@@ -296,13 +289,14 @@ func ApprovePR(ctx context.Context, prNumber, body string) error {
 	return nil
 }
 
-func SubmitPRReview(ctx context.Context, prNumber, body string, requestChanges bool) error {
+func SubmitPRReview(ctx context.Context, repositoryRoot, prNumber, body string, requestChanges bool) error {
 	flag := "--comment"
 	if requestChanges {
 		flag = "--request-changes"
 	}
 
 	cmd := exec.CommandContext(ctx, "gh", "pr", "review", prNumber, flag, "--body-file", "-")
+	cmd.Dir = repositoryRoot
 	cmd.Stdin = strings.NewReader(body)
 
 	var stderr bytes.Buffer
@@ -318,8 +312,9 @@ func SubmitPRReview(ctx context.Context, prNumber, body string, requestChanges b
 	return nil
 }
 
-func CheckCIStatus(ctx context.Context, prNumber string) CIStatus {
+func CheckCIStatus(ctx context.Context, repositoryRoot, prNumber string) CIStatus {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "checks", prNumber, "--json", "name,bucket")
+	cmd.Dir = repositoryRoot
 	out, err := cmd.Output()
 	if err != nil {
 		var stderr bytes.Buffer
@@ -397,8 +392,9 @@ func (s PRWatchState) ReviewRequestedFrom(login string) bool {
 	return false
 }
 
-func GetPRWatchState(ctx context.Context, prNumber string) (PRWatchState, error) {
+func GetPRWatchState(ctx context.Context, repositoryRoot, prNumber string) (PRWatchState, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "headRefOid,state,reviewRequests")
+	cmd.Dir = repositoryRoot
 	out, err := cmd.Output()
 	if err != nil {
 		return PRWatchState{}, classifyGHError(err)
@@ -456,8 +452,9 @@ func GetCurrentUser(ctx context.Context) string {
 	return strings.TrimSpace(string(out))
 }
 
-func GetPRAuthor(ctx context.Context, prNumber string) string {
+func GetPRAuthor(ctx context.Context, repositoryRoot, prNumber string) string {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "author", "--jq", ".author.login")
+	cmd.Dir = repositoryRoot
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -465,9 +462,9 @@ func GetPRAuthor(ctx context.Context, prNumber string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func IsSelfReview(ctx context.Context, prNumber string) bool {
+func IsSelfReview(ctx context.Context, repositoryRoot, prNumber string) bool {
 	currentUser := GetCurrentUser(ctx)
-	prAuthor := GetPRAuthor(ctx, prNumber)
+	prAuthor := GetPRAuthor(ctx, repositoryRoot, prNumber)
 	return checkSelfReview(currentUser, prAuthor)
 }
 

--- a/internal/github/repo_scope_test.go
+++ b/internal/github/repo_scope_test.go
@@ -1,0 +1,232 @@
+package github
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupMockGH(t *testing.T, response string) string {
+	t.Helper()
+	scriptDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"DIR=$(cd \"$(dirname \"$0\")\" && pwd -P)\n" +
+		"pwd -P >> \"$DIR/cwd.log\"\n" +
+		"echo \"$@\" >> \"$DIR/args.log\"\n" +
+		"cat \"$DIR/response\" 2>/dev/null\n"
+	if err := os.WriteFile(filepath.Join(scriptDir, "gh"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "response"), []byte(response), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+originalPath)
+	return scriptDir
+}
+
+func setupMockGHRoutedByArgs(t *testing.T, routes map[string]string) string {
+	t.Helper()
+	scriptDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"DIR=$(cd \"$(dirname \"$0\")\" && pwd -P)\n" +
+		"pwd -P >> \"$DIR/cwd.log\"\n" +
+		"echo \"$@\" >> \"$DIR/args.log\"\n" +
+		"case \"$1 $2\" in\n"
+	for prefix, response := range routes {
+		responseFile := strings.ReplaceAll(prefix, " ", "_") + ".response"
+		if err := os.WriteFile(filepath.Join(scriptDir, responseFile), []byte(response), 0644); err != nil {
+			t.Fatal(err)
+		}
+		script += "\"" + prefix + "\") cat \"$DIR/" + responseFile + "\" ;;\n"
+	}
+	script += "esac\n"
+	if err := os.WriteFile(filepath.Join(scriptDir, "gh"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+originalPath)
+	return scriptDir
+}
+
+func readCapturedCwd(t *testing.T, scriptDir string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(scriptDir, "cwd.log"))
+	if err != nil {
+		t.Fatalf("failed to read cwd.log: %v", err)
+	}
+	var lines []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func readCapturedArgs(t *testing.T, scriptDir string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(scriptDir, "args.log"))
+	if err != nil {
+		t.Fatalf("failed to read args.log: %v", err)
+	}
+	var lines []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func resolvedDir(t *testing.T, dir string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+func TestGetCurrentPRNumber_ScopesToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGH(t, "42")
+
+	got, err := GetCurrentPRNumber(context.Background(), repoRoot, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "42" {
+		t.Errorf("expected 42, got %q", got)
+	}
+
+	cwds := readCapturedCwd(t, scriptDir)
+	if len(cwds) != 1 || cwds[0] != resolvedDir(t, repoRoot) {
+		t.Errorf("expected gh invoked in %s, got %v", resolvedDir(t, repoRoot), cwds)
+	}
+}
+
+func TestGetPRWatchState_ScopesToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGH(t, `{"headRefOid":"abc123","state":"OPEN","reviewRequests":[]}`)
+
+	st, err := GetPRWatchState(context.Background(), repoRoot, "7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st.HeadSHA != "abc123" {
+		t.Errorf("expected headSHA abc123, got %q", st.HeadSHA)
+	}
+
+	cwds := readCapturedCwd(t, scriptDir)
+	if len(cwds) != 1 || cwds[0] != resolvedDir(t, repoRoot) {
+		t.Errorf("expected gh invoked in %s, got %v", resolvedDir(t, repoRoot), cwds)
+	}
+}
+
+func TestApprovePR_ScopesToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGH(t, "")
+
+	if err := ApprovePR(context.Background(), repoRoot, "7", "lgtm"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cwds := readCapturedCwd(t, scriptDir)
+	if len(cwds) != 1 || cwds[0] != resolvedDir(t, repoRoot) {
+		t.Errorf("expected gh invoked in %s, got %v", resolvedDir(t, repoRoot), cwds)
+	}
+}
+
+func TestCheckCIStatus_ScopesToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGH(t, `[]`)
+
+	status := CheckCIStatus(context.Background(), repoRoot, "7")
+	if !status.AllPassed {
+		t.Errorf("expected all passed for empty checks, got %+v", status)
+	}
+
+	cwds := readCapturedCwd(t, scriptDir)
+	if len(cwds) != 1 || cwds[0] != resolvedDir(t, repoRoot) {
+		t.Errorf("expected gh invoked in %s, got %v", resolvedDir(t, repoRoot), cwds)
+	}
+}
+
+func TestGetPRAuthor_ScopesToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGH(t, "octocat")
+
+	author := GetPRAuthor(context.Background(), repoRoot, "7")
+	if author != "octocat" {
+		t.Errorf("expected octocat, got %q", author)
+	}
+
+	cwds := readCapturedCwd(t, scriptDir)
+	if len(cwds) != 1 || cwds[0] != resolvedDir(t, repoRoot) {
+		t.Errorf("expected gh invoked in %s, got %v", resolvedDir(t, repoRoot), cwds)
+	}
+}
+
+func TestIsSelfReview_BothGHCallsScopeToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGHRoutedByArgs(t, map[string]string{
+		"api user": "octocat",
+		"pr view":  "octocat",
+	})
+
+	if !IsSelfReview(context.Background(), repoRoot, "7") {
+		t.Error("expected self-review to be detected")
+	}
+
+	cwds := readCapturedCwd(t, scriptDir)
+	args := readCapturedArgs(t, scriptDir)
+	if len(cwds) != 2 || len(args) != 2 {
+		t.Fatalf("expected 2 gh invocations (current user + pr author), got cwds=%v args=%v", cwds, args)
+	}
+
+	for i, a := range args {
+		switch {
+		case strings.HasPrefix(a, "api user"):
+			if cwds[i] == resolvedDir(t, repoRoot) {
+				t.Errorf("expected GetCurrentUser (host-scoped, not repo-scoped) to NOT run in %s", repoRoot)
+			}
+		case strings.HasPrefix(a, "pr view"):
+			if cwds[i] != resolvedDir(t, repoRoot) {
+				t.Errorf("expected GetPRAuthor to run in %s, got %s", resolvedDir(t, repoRoot), cwds[i])
+			}
+		default:
+			t.Errorf("unexpected gh invocation: %s", a)
+		}
+	}
+}
+
+func TestTwoRepositoriesScopeIndependentlyWithoutChdir(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	scriptDirA := setupMockGH(t, "1")
+	got, err := GetCurrentPRNumber(context.Background(), repoA, "")
+	if err != nil || got != "1" {
+		t.Fatalf("unexpected result for repoA: %q, %v", got, err)
+	}
+
+	scriptDirB := setupMockGH(t, "2")
+	got, err = GetCurrentPRNumber(context.Background(), repoB, "")
+	if err != nil || got != "2" {
+		t.Fatalf("unexpected result for repoB: %q, %v", got, err)
+	}
+
+	cwdsA := readCapturedCwd(t, scriptDirA)
+	cwdsB := readCapturedCwd(t, scriptDirB)
+	if len(cwdsA) != 1 || cwdsA[0] != resolvedDir(t, repoA) {
+		t.Errorf("expected repoA call scoped to %s, got %v", resolvedDir(t, repoA), cwdsA)
+	}
+	if len(cwdsB) != 1 || cwdsB[0] != resolvedDir(t, repoB) {
+		t.Errorf("expected repoB call scoped to %s, got %v", resolvedDir(t, repoB), cwdsB)
+	}
+}


### PR DESCRIPTION
## Summary

- Every GitHub CLI operation that inspects or mutates a specific PR (`GetCurrentPRNumber`, `GetPRBaseRef`, `ValidatePR`, `ApprovePR`, `SubmitPRReview`, `CheckCIStatus`, `GetPRWatchState`, `GetPRAuthor`, `IsSelfReview`) previously relied on `gh`'s own CWD-based repository inference — no `cmd.Dir`, no `-R` flag. They now take an explicit `repositoryRoot` and set `cmd.Dir`, matching the pattern already established by `FindRepoRemote` and `GetPullRequestKey`. `GetCurrentUser` is intentionally unchanged — it queries the authenticated user, not a repository.
- `internal/git` worktree setup had the same gap: `CreateWorktree` and `PruneStaleWorktrees` resolved the repository implicitly via `GetRoot()`/`GetCommonDir()` (ambient process CWD). `CreateWorktreeFromPR` already took an explicit `repoRoot` for its git commands but still called the CWD-implicit `GetCommonDir()` internally for worktree placement — a latent bug, harmless only because CWD always equaled the repo root in today's single-repo usage. All three now take an explicit `repositoryRoot` and route through `GetCommonDirAt(ctx, repositoryRoot)`. `GetCommonDir()` is deleted; it had no remaining callers.
- Deleted `GetPRBranch`, which had no callers anywhere in the codebase.
- `cmd/acr/main.go`, `pr_submit.go`, and `watch.go` thread the already-resolved repository root through every call site instead of letting `gh`/`git` infer it from process CWD. `setupWorktree`'s `--pr` branch now resolves `repoRoot` before validating the PR (previously validated via ambient CWD before `repoRoot` was even known); the `--worktree-branch` branch resolves it once up front instead of only inside the fork-PR case.
- Added command-construction fixtures proving `cmd.Dir` is set correctly per repository (via a PATH-stubbed `gh` script capturing invocation CWD and args), that `GetCurrentUser` is correctly *not* repo-scoped, and that two repositories resolve independently without any `chdir`. `CreateWorktree` gained a same-process, two-repository, no-`chdir` regression test.

## Test plan

- [x] `make check` (fmt, lint, vet, staticcheck, full unit test suite) passes
- [x] New command-construction fixtures in `internal/github/repo_scope_test.go` and the no-chdir two-repo test in `internal/git/worktree_test.go`
- [x] Manually verified against this repository: `acr review --local` and `acr review --local --pr 235` both complete correctly end-to-end (worktree setup, trusted-config resolution, diff/fetch, agent selection, cleanup) with no observable behavior change for the ordinary single-repo case

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)