### PR TITLE
[P4] Implement GitHub candidate discovery and PR enrichment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,8 @@ linters:
   settings:
     misspell:
       locale: US
+      ignore-rules:
+        - CANCELLED
 
     errcheck:
 

--- a/internal/domain/snapshot.go
+++ b/internal/domain/snapshot.go
@@ -1,0 +1,133 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type PullRequestState string
+
+const (
+	PullRequestStateOpen   PullRequestState = "open"
+	PullRequestStateClosed PullRequestState = "closed"
+	PullRequestStateMerged PullRequestState = "merged"
+)
+
+func (s PullRequestState) Validate() error {
+	switch s {
+	case PullRequestStateOpen, PullRequestStateClosed, PullRequestStateMerged:
+		return nil
+	default:
+		return fmt.Errorf("unknown pull request state %q", s)
+	}
+}
+
+type ReviewRequestKind string
+
+const (
+	ReviewRequestKindUser ReviewRequestKind = "user"
+	ReviewRequestKindTeam ReviewRequestKind = "team"
+)
+
+func (k ReviewRequestKind) Validate() error {
+	switch k {
+	case ReviewRequestKindUser, ReviewRequestKindTeam:
+		return nil
+	default:
+		return fmt.Errorf("unknown review request kind %q", k)
+	}
+}
+
+type ReviewRequest struct {
+	Kind  ReviewRequestKind
+	Login string
+}
+
+func (r ReviewRequest) Validate() error {
+	if err := r.Kind.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(r.Login) == "" {
+		return fmt.Errorf("review request login is required")
+	}
+	return nil
+}
+
+type LatestReview struct {
+	Author      string
+	State       string
+	SubmittedAt time.Time
+}
+
+func (r LatestReview) Validate() error {
+	if strings.TrimSpace(r.Author) == "" {
+		return fmt.Errorf("review author is required")
+	}
+	if strings.TrimSpace(r.State) == "" {
+		return fmt.Errorf("review state is required")
+	}
+	return nil
+}
+
+type PullRequestSnapshot struct {
+	PullRequest      PullRequestKey
+	URL              string
+	Title            string
+	Author           string
+	State            PullRequestState
+	Draft            bool
+	HeadObjectID     string
+	BaseObjectID     string
+	ReviewRequests   []ReviewRequest
+	ReviewDecision   string
+	LatestReviews    []LatestReview
+	CheckRollupState string
+	MergeState       string
+	UpdatedAt        time.Time
+	CapturedAt       time.Time
+	Stale            bool
+}
+
+func (s PullRequestSnapshot) Age(now time.Time) time.Duration {
+	if s.CapturedAt.IsZero() {
+		return 0
+	}
+	age := now.Sub(s.CapturedAt)
+	if age < 0 {
+		return 0
+	}
+	return age
+}
+
+func (s PullRequestSnapshot) Validate() error {
+	if err := s.PullRequest.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(s.URL) == "" {
+		return fmt.Errorf("pull request snapshot url is required")
+	}
+	if err := s.State.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(s.HeadObjectID) == "" {
+		return fmt.Errorf("pull request snapshot head object id is required")
+	}
+	if strings.TrimSpace(s.BaseObjectID) == "" {
+		return fmt.Errorf("pull request snapshot base object id is required")
+	}
+	for i, request := range s.ReviewRequests {
+		if err := request.Validate(); err != nil {
+			return fmt.Errorf("review request %d: %w", i, err)
+		}
+	}
+	for i, review := range s.LatestReviews {
+		if err := review.Validate(); err != nil {
+			return fmt.Errorf("latest review %d: %w", i, err)
+		}
+	}
+	if s.CapturedAt.IsZero() {
+		return fmt.Errorf("pull request snapshot captured_at is required")
+	}
+	return nil
+}

--- a/internal/domain/snapshot_test.go
+++ b/internal/domain/snapshot_test.go
@@ -1,0 +1,127 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func validSnapshot() PullRequestSnapshot {
+	return PullRequestSnapshot{
+		PullRequest:  PullRequestKey{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 202},
+		URL:          "https://github.com/richhaase/agentic-code-reviewer/pull/202",
+		Title:        "Implement GitHub candidate discovery and PR enrichment",
+		Author:       "richhaase",
+		State:        PullRequestStateOpen,
+		Draft:        false,
+		HeadObjectID: "headsha",
+		BaseObjectID: "basesha",
+		ReviewRequests: []ReviewRequest{
+			{Kind: ReviewRequestKindUser, Login: "reviewer1"},
+			{Kind: ReviewRequestKindTeam, Login: "org/reviewers"},
+		},
+		ReviewDecision: "REVIEW_REQUIRED",
+		LatestReviews: []LatestReview{
+			{Author: "reviewer2", State: "COMMENTED", SubmittedAt: time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)},
+		},
+		CheckRollupState: "PENDING",
+		MergeState:       "CLEAN",
+		UpdatedAt:        time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC),
+		CapturedAt:       time.Date(2026, 7, 24, 9, 5, 0, 0, time.UTC),
+	}
+}
+
+func TestPullRequestSnapshot_ValidateAccepts(t *testing.T) {
+	if err := validSnapshot().Validate(); err != nil {
+		t.Fatalf("expected valid snapshot, got %v", err)
+	}
+}
+
+func TestPullRequestSnapshot_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(s *PullRequestSnapshot)
+	}{
+		{"missing url", func(s *PullRequestSnapshot) { s.URL = "" }},
+		{"invalid pull request key", func(s *PullRequestSnapshot) { s.PullRequest.Number = 0 }},
+		{"invalid state", func(s *PullRequestSnapshot) { s.State = "unknown" }},
+		{"missing head object id", func(s *PullRequestSnapshot) { s.HeadObjectID = "" }},
+		{"missing base object id", func(s *PullRequestSnapshot) { s.BaseObjectID = "" }},
+		{"invalid review request kind", func(s *PullRequestSnapshot) {
+			s.ReviewRequests = []ReviewRequest{{Kind: "bogus", Login: "x"}}
+		}},
+		{"missing review request login", func(s *PullRequestSnapshot) {
+			s.ReviewRequests = []ReviewRequest{{Kind: ReviewRequestKindUser, Login: ""}}
+		}},
+		{"missing latest review author", func(s *PullRequestSnapshot) {
+			s.LatestReviews = []LatestReview{{Author: "", State: "APPROVED"}}
+		}},
+		{"missing latest review state", func(s *PullRequestSnapshot) {
+			s.LatestReviews = []LatestReview{{Author: "reviewer", State: ""}}
+		}},
+		{"missing captured at", func(s *PullRequestSnapshot) { s.CapturedAt = time.Time{} }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := validSnapshot()
+			tt.mutate(&snapshot)
+			if err := snapshot.Validate(); err == nil {
+				t.Fatalf("expected validation error")
+			}
+		})
+	}
+}
+
+func TestPullRequestState_Validate(t *testing.T) {
+	valid := []PullRequestState{PullRequestStateOpen, PullRequestStateClosed, PullRequestStateMerged}
+	for _, s := range valid {
+		if err := s.Validate(); err != nil {
+			t.Errorf("expected %q to be valid, got %v", s, err)
+		}
+	}
+	if err := PullRequestState("bogus").Validate(); err == nil {
+		t.Error("expected error for unknown state")
+	}
+}
+
+func TestPullRequestSnapshot_Age(t *testing.T) {
+	now := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+
+	snapshot := validSnapshot()
+	snapshot.CapturedAt = now.Add(-5 * time.Minute)
+	if got := snapshot.Age(now); got != 5*time.Minute {
+		t.Errorf("expected 5m age, got %v", got)
+	}
+
+	snapshot.CapturedAt = time.Time{}
+	if got := snapshot.Age(now); got != 0 {
+		t.Errorf("expected zero age for zero captured_at, got %v", got)
+	}
+
+	snapshot.CapturedAt = now.Add(time.Minute)
+	if got := snapshot.Age(now); got != 0 {
+		t.Errorf("expected zero age for future captured_at, got %v", got)
+	}
+}
+
+func TestReviewRequest_Validate(t *testing.T) {
+	if err := (ReviewRequest{Kind: ReviewRequestKindUser, Login: "x"}).Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := (ReviewRequest{Kind: "bogus", Login: "x"}).Validate(); err == nil {
+		t.Error("expected error for unknown kind")
+	}
+	if err := (ReviewRequest{Kind: ReviewRequestKindUser, Login: " "}).Validate(); err == nil {
+		t.Error("expected error for blank login")
+	}
+}
+
+func TestPullRequestSnapshot_ValidateErrorMentionsField(t *testing.T) {
+	snapshot := validSnapshot()
+	snapshot.HeadObjectID = ""
+	err := snapshot.Validate()
+	if err == nil || !strings.Contains(err.Error(), "head object id") {
+		t.Fatalf("expected error mentioning head object id, got %v", err)
+	}
+}

--- a/internal/github/discovery.go
+++ b/internal/github/discovery.go
@@ -143,10 +143,7 @@ func (ghDiscovery) Enrich(ctx context.Context, key domain.PullRequestKey) (domai
 		return domain.PullRequestSnapshot{}, err
 	}
 
-	repo := key.Owner + "/" + key.Repository
-	if key.Host != "" && key.Host != "github.com" {
-		repo = key.Host + "/" + repo
-	}
+	repo := key.Host + "/" + key.Owner + "/" + key.Repository
 
 	args := []string{
 		"pr", "view", strconv.Itoa(key.Number),
@@ -213,7 +210,11 @@ func parseEnrichResponse(data []byte, key domain.PullRequestKey) (domain.PullReq
 	reviewRequests := make([]domain.ReviewRequest, 0, len(resp.ReviewRequests))
 	for _, r := range resp.ReviewRequests {
 		if r.Typename == "Team" {
-			reviewRequests = append(reviewRequests, domain.ReviewRequest{Kind: domain.ReviewRequestKindTeam, Login: r.Slug})
+			slug := r.Slug
+			if !strings.Contains(slug, "/") {
+				slug = key.Owner + "/" + slug
+			}
+			reviewRequests = append(reviewRequests, domain.ReviewRequest{Kind: domain.ReviewRequestKindTeam, Login: slug})
 			continue
 		}
 		reviewRequests = append(reviewRequests, domain.ReviewRequest{Kind: domain.ReviewRequestKindUser, Login: r.Login})
@@ -283,7 +284,7 @@ func isFailingCheck(c enrichCheck) bool {
 		return false
 	}
 	switch c.Conclusion {
-	case "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE":
+	case "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE":
 		return true
 	default:
 		return false

--- a/internal/github/discovery.go
+++ b/internal/github/discovery.go
@@ -16,6 +16,8 @@ import (
 
 var ErrTransient = errors.New("transient GitHub failure")
 
+const maxSearchResults = 1000
+
 type SearchKind string
 
 const (
@@ -41,6 +43,9 @@ func (q SearchQuery) Validate() error {
 		if strings.TrimSpace(q.Team) == "" {
 			return fmt.Errorf("search query: team is required for kind %q", q.Kind)
 		}
+		if !strings.Contains(q.Team, "/") && strings.TrimSpace(q.Organization) == "" {
+			return fmt.Errorf("search query: team %q is ambiguous without org/team or an organization", q.Team)
+		}
 	default:
 		return fmt.Errorf("search query: unknown kind %q", q.Kind)
 	}
@@ -65,7 +70,7 @@ func (ghDiscovery) Search(ctx context.Context, query SearchQuery) ([]domain.Pull
 		return nil, err
 	}
 
-	args := []string{"search", "prs", "--state", "open", "--json", "number,url,repository"}
+	args := []string{"search", "prs", "--state", "open", "--limit", strconv.Itoa(maxSearchResults), "--json", "number,url,repository"}
 	if query.Organization != "" {
 		args = append(args, "--owner", query.Organization)
 	}
@@ -287,7 +292,7 @@ func isFailingCheck(c enrichCheck) bool {
 
 func isPendingCheck(c enrichCheck) bool {
 	if c.Typename == "StatusContext" {
-		return c.State == "PENDING" || c.State == ""
+		return c.State == "PENDING" || c.State == "EXPECTED" || c.State == ""
 	}
 	return c.Status != "COMPLETED"
 }

--- a/internal/github/discovery.go
+++ b/internal/github/discovery.go
@@ -222,6 +222,9 @@ func parseEnrichResponse(data []byte, key domain.PullRequestKey) (domain.PullReq
 
 	latestReviews := make([]domain.LatestReview, 0, len(resp.LatestReviews))
 	for _, r := range resp.LatestReviews {
+		if strings.TrimSpace(r.Author.Login) == "" {
+			continue
+		}
 		latestReviews = append(latestReviews, domain.LatestReview{Author: r.Author.Login, State: r.State, SubmittedAt: r.SubmittedAt})
 	}
 
@@ -322,6 +325,8 @@ func classifyDiscoveryError(err error) error {
 		"timed out",
 		"temporarily unavailable",
 		"could not resolve host",
+		"no such host",
+		"error connecting",
 		"connection reset",
 		"connection refused",
 		"502",

--- a/internal/github/discovery.go
+++ b/internal/github/discovery.go
@@ -1,0 +1,349 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+var ErrTransient = errors.New("transient GitHub failure")
+
+type SearchKind string
+
+const (
+	SearchKindReviewRequested     SearchKind = "review_requested"
+	SearchKindAuthored            SearchKind = "authored"
+	SearchKindTeamReviewRequested SearchKind = "team_review_requested"
+)
+
+type SearchQuery struct {
+	Kind         SearchKind
+	Organization string
+	Login        string
+	Team         string
+}
+
+func (q SearchQuery) Validate() error {
+	switch q.Kind {
+	case SearchKindReviewRequested, SearchKindAuthored:
+		if strings.TrimSpace(q.Login) == "" {
+			return fmt.Errorf("search query: login is required for kind %q", q.Kind)
+		}
+	case SearchKindTeamReviewRequested:
+		if strings.TrimSpace(q.Team) == "" {
+			return fmt.Errorf("search query: team is required for kind %q", q.Kind)
+		}
+	default:
+		return fmt.Errorf("search query: unknown kind %q", q.Kind)
+	}
+	return nil
+}
+
+type Discovery interface {
+	Search(ctx context.Context, query SearchQuery) ([]domain.PullRequestKey, error)
+	Enrich(ctx context.Context, key domain.PullRequestKey) (domain.PullRequestSnapshot, error)
+}
+
+type ghDiscovery struct{}
+
+func NewDiscovery() Discovery {
+	return ghDiscovery{}
+}
+
+var _ Discovery = ghDiscovery{}
+
+func (ghDiscovery) Search(ctx context.Context, query SearchQuery) ([]domain.PullRequestKey, error) {
+	if err := query.Validate(); err != nil {
+		return nil, err
+	}
+
+	args := []string{"search", "prs", "--state", "open", "--json", "number,url,repository"}
+	if query.Organization != "" {
+		args = append(args, "--owner", query.Organization)
+	}
+	switch query.Kind {
+	case SearchKindReviewRequested:
+		args = append(args, "--review-requested", query.Login)
+	case SearchKindAuthored:
+		args = append(args, "--author", query.Login)
+	case SearchKindTeamReviewRequested:
+		team := query.Team
+		if query.Organization != "" && !strings.Contains(team, "/") {
+			team = query.Organization + "/" + team
+		}
+		args = append(args, "--review-requested", team)
+	}
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, classifyDiscoveryError(err)
+	}
+	return parseSearchResults(out)
+}
+
+type searchResultRepository struct {
+	NameWithOwner string `json:"nameWithOwner"`
+}
+
+type searchResultItem struct {
+	Number     int                    `json:"number"`
+	URL        string                 `json:"url"`
+	Repository searchResultRepository `json:"repository"`
+}
+
+func parseSearchResults(data []byte) ([]domain.PullRequestKey, error) {
+	var items []searchResultItem
+	if err := json.Unmarshal(data, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse search results: %w", err)
+	}
+
+	keys := make([]domain.PullRequestKey, 0, len(items))
+	for _, item := range items {
+		host, err := hostFromURL(item.URL)
+		if err != nil {
+			return nil, err
+		}
+		parts := strings.SplitN(item.Repository.NameWithOwner, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("search result has unexpected repository %q", item.Repository.NameWithOwner)
+		}
+		key := domain.PullRequestKey{Host: host, Owner: parts[0], Repository: parts[1], Number: item.Number}
+		if err := key.Validate(); err != nil {
+			return nil, fmt.Errorf("search result produced invalid pull request key: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func hostFromURL(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Hostname() == "" {
+		return "", fmt.Errorf("failed to parse pull request URL %q", raw)
+	}
+	return parsed.Hostname(), nil
+}
+
+func (ghDiscovery) Enrich(ctx context.Context, key domain.PullRequestKey) (domain.PullRequestSnapshot, error) {
+	if err := key.Validate(); err != nil {
+		return domain.PullRequestSnapshot{}, err
+	}
+
+	repo := key.Owner + "/" + key.Repository
+	if key.Host != "" && key.Host != "github.com" {
+		repo = key.Host + "/" + repo
+	}
+
+	args := []string{
+		"pr", "view", strconv.Itoa(key.Number),
+		"-R", repo,
+		"--json", "number,url,title,author,state,isDraft,headRefOid,baseRefOid,reviewDecision,reviewRequests,latestReviews,statusCheckRollup,mergeStateStatus,updatedAt",
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return domain.PullRequestSnapshot{}, classifyDiscoveryError(err)
+	}
+	return parseEnrichResponse(out, key)
+}
+
+type enrichAuthor struct {
+	Login string `json:"login"`
+}
+
+type enrichReviewRequest struct {
+	Typename string `json:"__typename"`
+	Login    string `json:"login"`
+	Slug     string `json:"slug"`
+}
+
+type enrichLatestReview struct {
+	Author      enrichAuthor `json:"author"`
+	State       string       `json:"state"`
+	SubmittedAt time.Time    `json:"submittedAt"`
+}
+
+type enrichCheck struct {
+	Typename   string `json:"__typename"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	State      string `json:"state"`
+}
+
+type prViewEnrichResponse struct {
+	Number            int                   `json:"number"`
+	URL               string                `json:"url"`
+	Title             string                `json:"title"`
+	Author            enrichAuthor          `json:"author"`
+	State             string                `json:"state"`
+	IsDraft           bool                  `json:"isDraft"`
+	HeadRefOid        string                `json:"headRefOid"`
+	BaseRefOid        string                `json:"baseRefOid"`
+	ReviewDecision    string                `json:"reviewDecision"`
+	ReviewRequests    []enrichReviewRequest `json:"reviewRequests"`
+	LatestReviews     []enrichLatestReview  `json:"latestReviews"`
+	StatusCheckRollup []enrichCheck         `json:"statusCheckRollup"`
+	MergeStateStatus  string                `json:"mergeStateStatus"`
+	UpdatedAt         time.Time             `json:"updatedAt"`
+}
+
+func parseEnrichResponse(data []byte, key domain.PullRequestKey) (domain.PullRequestSnapshot, error) {
+	var resp prViewEnrichResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return domain.PullRequestSnapshot{}, fmt.Errorf("failed to parse pull request enrichment: %w", err)
+	}
+	if resp.Number != key.Number {
+		return domain.PullRequestSnapshot{}, fmt.Errorf("enrichment response number %d does not match requested %d", resp.Number, key.Number)
+	}
+
+	reviewRequests := make([]domain.ReviewRequest, 0, len(resp.ReviewRequests))
+	for _, r := range resp.ReviewRequests {
+		if r.Typename == "Team" {
+			reviewRequests = append(reviewRequests, domain.ReviewRequest{Kind: domain.ReviewRequestKindTeam, Login: r.Slug})
+			continue
+		}
+		reviewRequests = append(reviewRequests, domain.ReviewRequest{Kind: domain.ReviewRequestKindUser, Login: r.Login})
+	}
+
+	latestReviews := make([]domain.LatestReview, 0, len(resp.LatestReviews))
+	for _, r := range resp.LatestReviews {
+		latestReviews = append(latestReviews, domain.LatestReview{Author: r.Author.Login, State: r.State, SubmittedAt: r.SubmittedAt})
+	}
+
+	return domain.PullRequestSnapshot{
+		PullRequest:      key,
+		URL:              resp.URL,
+		Title:            resp.Title,
+		Author:           resp.Author.Login,
+		State:            normalizePullRequestState(resp.State),
+		Draft:            resp.IsDraft,
+		HeadObjectID:     resp.HeadRefOid,
+		BaseObjectID:     resp.BaseRefOid,
+		ReviewRequests:   reviewRequests,
+		ReviewDecision:   resp.ReviewDecision,
+		LatestReviews:    latestReviews,
+		CheckRollupState: reduceCheckRollup(resp.StatusCheckRollup),
+		MergeState:       resp.MergeStateStatus,
+		UpdatedAt:        resp.UpdatedAt,
+		CapturedAt:       time.Now(),
+	}, nil
+}
+
+func normalizePullRequestState(raw string) domain.PullRequestState {
+	switch strings.ToUpper(raw) {
+	case "OPEN":
+		return domain.PullRequestStateOpen
+	case "CLOSED":
+		return domain.PullRequestStateClosed
+	case "MERGED":
+		return domain.PullRequestStateMerged
+	default:
+		return domain.PullRequestState(strings.ToLower(raw))
+	}
+}
+
+func reduceCheckRollup(checks []enrichCheck) string {
+	if len(checks) == 0 {
+		return "NONE"
+	}
+	pending := false
+	for _, c := range checks {
+		if isFailingCheck(c) {
+			return "FAILURE"
+		}
+		if isPendingCheck(c) {
+			pending = true
+		}
+	}
+	if pending {
+		return "PENDING"
+	}
+	return "SUCCESS"
+}
+
+func isFailingCheck(c enrichCheck) bool {
+	if c.Typename == "StatusContext" {
+		return c.State == "FAILURE" || c.State == "ERROR"
+	}
+	if c.Status != "COMPLETED" {
+		return false
+	}
+	switch c.Conclusion {
+	case "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE":
+		return true
+	default:
+		return false
+	}
+}
+
+func isPendingCheck(c enrichCheck) bool {
+	if c.Typename == "StatusContext" {
+		return c.State == "PENDING" || c.State == ""
+	}
+	return c.Status != "COMPLETED"
+}
+
+func classifyDiscoveryError(err error) error {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return fmt.Errorf("gh command failed: %w", err)
+	}
+
+	stderr := strings.ToLower(string(exitErr.Stderr))
+
+	if strings.Contains(stderr, "no pull request") {
+		return ErrNoPRFound
+	}
+	if strings.Contains(stderr, "401") ||
+		strings.Contains(stderr, "auth") ||
+		strings.Contains(stderr, "credentials") ||
+		strings.Contains(stderr, "login") {
+		return ErrAuthFailed
+	}
+
+	transientMarkers := []string{
+		"rate limit",
+		"timeout",
+		"timed out",
+		"temporarily unavailable",
+		"could not resolve host",
+		"connection reset",
+		"connection refused",
+		"502",
+		"503",
+		"504",
+	}
+	for _, marker := range transientMarkers {
+		if strings.Contains(stderr, marker) {
+			return fmt.Errorf("%w: %s", ErrTransient, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+	}
+
+	errMsg := strings.TrimSpace(string(exitErr.Stderr))
+	if errMsg != "" {
+		return fmt.Errorf("gh command failed: %s", errMsg)
+	}
+	return fmt.Errorf("gh command failed: %w", err)
+}
+
+func ObserveSnapshot(ctx context.Context, discovery Discovery, key domain.PullRequestKey, previous *domain.PullRequestSnapshot) (domain.PullRequestSnapshot, error) {
+	snapshot, err := discovery.Enrich(ctx, key)
+	if err == nil {
+		return snapshot, nil
+	}
+	if errors.Is(err, ErrTransient) && previous != nil {
+		stale := *previous
+		stale.Stale = true
+		return stale, nil
+	}
+	return domain.PullRequestSnapshot{}, err
+}

--- a/internal/github/discovery_test.go
+++ b/internal/github/discovery_test.go
@@ -87,6 +87,53 @@ func TestSearch_RejectsInvalidQuery(t *testing.T) {
 	}
 }
 
+func TestSearch_RejectsBareTeamSlugWithoutOrganization(t *testing.T) {
+	setupMockGH(t, `[]`)
+
+	_, err := NewDiscovery().Search(context.Background(), SearchQuery{
+		Kind: SearchKindTeamReviewRequested,
+		Team: "reviewers",
+	})
+	if err == nil {
+		t.Fatal("expected validation error for ambiguous bare team slug")
+	}
+}
+
+func TestSearch_AcceptsFullyQualifiedTeamWithoutOrganization(t *testing.T) {
+	scriptDir := setupMockGH(t, `[]`)
+
+	_, err := NewDiscovery().Search(context.Background(), SearchQuery{
+		Kind: SearchKindTeamReviewRequested,
+		Team: "richhaase/reviewers",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || !strings.Contains(args[0], "--review-requested richhaase/reviewers") {
+		t.Errorf("expected qualified team review-requested flag, got %v", args)
+	}
+}
+
+func TestSearch_RequestsMaxResultLimitToAvoidTruncation(t *testing.T) {
+	scriptDir := setupMockGH(t, `[]`)
+
+	_, err := NewDiscovery().Search(context.Background(), SearchQuery{
+		Kind:         SearchKindReviewRequested,
+		Organization: "richhaase",
+		Login:        "richhaase",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || !strings.Contains(args[0], "--limit 1000") {
+		t.Errorf("expected an explicit high --limit to avoid the gh default of 30, got %v", args)
+	}
+}
+
 func TestEnrich_BuildsExpectedArgsAndParsesFullResponse(t *testing.T) {
 	response := `{
 		"number": 202,
@@ -370,6 +417,7 @@ func TestReduceCheckRollup_StatusContextStates(t *testing.T) {
 		{"status context failure", enrichCheck{Typename: "StatusContext", State: "FAILURE"}, "FAILURE"},
 		{"status context error", enrichCheck{Typename: "StatusContext", State: "ERROR"}, "FAILURE"},
 		{"status context pending", enrichCheck{Typename: "StatusContext", State: "PENDING"}, "PENDING"},
+		{"status context expected", enrichCheck{Typename: "StatusContext", State: "EXPECTED"}, "PENDING"},
 		{"status context success", enrichCheck{Typename: "StatusContext", State: "SUCCESS"}, "SUCCESS"},
 	}
 	for _, tt := range tests {
@@ -378,6 +426,16 @@ func TestReduceCheckRollup_StatusContextStates(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.want, got)
 			}
 		})
+	}
+}
+
+func TestReduceCheckRollup_ExpectedRequiredCheckDoesNotReportSuccess(t *testing.T) {
+	checks := []enrichCheck{
+		{Typename: "CheckRun", Status: "COMPLETED", Conclusion: "SUCCESS"},
+		{Typename: "StatusContext", State: "EXPECTED"},
+	}
+	if got := reduceCheckRollup(checks); got != "PENDING" {
+		t.Errorf("expected an EXPECTED required status to keep the rollup PENDING, got %q", got)
 	}
 }
 

--- a/internal/github/discovery_test.go
+++ b/internal/github/discovery_test.go
@@ -181,7 +181,7 @@ func TestEnrich_BuildsExpectedArgsAndParsesFullResponse(t *testing.T) {
 	if snapshot.ReviewRequests[0].Kind != domain.ReviewRequestKindUser || snapshot.ReviewRequests[0].Login != "reviewer1" {
 		t.Errorf("unexpected user review request: %+v", snapshot.ReviewRequests[0])
 	}
-	if snapshot.ReviewRequests[1].Kind != domain.ReviewRequestKindTeam || snapshot.ReviewRequests[1].Login != "reviewers" {
+	if snapshot.ReviewRequests[1].Kind != domain.ReviewRequestKindTeam || snapshot.ReviewRequests[1].Login != "richhaase/reviewers" {
 		t.Errorf("unexpected team review request: %+v", snapshot.ReviewRequests[1])
 	}
 	if len(snapshot.LatestReviews) != 1 || snapshot.LatestReviews[0].Author != "reviewer2" {
@@ -195,8 +195,72 @@ func TestEnrich_BuildsExpectedArgsAndParsesFullResponse(t *testing.T) {
 	}
 
 	args := readCapturedArgs(t, scriptDir)
-	if len(args) != 1 || !strings.Contains(args[0], "pr view 202") || !strings.Contains(args[0], "-R richhaase/agentic-code-reviewer") {
+	if len(args) != 1 || !strings.Contains(args[0], "pr view 202") || !strings.Contains(args[0], "-R github.com/richhaase/agentic-code-reviewer") {
 		t.Errorf("unexpected args: %v", args)
+	}
+}
+
+func TestEnrich_IncludesHostInRepoSelectorForEnterpriseHost(t *testing.T) {
+	scriptDir := setupMockGH(t, `{
+		"number": 20, "url": "https://ghe.example.com/o/r/pull/20", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "h", "baseRefOid": "b",
+		"reviewRequests": [], "latestReviews": [], "statusCheckRollup": [],
+		"mergeStateStatus": "CLEAN", "updatedAt": "2026-07-24T09:00:00Z"
+	}`)
+
+	_, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "ghe.example.com", Owner: "o", Repository: "r", Number: 20})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || !strings.Contains(args[0], "-R ghe.example.com/o/r") {
+		t.Errorf("expected host-qualified repo selector, got %v", args)
+	}
+}
+
+func TestEnrich_TeamReviewRequestQualifiedWithRepositoryOwner(t *testing.T) {
+	response := `{
+		"number": 21, "url": "https://github.com/richhaase/agentic-code-reviewer/pull/21", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "h", "baseRefOid": "b",
+		"reviewRequests": [{"__typename":"Team","slug":"reviewers","name":"Reviewers"}],
+		"latestReviews": [], "statusCheckRollup": [],
+		"mergeStateStatus": "CLEAN", "updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	setupMockGH(t, response)
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 21}
+	snapshot, err := NewDiscovery().Enrich(context.Background(), key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(snapshot.ReviewRequests) != 1 || snapshot.ReviewRequests[0].Login != "richhaase/reviewers" {
+		t.Fatalf("expected org-qualified team login, got %+v", snapshot.ReviewRequests)
+	}
+}
+
+func TestEnrich_StaleChecksReportFailure(t *testing.T) {
+	response := `{
+		"number": 22, "url": "https://github.com/o/r/pull/22", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "h", "baseRefOid": "b",
+		"reviewRequests": [], "latestReviews": [],
+		"statusCheckRollup": [
+			{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},
+			{"__typename":"CheckRun","status":"COMPLETED","conclusion":"STALE"}
+		],
+		"mergeStateStatus": "UNKNOWN", "updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	setupMockGH(t, response)
+
+	snapshot, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 22})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snapshot.CheckRollupState != "FAILURE" {
+		t.Errorf("expected STALE check conclusion to report FAILURE, got %q", snapshot.CheckRollupState)
 	}
 }
 

--- a/internal/github/discovery_test.go
+++ b/internal/github/discovery_test.go
@@ -1,0 +1,429 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
+
+func TestSearch_ReviewRequested_BuildsExpectedArgsAndParsesResults(t *testing.T) {
+	response := `[
+		{"number":42,"url":"https://github.com/richhaase/agentic-code-reviewer/pull/42","repository":{"nameWithOwner":"richhaase/agentic-code-reviewer"}},
+		{"number":7,"url":"https://github.com/richhaase/other-repo/pull/7","repository":{"nameWithOwner":"richhaase/other-repo"}}
+	]`
+	scriptDir := setupMockGH(t, response)
+
+	keys, err := NewDiscovery().Search(context.Background(), SearchQuery{
+		Kind:         SearchKindReviewRequested,
+		Organization: "richhaase",
+		Login:        "richhaase",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d: %+v", len(keys), keys)
+	}
+	want := domain.PullRequestKey{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 42}
+	if keys[0] != want {
+		t.Errorf("expected %+v, got %+v", want, keys[0])
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 {
+		t.Fatalf("expected 1 gh invocation, got %v", args)
+	}
+	if got := args[0]; !strings.Contains(got, "search prs") || !strings.Contains(got, "--review-requested richhaase") || !strings.Contains(got, "--owner richhaase") {
+		t.Errorf("unexpected args: %q", got)
+	}
+}
+
+func TestSearch_Authored_UsesAuthorFlag(t *testing.T) {
+	scriptDir := setupMockGH(t, `[]`)
+
+	_, err := NewDiscovery().Search(context.Background(), SearchQuery{
+		Kind:         SearchKindAuthored,
+		Organization: "richhaase",
+		Login:        "richhaase",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || !strings.Contains(args[0], "--author richhaase") {
+		t.Errorf("expected --author flag, got %v", args)
+	}
+}
+
+func TestSearch_TeamReviewRequested_QualifiesTeamWithOrganization(t *testing.T) {
+	scriptDir := setupMockGH(t, `[]`)
+
+	_, err := NewDiscovery().Search(context.Background(), SearchQuery{
+		Kind:         SearchKindTeamReviewRequested,
+		Organization: "richhaase",
+		Team:         "reviewers",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || !strings.Contains(args[0], "--review-requested richhaase/reviewers") {
+		t.Errorf("expected qualified team review-requested flag, got %v", args)
+	}
+}
+
+func TestSearch_RejectsInvalidQuery(t *testing.T) {
+	setupMockGH(t, `[]`)
+
+	if _, err := NewDiscovery().Search(context.Background(), SearchQuery{Kind: SearchKindReviewRequested}); err == nil {
+		t.Fatal("expected validation error for missing login")
+	}
+}
+
+func TestEnrich_BuildsExpectedArgsAndParsesFullResponse(t *testing.T) {
+	response := `{
+		"number": 202,
+		"url": "https://github.com/richhaase/agentic-code-reviewer/pull/202",
+		"title": "Implement GitHub candidate discovery and PR enrichment",
+		"author": {"login": "richhaase"},
+		"state": "OPEN",
+		"isDraft": false,
+		"headRefOid": "headsha123",
+		"baseRefOid": "basesha456",
+		"reviewDecision": "REVIEW_REQUIRED",
+		"reviewRequests": [
+			{"__typename":"User","login":"reviewer1"},
+			{"__typename":"Team","slug":"reviewers","name":"Reviewers"}
+		],
+		"latestReviews": [
+			{"author":{"login":"reviewer2"},"state":"COMMENTED","submittedAt":"2026-07-24T10:00:00Z"}
+		],
+		"statusCheckRollup": [
+			{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS","name":"Test"}
+		],
+		"mergeStateStatus": "CLEAN",
+		"updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	scriptDir := setupMockGH(t, response)
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "richhaase", Repository: "agentic-code-reviewer", Number: 202}
+	snapshot, err := NewDiscovery().Enrich(context.Background(), key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if snapshot.HeadObjectID != "headsha123" || snapshot.BaseObjectID != "basesha456" {
+		t.Errorf("unexpected object ids: %+v", snapshot)
+	}
+	if snapshot.State != domain.PullRequestStateOpen {
+		t.Errorf("expected open state, got %q", snapshot.State)
+	}
+	if snapshot.CheckRollupState != "SUCCESS" {
+		t.Errorf("expected SUCCESS rollup, got %q", snapshot.CheckRollupState)
+	}
+	if len(snapshot.ReviewRequests) != 2 {
+		t.Fatalf("expected 2 review requests, got %+v", snapshot.ReviewRequests)
+	}
+	if snapshot.ReviewRequests[0].Kind != domain.ReviewRequestKindUser || snapshot.ReviewRequests[0].Login != "reviewer1" {
+		t.Errorf("unexpected user review request: %+v", snapshot.ReviewRequests[0])
+	}
+	if snapshot.ReviewRequests[1].Kind != domain.ReviewRequestKindTeam || snapshot.ReviewRequests[1].Login != "reviewers" {
+		t.Errorf("unexpected team review request: %+v", snapshot.ReviewRequests[1])
+	}
+	if len(snapshot.LatestReviews) != 1 || snapshot.LatestReviews[0].Author != "reviewer2" {
+		t.Errorf("unexpected latest reviews: %+v", snapshot.LatestReviews)
+	}
+	if snapshot.CapturedAt.IsZero() {
+		t.Error("expected captured_at to be set")
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Errorf("expected valid snapshot, got %v", err)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || !strings.Contains(args[0], "pr view 202") || !strings.Contains(args[0], "-R richhaase/agentic-code-reviewer") {
+		t.Errorf("unexpected args: %v", args)
+	}
+}
+
+func TestEnrich_DraftPullRequest(t *testing.T) {
+	response := `{
+		"number": 5, "url": "https://github.com/o/r/pull/5", "title": "wip",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": true,
+		"headRefOid": "h", "baseRefOid": "b",
+		"reviewRequests": [], "latestReviews": [], "statusCheckRollup": [],
+		"mergeStateStatus": "DRAFT", "updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	setupMockGH(t, response)
+
+	snapshot, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !snapshot.Draft {
+		t.Error("expected draft to be true")
+	}
+}
+
+func TestEnrich_ClosedAndMergedPullRequests(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want domain.PullRequestState
+	}{
+		{"CLOSED", domain.PullRequestStateClosed},
+		{"MERGED", domain.PullRequestStateMerged},
+	} {
+		response := `{
+			"number": 6, "url": "https://github.com/o/r/pull/6", "title": "done",
+			"author": {"login": "a"}, "state": "` + tc.raw + `", "isDraft": false,
+			"headRefOid": "h", "baseRefOid": "b",
+			"reviewRequests": [], "latestReviews": [], "statusCheckRollup": [],
+			"mergeStateStatus": "UNKNOWN", "updatedAt": "2026-07-24T09:00:00Z"
+		}`
+		setupMockGH(t, response)
+
+		snapshot, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 6})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if snapshot.State != tc.want {
+			t.Errorf("state %q: expected %q, got %q", tc.raw, tc.want, snapshot.State)
+		}
+	}
+}
+
+func TestEnrich_FailingChecksReportFailure(t *testing.T) {
+	response := `{
+		"number": 8, "url": "https://github.com/o/r/pull/8", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "h", "baseRefOid": "b",
+		"reviewRequests": [], "latestReviews": [],
+		"statusCheckRollup": [
+			{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},
+			{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"}
+		],
+		"mergeStateStatus": "DIRTY", "updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	setupMockGH(t, response)
+
+	snapshot, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 8})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snapshot.CheckRollupState != "FAILURE" {
+		t.Errorf("expected FAILURE, got %q", snapshot.CheckRollupState)
+	}
+}
+
+func TestEnrich_PendingChecksReportPending(t *testing.T) {
+	response := `{
+		"number": 9, "url": "https://github.com/o/r/pull/9", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "h", "baseRefOid": "b",
+		"reviewRequests": [], "latestReviews": [],
+		"statusCheckRollup": [
+			{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},
+			{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""}
+		],
+		"mergeStateStatus": "UNKNOWN", "updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	setupMockGH(t, response)
+
+	snapshot, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 9})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snapshot.CheckRollupState != "PENDING" {
+		t.Errorf("expected PENDING, got %q", snapshot.CheckRollupState)
+	}
+}
+
+func TestEnrich_HeadChangeReflectedInSnapshot(t *testing.T) {
+	first := `{
+		"number": 10, "url": "https://github.com/o/r/pull/10", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "sha-one", "baseRefOid": "b",
+		"reviewRequests": [], "latestReviews": [], "statusCheckRollup": [],
+		"mergeStateStatus": "CLEAN", "updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	scriptDir := setupMockGH(t, first)
+	key := domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 10}
+
+	snapshot, err := NewDiscovery().Enrich(context.Background(), key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snapshot.HeadObjectID != "sha-one" {
+		t.Fatalf("expected sha-one, got %q", snapshot.HeadObjectID)
+	}
+
+	second := `{
+		"number": 10, "url": "https://github.com/o/r/pull/10", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "sha-two", "baseRefOid": "b",
+		"reviewRequests": [], "latestReviews": [], "statusCheckRollup": [],
+		"mergeStateStatus": "CLEAN", "updatedAt": "2026-07-24T09:05:00Z"
+	}`
+	if err := writeMockGHResponse(scriptDir, second); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err = NewDiscovery().Enrich(context.Background(), key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snapshot.HeadObjectID != "sha-two" {
+		t.Fatalf("expected sha-two after head change, got %q", snapshot.HeadObjectID)
+	}
+}
+
+func TestEnrich_TransientGitHubFailure(t *testing.T) {
+	setupMockGHFailure(t, `HTTP 503: Service Unavailable (https://api.github.com/graphql)`)
+
+	_, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 11})
+	if !errors.Is(err, ErrTransient) {
+		t.Fatalf("expected ErrTransient, got %v", err)
+	}
+}
+
+func TestObserveSnapshot_RetainsPreviousSnapshotAsStaleOnTransientFailure(t *testing.T) {
+	key := domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 12}
+	previous := domain.PullRequestSnapshot{
+		PullRequest:  key,
+		URL:          "https://github.com/o/r/pull/12",
+		State:        domain.PullRequestStateOpen,
+		HeadObjectID: "sha",
+		BaseObjectID: "base",
+		CapturedAt:   time.Date(2026, 7, 24, 8, 0, 0, 0, time.UTC),
+	}
+
+	discovery := stubDiscovery{enrichErr: transientErr("rate limit")}
+	got, err := ObserveSnapshot(context.Background(), discovery, key, &previous)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Stale {
+		t.Error("expected retained snapshot to be marked stale")
+	}
+	if got.HeadObjectID != "sha" {
+		t.Errorf("expected retained snapshot data, got %+v", got)
+	}
+}
+
+func TestObserveSnapshot_PropagatesTransientFailureWithNoPrevious(t *testing.T) {
+	key := domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 13}
+	discovery := stubDiscovery{enrichErr: transientErr("rate limit")}
+
+	_, err := ObserveSnapshot(context.Background(), discovery, key, nil)
+	if !errors.Is(err, ErrTransient) {
+		t.Fatalf("expected ErrTransient to propagate, got %v", err)
+	}
+}
+
+func TestObserveSnapshot_NonTransientFailurePropagatesEvenWithPrevious(t *testing.T) {
+	key := domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 14}
+	previous := domain.PullRequestSnapshot{PullRequest: key, HeadObjectID: "sha", CapturedAt: time.Now()}
+	discovery := stubDiscovery{enrichErr: errors.New("repository not found")}
+
+	_, err := ObserveSnapshot(context.Background(), discovery, key, &previous)
+	if err == nil || errors.Is(err, ErrTransient) {
+		t.Fatalf("expected non-transient error to propagate as-is, got %v", err)
+	}
+}
+
+func TestObserveSnapshot_ReturnsFreshSnapshotOnSuccess(t *testing.T) {
+	key := domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 15}
+	fresh := domain.PullRequestSnapshot{PullRequest: key, HeadObjectID: "fresh-sha", CapturedAt: time.Now()}
+	discovery := stubDiscovery{enrichResult: fresh}
+
+	got, err := ObserveSnapshot(context.Background(), discovery, key, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Stale {
+		t.Error("expected fresh snapshot to not be marked stale")
+	}
+	if got.HeadObjectID != "fresh-sha" {
+		t.Errorf("expected fresh snapshot data, got %+v", got)
+	}
+}
+
+func TestReduceCheckRollup_EmptyIsNone(t *testing.T) {
+	if got := reduceCheckRollup(nil); got != "NONE" {
+		t.Errorf("expected NONE for empty checks, got %q", got)
+	}
+}
+
+func TestReduceCheckRollup_StatusContextStates(t *testing.T) {
+	tests := []struct {
+		name  string
+		check enrichCheck
+		want  string
+	}{
+		{"status context failure", enrichCheck{Typename: "StatusContext", State: "FAILURE"}, "FAILURE"},
+		{"status context error", enrichCheck{Typename: "StatusContext", State: "ERROR"}, "FAILURE"},
+		{"status context pending", enrichCheck{Typename: "StatusContext", State: "PENDING"}, "PENDING"},
+		{"status context success", enrichCheck{Typename: "StatusContext", State: "SUCCESS"}, "SUCCESS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reduceCheckRollup([]enrichCheck{tt.check}); got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestClassifyDiscoveryError_TransientMarkers(t *testing.T) {
+	markers := []string{
+		"API rate limit exceeded",
+		"context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+		"connection reset by peer",
+		"connection refused",
+		"HTTP 502: Bad Gateway",
+		"HTTP 503: Service Unavailable",
+		"HTTP 504: Gateway Timeout",
+		"could not resolve host: api.github.com",
+	}
+	for _, marker := range markers {
+		t.Run(marker, func(t *testing.T) {
+			exitErr := &exec.ExitError{Stderr: []byte(marker)}
+			err := classifyDiscoveryError(exitErr)
+			if !errors.Is(err, ErrTransient) {
+				t.Errorf("expected ErrTransient for %q, got %v", marker, err)
+			}
+		})
+	}
+}
+
+func TestClassifyDiscoveryError_NonTransientErrorsAreNotTransient(t *testing.T) {
+	exitErr := &exec.ExitError{Stderr: []byte("repository not found")}
+	err := classifyDiscoveryError(exitErr)
+	if errors.Is(err, ErrTransient) {
+		t.Errorf("expected non-transient error, got %v", err)
+	}
+}
+
+type stubDiscovery struct {
+	enrichResult domain.PullRequestSnapshot
+	enrichErr    error
+}
+
+func (s stubDiscovery) Search(ctx context.Context, query SearchQuery) ([]domain.PullRequestKey, error) {
+	return nil, nil
+}
+
+func (s stubDiscovery) Enrich(ctx context.Context, key domain.PullRequestKey) (domain.PullRequestSnapshot, error) {
+	return s.enrichResult, s.enrichErr
+}
+
+func transientErr(stderr string) error {
+	return classifyDiscoveryError(&exec.ExitError{Stderr: []byte(stderr)})
+}

--- a/internal/github/discovery_test.go
+++ b/internal/github/discovery_test.go
@@ -264,6 +264,33 @@ func TestEnrich_StaleChecksReportFailure(t *testing.T) {
 	}
 }
 
+func TestEnrich_SkipsLatestReviewsWithNullAuthor(t *testing.T) {
+	response := `{
+		"number": 23, "url": "https://github.com/o/r/pull/23", "title": "t",
+		"author": {"login": "a"}, "state": "OPEN", "isDraft": false,
+		"headRefOid": "h", "baseRefOid": "b",
+		"reviewRequests": [],
+		"latestReviews": [
+			{"author": null, "state": "APPROVED", "submittedAt": "2026-07-24T09:00:00Z"},
+			{"author": {"login": "reviewer1"}, "state": "COMMENTED", "submittedAt": "2026-07-24T09:05:00Z"}
+		],
+		"statusCheckRollup": [],
+		"mergeStateStatus": "CLEAN", "updatedAt": "2026-07-24T09:00:00Z"
+	}`
+	setupMockGH(t, response)
+
+	snapshot, err := NewDiscovery().Enrich(context.Background(), domain.PullRequestKey{Host: "github.com", Owner: "o", Repository: "r", Number: 23})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(snapshot.LatestReviews) != 1 || snapshot.LatestReviews[0].Author != "reviewer1" {
+		t.Fatalf("expected the null-author review to be skipped, got %+v", snapshot.LatestReviews)
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Errorf("expected valid snapshot, got %v", err)
+	}
+}
+
 func TestEnrich_DraftPullRequest(t *testing.T) {
 	response := `{
 		"number": 5, "url": "https://github.com/o/r/pull/5", "title": "wip",
@@ -513,6 +540,8 @@ func TestClassifyDiscoveryError_TransientMarkers(t *testing.T) {
 		"HTTP 503: Service Unavailable",
 		"HTTP 504: Gateway Timeout",
 		"could not resolve host: api.github.com",
+		"error connecting to api.github.com",
+		"dial tcp: lookup api.github.com: no such host",
 	}
 	for _, marker := range markers {
 		t.Run(marker, func(t *testing.T) {

--- a/internal/github/repo_scope_test.go
+++ b/internal/github/repo_scope_test.go
@@ -28,6 +28,31 @@ func setupMockGH(t *testing.T, response string) string {
 	return scriptDir
 }
 
+func writeMockGHResponse(scriptDir, response string) error {
+	return os.WriteFile(filepath.Join(scriptDir, "response"), []byte(response), 0644)
+}
+
+func setupMockGHFailure(t *testing.T, stderr string) string {
+	t.Helper()
+	scriptDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"DIR=$(cd \"$(dirname \"$0\")\" && pwd -P)\n" +
+		"pwd -P >> \"$DIR/cwd.log\"\n" +
+		"echo \"$@\" >> \"$DIR/args.log\"\n" +
+		"cat \"$DIR/stderr\" >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(filepath.Join(scriptDir, "gh"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "stderr"), []byte(stderr), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+originalPath)
+	return scriptDir
+}
+
 func setupMockGHRoutedByArgs(t *testing.T, routes map[string]string) string {
 	t.Helper()
 	scriptDir := t.TempDir()

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -3,6 +3,8 @@ package store
 import (
 	"fmt"
 	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 type PullRequestStateV1 string
@@ -126,4 +128,69 @@ func (s PRSnapshotV1) Validate() error {
 		return fmt.Errorf("pull request snapshot captured_at is required")
 	}
 	return nil
+}
+
+func ToPRSnapshotSchema(s domain.PullRequestSnapshot) PRSnapshotV1 {
+	reviewRequests := make([]ReviewRequestV1, len(s.ReviewRequests))
+	for i, r := range s.ReviewRequests {
+		reviewRequests[i] = ReviewRequestV1{Kind: ReviewRequestKindV1(r.Kind), Login: r.Login}
+	}
+	latestReviews := make([]LatestReviewV1, len(s.LatestReviews))
+	for i, r := range s.LatestReviews {
+		latestReviews[i] = LatestReviewV1{Author: r.Author, State: r.State, SubmittedAt: r.SubmittedAt}
+	}
+	return PRSnapshotV1{
+		SchemaVersion:    CurrentSchemaVersion,
+		PullRequest:      ToPullRequestKeySchema(s.PullRequest),
+		URL:              s.URL,
+		Title:            s.Title,
+		Author:           s.Author,
+		State:            PullRequestStateV1(s.State),
+		Draft:            s.Draft,
+		HeadObjectID:     s.HeadObjectID,
+		BaseObjectID:     s.BaseObjectID,
+		ReviewRequests:   reviewRequests,
+		ReviewDecision:   s.ReviewDecision,
+		LatestReviews:    latestReviews,
+		CheckRollupState: s.CheckRollupState,
+		MergeState:       s.MergeState,
+		UpdatedAt:        s.UpdatedAt,
+		CapturedAt:       s.CapturedAt,
+	}
+}
+
+func (s PRSnapshotV1) ToDomain() (domain.PullRequestSnapshot, error) {
+	if err := s.State.Validate(); err != nil {
+		return domain.PullRequestSnapshot{}, err
+	}
+
+	reviewRequests := make([]domain.ReviewRequest, len(s.ReviewRequests))
+	for i, r := range s.ReviewRequests {
+		if err := r.Kind.Validate(); err != nil {
+			return domain.PullRequestSnapshot{}, fmt.Errorf("review request %d: %w", i, err)
+		}
+		reviewRequests[i] = domain.ReviewRequest{Kind: domain.ReviewRequestKind(r.Kind), Login: r.Login}
+	}
+	latestReviews := make([]domain.LatestReview, len(s.LatestReviews))
+	for i, r := range s.LatestReviews {
+		latestReviews[i] = domain.LatestReview{Author: r.Author, State: r.State, SubmittedAt: r.SubmittedAt}
+	}
+
+	return domain.PullRequestSnapshot{
+		PullRequest:      s.PullRequest.ToDomain(),
+		URL:              s.URL,
+		Title:            s.Title,
+		Author:           s.Author,
+		State:            domain.PullRequestState(s.State),
+		Draft:            s.Draft,
+		HeadObjectID:     s.HeadObjectID,
+		BaseObjectID:     s.BaseObjectID,
+		ReviewRequests:   reviewRequests,
+		ReviewDecision:   s.ReviewDecision,
+		LatestReviews:    latestReviews,
+		CheckRollupState: s.CheckRollupState,
+		MergeState:       s.MergeState,
+		UpdatedAt:        s.UpdatedAt,
+		CapturedAt:       s.CapturedAt,
+	}, nil
 }

--- a/internal/store/snapshot.go
+++ b/internal/store/snapshot.go
@@ -160,15 +160,12 @@ func ToPRSnapshotSchema(s domain.PullRequestSnapshot) PRSnapshotV1 {
 }
 
 func (s PRSnapshotV1) ToDomain() (domain.PullRequestSnapshot, error) {
-	if err := s.State.Validate(); err != nil {
+	if err := s.Validate(); err != nil {
 		return domain.PullRequestSnapshot{}, err
 	}
 
 	reviewRequests := make([]domain.ReviewRequest, len(s.ReviewRequests))
 	for i, r := range s.ReviewRequests {
-		if err := r.Kind.Validate(); err != nil {
-			return domain.PullRequestSnapshot{}, fmt.Errorf("review request %d: %w", i, err)
-		}
 		reviewRequests[i] = domain.ReviewRequest{Kind: domain.ReviewRequestKind(r.Kind), Login: r.Login}
 	}
 	latestReviews := make([]domain.LatestReview, len(s.LatestReviews))

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -98,6 +98,27 @@ func TestToPRSnapshotSchema_ToDomain_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestPRSnapshotV1_ToDomain_RejectsUnvalidatedCorruptData(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(s *PRSnapshotV1)
+	}{
+		{"unsupported schema version", func(s *PRSnapshotV1) { s.SchemaVersion = 99 }},
+		{"invalid pull request key", func(s *PRSnapshotV1) { s.PullRequest.Number = 0 }},
+		{"missing head object id", func(s *PRSnapshotV1) { s.HeadObjectID = "" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := validSnapshot()
+			tt.mutate(&schema)
+			if _, err := schema.ToDomain(); err == nil {
+				t.Fatal("expected ToDomain to reject corrupt data even when called directly, bypassing decodePRSnapshot")
+			}
+		})
+	}
+}
+
 func TestPRSnapshotV1_ToDomain_RejectsUnknownReviewRequestKind(t *testing.T) {
 	schema := validSnapshot()
 	schema.ReviewRequests[0].Kind = "org"

--- a/internal/store/snapshot_test.go
+++ b/internal/store/snapshot_test.go
@@ -82,3 +82,39 @@ func TestPRSnapshotV1_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestToPRSnapshotSchema_ToDomain_RoundTrip(t *testing.T) {
+	schema := validSnapshot()
+
+	converted, err := schema.ToDomain()
+	if err != nil {
+		t.Fatalf("ToDomain: %v", err)
+	}
+
+	back := ToPRSnapshotSchema(converted)
+	back.SchemaVersion = schema.SchemaVersion
+	if !reflect.DeepEqual(back, schema) {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", back, schema)
+	}
+}
+
+func TestPRSnapshotV1_ToDomain_RejectsUnknownReviewRequestKind(t *testing.T) {
+	schema := validSnapshot()
+	schema.ReviewRequests[0].Kind = "org"
+
+	if _, err := schema.ToDomain(); err == nil {
+		t.Fatal("expected error for unknown review request kind")
+	}
+}
+
+func TestPRSnapshotV1_ToDomain_PreservesStaleFalse(t *testing.T) {
+	schema := validSnapshot()
+
+	converted, err := schema.ToDomain()
+	if err != nil {
+		t.Fatalf("ToDomain: %v", err)
+	}
+	if converted.Stale {
+		t.Error("expected a freshly loaded snapshot to not be marked stale")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `github.Discovery` (`Search` + `Enrich`) so domain/TUI code never shells out to `gh` directly.
- `Search` finds open PR candidates per configured organization via `gh search prs`, for three kinds: review-requested-of-a-user, authored-by-a-user, and team-review-requested.
- `Enrich` fetches full lifecycle data for a candidate via a single `gh pr view -R host/owner/repo --json ...` call (verified the exact field set against the locally installed `gh` CLI's `--json` field list, including `baseRefOid`, which does exist), producing an immutable `domain.PullRequestSnapshot`.
- Adds `domain.PullRequestSnapshot` (+ `PullRequestState`, `ReviewRequest`, `LatestReview`) as the pure domain counterpart to the `store.PRSnapshotV1` schema that Phase 2 already persists, with `ToPRSnapshotSchema`/`(PRSnapshotV1).ToDomain()` bridging functions mirroring the existing `ReviewRun`/`ReviewTarget` conversion pattern.
- Adds `ObserveSnapshot`, which retains the last valid snapshot and marks it `Stale` when a fresh `Enrich` fails transiently (rate limit, timeout, 5xx) instead of dropping the PR from the workspace. Non-transient failures (e.g. repo not found) still propagate.
- A small pure reducer (`reduceCheckRollup`) turns `statusCheckRollup`'s mixed `CheckRun`/`StatusContext` entries into a single rollup string (`SUCCESS`/`PENDING`/`FAILURE`/`NONE`).

## Design notes

- **Enrich is `-R`-scoped, not `cmd.Dir`-scoped** — a deliberate divergence from #200's pattern. #200's repository-scoped operations assume a local checkout exists; discovery explicitly must work for PRs whose repository isn't cloned locally yet (`repository_unavailable` is a first-class outcome per #202's acceptance criteria), so there's no working tree to set `cmd.Dir` to.
- Added a `misspell` ignore-rule for `CANCELLED` in `.golangci.yml` — it's GitHub's real `CheckConclusionState` enum value (confirmed against a live PR's `statusCheckRollup` output), not a spelling error.

## Test plan

- [x] `make check` (fmt, lint, vet, staticcheck, full test suite)
- [x] Re-ran `make check` under `HOME=$(mktemp -d) GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` to simulate CI's absent git identity
- [x] Fixture coverage: review-requested/authored/team search query construction, enrichment of open/draft/closed/merged PRs, failing/pending/passing check rollups, head-change reflected in a fresh snapshot, transient vs. non-transient `gh` failure classification, stale-snapshot retention with and without a prior observation

Closes #202