### PR TITLE
[P4] Ship the one-shot desk inbox and JSON output

### DIFF
--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -12,11 +12,23 @@ import (
 )
 
 func newDeskCmd() *cobra.Command {
+	var once bool
+	var jsonOutput bool
+
 	cmd := &cobra.Command{
 		Use:   "desk",
 		Short: "Inspect and manage the persistent review workspace",
 		Long:  "View and manage locally stored pull request review history.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !once {
+				return errors.New("continuous desk mode is not implemented yet; pass --once")
+			}
+			return runDeskOnce(jsonOutput)
+		},
 	}
+
+	cmd.Flags().BoolVar(&once, "once", false, "Refresh, classify, and print an actionable snapshot, then exit")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print the snapshot as JSON instead of human-readable text")
 
 	cmd.AddCommand(newDeskHistoryCmd())
 	cmd.AddCommand(newDeskForgetCmd())

--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -19,6 +19,7 @@ func newDeskCmd() *cobra.Command {
 		Use:   "desk",
 		Short: "Inspect and manage the persistent review workspace",
 		Long:  "View and manage locally stored pull request review history.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !once {
 				return errors.New("continuous desk mode is not implemented yet; pass --once")

--- a/cmd/acr/desk_once.go
+++ b/cmd/acr/desk_once.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func runDeskOnce(jsonOutput bool) error {
+	configDir, err := workspace.ConfigDir()
+	if err != nil {
+		return err
+	}
+	cfg, err := workspace.Load(configDir)
+	if err != nil {
+		return err
+	}
+	if errs := cfg.Validate(); len(errs) > 0 {
+		return fmt.Errorf("workspace configuration has %d error(s): %s", len(errs), strings.Join(errs, "; "))
+	}
+
+	ctx := context.Background()
+	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
+		return err
+	}
+
+	dataDir, err := store.DataDir()
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+
+	lock, lockErr := store.AcquireWriteLock(dataDir)
+	if lockErr != nil {
+		if !errors.Is(lockErr, store.ErrWriterLocked) {
+			return lockErr
+		}
+		inbox, err := desk.LoadStored(dataDir, *cfg, now)
+		if err != nil {
+			return err
+		}
+		renderInbox(inbox, jsonOutput, now)
+		return nil
+	}
+
+	inbox, refreshErr := desk.Refresh(ctx, *cfg, dataDir, github.NewDiscovery(), now)
+	if releaseErr := lock.Release(); releaseErr != nil && refreshErr == nil {
+		return releaseErr
+	}
+	if refreshErr != nil {
+		return refreshErr
+	}
+	renderInbox(inbox, jsonOutput, now)
+	return nil
+}
+
+func renderInbox(inbox desk.Inbox, jsonOutput bool, now time.Time) {
+	if jsonOutput {
+		data, err := json.MarshalIndent(inbox, "", "  ")
+		if err != nil {
+			fmt.Printf("failed to render inbox as JSON: %v\n", err)
+			return
+		}
+		fmt.Println(string(data))
+		return
+	}
+
+	if inbox.FromLiveLock {
+		fmt.Println("Another acr process owns the workspace; showing the last stored snapshot without refreshing.")
+	}
+	fmt.Printf("Desk snapshot at %s\n\n", inbox.GeneratedAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+
+	if len(inbox.Items) == 0 {
+		fmt.Println("Nothing needs your attention.")
+	} else {
+		grouped := groupItemsByState(inbox.Items)
+		for _, group := range desk.DeskStateDisplayOrder {
+			items := grouped[group]
+			if len(items) == 0 {
+				continue
+			}
+			fmt.Printf("%s (%d)\n", deskStateLabels[group], len(items))
+			for _, item := range items {
+				renderInboxItem(item, now)
+			}
+			fmt.Println()
+		}
+	}
+
+	if len(inbox.Warnings) > 0 {
+		fmt.Printf("%d warning(s):\n", len(inbox.Warnings))
+		for _, warning := range inbox.Warnings {
+			fmt.Printf("  - %s\n", warning)
+		}
+	}
+}
+
+func renderInboxItem(item desk.Item, now time.Time) {
+	fmt.Printf("  %s\n", item.Title)
+	fmt.Printf("    %s\n", item.URL)
+	fmt.Printf("    %s", item.Reason)
+	if item.RepositoryPath != "" {
+		fmt.Printf("  repo=%s", item.RepositoryPath)
+	}
+	if item.SnapshotStale {
+		fmt.Printf("  (stale snapshot, GitHub was unreachable)")
+	}
+	age := item.SnapshotAge(now)
+	fmt.Printf("  age=%s\n", terminal.FormatDuration(age))
+}
+
+func groupItemsByState(items []desk.Item) map[domain.DeskState][]desk.Item {
+	grouped := make(map[domain.DeskState][]desk.Item)
+	for _, item := range items {
+		grouped[item.DeskState] = append(grouped[item.DeskState], item)
+	}
+	return grouped
+}
+
+var deskStateLabels = map[domain.DeskState]string{
+	domain.DeskStateFailed:                "Failed",
+	domain.DeskStateFindingsReady:         "Findings ready",
+	domain.DeskStateDecisionReady:         "Decision ready",
+	domain.DeskStateNeedsReview:           "Needs review",
+	domain.DeskStateNeedsRereview:         "Needs re-review",
+	domain.DeskStateRunning:               "Running",
+	domain.DeskStateQueued:                "Queued",
+	domain.DeskStateStale:                 "Stale (settling)",
+	domain.DeskStateWaitingOnOthers:       "Waiting on others",
+	domain.DeskStateRepositoryUnavailable: "Repository unavailable",
+	domain.DeskStateResolved:              "Resolved",
+}

--- a/cmd/acr/desk_once.go
+++ b/cmd/acr/desk_once.go
@@ -29,11 +29,6 @@ func runDeskOnce(jsonOutput bool) error {
 		return fmt.Errorf("workspace configuration has %d error(s): %s", len(errs), strings.Join(errs, "; "))
 	}
 
-	ctx := context.Background()
-	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
-		return err
-	}
-
 	dataDir, err := store.DataDir()
 	if err != nil {
 		return err
@@ -51,6 +46,14 @@ func runDeskOnce(jsonOutput bool) error {
 		}
 		renderInbox(inbox, jsonOutput, now)
 		return nil
+	}
+
+	ctx := context.Background()
+	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
+		if releaseErr := lock.Release(); releaseErr != nil {
+			return fmt.Errorf("%w (also failed to release desk lock: %v)", err, releaseErr)
+		}
+		return err
 	}
 
 	inbox, refreshErr := desk.Refresh(ctx, *cfg, dataDir, github.NewDiscovery(), now)

--- a/cmd/acr/desk_once.go
+++ b/cmd/acr/desk_once.go
@@ -40,20 +40,15 @@ func runDeskOnce(jsonOutput bool) error {
 		if !errors.Is(lockErr, store.ErrWriterLocked) {
 			return lockErr
 		}
-		inbox, err := desk.LoadStored(dataDir, *cfg, now)
-		if err != nil {
-			return err
-		}
-		renderInbox(inbox, jsonOutput, now)
-		return nil
+		return renderStoredFallback(dataDir, *cfg, now, jsonOutput, "another acr process owns the workspace")
 	}
 
 	ctx := context.Background()
-	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
 		if releaseErr := lock.Release(); releaseErr != nil {
-			return fmt.Errorf("%w (also failed to release desk lock: %v)", err, releaseErr)
+			return fmt.Errorf("%w (also failed to release desk lock: %v)", identityErr, releaseErr)
 		}
-		return err
+		return renderStoredFallback(dataDir, *cfg, now, jsonOutput, fmt.Sprintf("GitHub identity could not be verified (%v)", identityErr))
 	}
 
 	inbox, refreshErr := desk.Refresh(ctx, *cfg, dataDir, github.NewDiscovery(), now)
@@ -63,6 +58,16 @@ func runDeskOnce(jsonOutput bool) error {
 	if refreshErr != nil {
 		return refreshErr
 	}
+	renderInbox(inbox, jsonOutput, now)
+	return nil
+}
+
+func renderStoredFallback(dataDir string, cfg workspace.Config, now time.Time, jsonOutput bool, reason string) error {
+	inbox, err := desk.LoadStored(dataDir, cfg, now)
+	if err != nil {
+		return err
+	}
+	inbox.Warnings = append([]string{"showing cached data only: " + reason}, inbox.Warnings...)
 	renderInbox(inbox, jsonOutput, now)
 	return nil
 }
@@ -78,9 +83,6 @@ func renderInbox(inbox desk.Inbox, jsonOutput bool, now time.Time) {
 		return
 	}
 
-	if inbox.FromLiveLock {
-		fmt.Println("Another acr process owns the workspace; showing the last stored snapshot without refreshing.")
-	}
 	fmt.Printf("Desk snapshot at %s\n\n", inbox.GeneratedAt.UTC().Format("2006-01-02 15:04:05 UTC"))
 
 	if len(inbox.Items) == 0 {

--- a/cmd/acr/desk_test.go
+++ b/cmd/acr/desk_test.go
@@ -289,7 +289,53 @@ notifications:
 			t.Fatalf("expected the locked fallback to succeed without gh, got %v", err)
 		}
 	})
-	if !strings.Contains(output, "Another acr process owns the workspace") {
+	if !strings.Contains(output, "showing cached data only: another acr process owns the workspace") {
 		t.Errorf("expected the locked-fallback notice, got %q", output)
+	}
+}
+
+func TestDeskOnce_FallsBackToCachedDataWhenIdentityCheckFails(t *testing.T) {
+	dataDir := t.TempDir()
+	configDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	t.Setenv("ACR_CONFIG_DIR", configDir)
+
+	noGHDir := t.TempDir()
+	t.Setenv("PATH", noGHDir)
+
+	if err := os.WriteFile(filepath.Join(configDir, "workspace.yaml"), []byte(`schema_version: 1
+identity:
+  expected_user: "me"
+scope:
+  organizations: []
+  teams: []
+  repository_roots: []
+  include: []
+  exclude: []
+  path_overrides: {}
+behavior:
+  poll_interval: 1m
+  settle_time: 10m
+  concurrency: 0
+  auto_review: false
+  re_review: false
+  own_pr_policy: disabled
+posting:
+  enabled: false
+notifications:
+  enabled: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"--once"})
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("expected identity check failure to fall back to cached data, not error out, got %v", err)
+		}
+	})
+	if !strings.Contains(output, "showing cached data only: GitHub identity could not be verified") {
+		t.Errorf("expected the identity-failure fallback notice, got %q", output)
 	}
 }

--- a/cmd/acr/desk_test.go
+++ b/cmd/acr/desk_test.go
@@ -241,3 +241,55 @@ func TestDeskForget_RemovesHistoryAndReportsIt(t *testing.T) {
 		t.Fatalf("expected no events remaining after forget, got %+v", events)
 	}
 }
+
+func TestDeskOnce_LockedFallbackWorksWithoutGH(t *testing.T) {
+	dataDir := t.TempDir()
+	configDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	t.Setenv("ACR_CONFIG_DIR", configDir)
+
+	noGHDir := t.TempDir()
+	t.Setenv("PATH", noGHDir)
+
+	if err := os.WriteFile(filepath.Join(configDir, "workspace.yaml"), []byte(`schema_version: 1
+identity:
+  expected_user: "me"
+scope:
+  organizations: []
+  teams: []
+  repository_roots: []
+  include: []
+  exclude: []
+  path_overrides: {}
+behavior:
+  poll_interval: 1m
+  settle_time: 10m
+  concurrency: 0
+  auto_review: false
+  re_review: false
+  own_pr_policy: disabled
+posting:
+  enabled: false
+notifications:
+  enabled: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lock, err := store.AcquireWriteLock(dataDir)
+	if err != nil {
+		t.Fatalf("acquire write lock: %v", err)
+	}
+	defer lock.Release()
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"--once"})
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("expected the locked fallback to succeed without gh, got %v", err)
+		}
+	})
+	if !strings.Contains(output, "Another acr process owns the workspace") {
+		t.Errorf("expected the locked-fallback notice, got %q", output)
+	}
+}

--- a/cmd/acr/desk_test.go
+++ b/cmd/acr/desk_test.go
@@ -339,3 +339,14 @@ notifications:
 		t.Errorf("expected the identity-failure fallback notice, got %q", output)
 	}
 }
+
+func TestDeskCmd_RejectsUnexpectedArguments(t *testing.T) {
+	t.Setenv("ACR_DATA_DIR", t.TempDir())
+	t.Setenv("ACR_CONFIG_DIR", t.TempDir())
+
+	cmd := newDeskCmd()
+	cmd.SetArgs([]string{"histroy", "--once"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an unknown subcommand to be rejected instead of silently running the refresh path")
+	}
+}

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -295,8 +295,12 @@ func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg 
 		}
 	}
 
-	for _, org := range cfg.Scope.Organizations {
-		if cfg.Identity.ExpectedUser != "" {
+	if cfg.Identity.ExpectedUser != "" {
+		if len(cfg.Scope.Organizations) == 0 {
+			search(github.SearchQuery{Kind: github.SearchKindReviewRequested, Login: cfg.Identity.ExpectedUser}, "review-requested search (no organization scope configured)")
+			search(github.SearchQuery{Kind: github.SearchKindAuthored, Login: cfg.Identity.ExpectedUser}, "authored search (no organization scope configured)")
+		}
+		for _, org := range cfg.Scope.Organizations {
 			search(github.SearchQuery{Kind: github.SearchKindReviewRequested, Organization: org, Login: cfg.Identity.ExpectedUser}, fmt.Sprintf("review-requested search in %s", org))
 			search(github.SearchQuery{Kind: github.SearchKindAuthored, Organization: org, Login: cfg.Identity.ExpectedUser}, fmt.Sprintf("authored search in %s", org))
 		}

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -323,10 +323,16 @@ func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg 
 }
 
 func appendUniqueKey(keys []domain.PullRequestKey, key domain.PullRequestKey) []domain.PullRequestKey {
-	if slices.Contains(keys, key) {
-		return keys
+	for _, existing := range keys {
+		if sameRepositoryIdentity(existing, key) && existing.Number == key.Number {
+			return keys
+		}
 	}
 	return append(keys, key)
+}
+
+func sameRepositoryIdentity(a, b domain.PullRequestKey) bool {
+	return strings.EqualFold(a.Host, b.Host) && strings.EqualFold(a.Owner, b.Owner) && strings.EqualFold(a.Repository, b.Repository)
 }
 
 var DeskStateDisplayOrder = []domain.DeskState{

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -74,9 +74,17 @@ func Refresh(ctx context.Context, cfg workspace.Config, dataDir string, discover
 
 	inbox := Inbox{GeneratedAt: now}
 	inbox.Warnings = append(inbox.Warnings, warnings...)
+	inbox.Warnings = append(inbox.Warnings, resolution.RootWarnings...)
 
 	for _, key := range keys {
 		schemaKey := store.ToPullRequestKeySchema(key)
+
+		if scopeExcludesKey(cfg, schemaKey) {
+			continue
+		}
+		if events, eventsErr := loadDomainEvents(dataDir, schemaKey); eventsErr == nil && domain.IsReleased(events) {
+			continue
+		}
 
 		var previous *domain.PullRequestSnapshot
 		if storedSchema, loadErr := snapshotStore.LoadSnapshot(schemaKey); loadErr == nil {
@@ -124,6 +132,7 @@ func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, err
 
 	snapshotStore := store.NewFilesystemSnapshotStore(dataDir)
 	inbox := Inbox{GeneratedAt: now, FromLiveLock: true}
+	inbox.Warnings = append(inbox.Warnings, resolution.RootWarnings...)
 
 	for _, schemaKey := range tracked {
 		storedSchema, err := snapshotStore.LoadSnapshot(schemaKey)
@@ -151,6 +160,30 @@ func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, err
 	return inbox, nil
 }
 
+func loadDomainEvents(dataDir string, key store.PullRequestKeyV1) ([]domain.LifecycleEvent, error) {
+	eventSchemas, _, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	if err != nil {
+		return nil, err
+	}
+	events := make([]domain.LifecycleEvent, 0, len(eventSchemas))
+	for _, schema := range eventSchemas {
+		if event, ok := schema.ToLifecycleEvent(); ok {
+			events = append(events, event)
+		}
+	}
+	return events, nil
+}
+
+func scopeExcludesKey(cfg workspace.Config, key store.PullRequestKeyV1) bool {
+	identity := repos.Identity{
+		Host:  strings.ToLower(key.Host),
+		Owner: strings.ToLower(key.Owner),
+		Name:  strings.ToLower(key.Repository),
+	}
+	excluded, _ := repos.MatchesExclusion(identity, cfg.Scope.Include, cfg.Scope.Exclude)
+	return excluded
+}
+
 func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Resolution, key store.PullRequestKeyV1, snapshot domain.PullRequestSnapshot, now time.Time) (Item, bool, error) {
 	if resolved, found := matchingResolvedRepository(resolution, key); found && resolved.Status == repos.StatusExcluded {
 		return Item{}, false, nil
@@ -169,16 +202,9 @@ func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Res
 		runs = append(runs, run)
 	}
 
-	eventSchemas, _, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	events, err := loadDomainEvents(dataDir, key)
 	if err != nil {
 		return Item{}, false, fmt.Errorf("load review events: %w", err)
-	}
-	events := make([]domain.LifecycleEvent, 0, len(eventSchemas))
-	for _, schema := range eventSchemas {
-		event, ok := schema.ToLifecycleEvent()
-		if ok {
-			events = append(events, event)
-		}
 	}
 
 	repositoryAvailable, repositoryPath := repositoryAvailability(resolution, key)

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -82,7 +82,7 @@ func Refresh(ctx context.Context, cfg workspace.Config, dataDir string, discover
 		if scopeExcludesKey(cfg, schemaKey) {
 			continue
 		}
-		if events, eventsErr := loadDomainEvents(dataDir, schemaKey); eventsErr == nil && domain.IsReleased(events) {
+		if events, _, eventsErr := loadDomainEvents(dataDir, schemaKey); eventsErr == nil && domain.IsReleased(events) {
 			continue
 		}
 
@@ -105,7 +105,8 @@ func Refresh(ctx context.Context, cfg workspace.Config, dataDir string, discover
 			}
 		}
 
-		item, ok, itemErr := classifySnapshot(dataDir, cfg, resolution, schemaKey, snapshot, now)
+		item, ok, itemWarnings, itemErr := classifySnapshot(dataDir, cfg, resolution, schemaKey, snapshot, now)
+		inbox.Warnings = append(inbox.Warnings, itemWarnings...)
 		if itemErr != nil {
 			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: %v", key.String(), itemErr))
 			continue
@@ -135,6 +136,10 @@ func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, err
 	inbox.Warnings = append(inbox.Warnings, resolution.RootWarnings...)
 
 	for _, schemaKey := range tracked {
+		if scopeExcludesKey(cfg, schemaKey) {
+			continue
+		}
+
 		storedSchema, err := snapshotStore.LoadSnapshot(schemaKey)
 		if err != nil {
 			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: no stored snapshot: %v", schemaKey.String(), err))
@@ -146,7 +151,8 @@ func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, err
 			continue
 		}
 
-		item, ok, itemErr := classifySnapshot(dataDir, cfg, resolution, schemaKey, snapshot, now)
+		item, ok, itemWarnings, itemErr := classifySnapshot(dataDir, cfg, resolution, schemaKey, snapshot, now)
+		inbox.Warnings = append(inbox.Warnings, itemWarnings...)
 		if itemErr != nil {
 			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: %v", schemaKey.String(), itemErr))
 			continue
@@ -160,10 +166,10 @@ func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, err
 	return inbox, nil
 }
 
-func loadDomainEvents(dataDir string, key store.PullRequestKeyV1) ([]domain.LifecycleEvent, error) {
-	eventSchemas, _, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+func loadDomainEvents(dataDir string, key store.PullRequestKeyV1) ([]domain.LifecycleEvent, []store.CorruptRecord, error) {
+	eventSchemas, corrupt, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	events := make([]domain.LifecycleEvent, 0, len(eventSchemas))
 	for _, schema := range eventSchemas {
@@ -171,7 +177,7 @@ func loadDomainEvents(dataDir string, key store.PullRequestKeyV1) ([]domain.Life
 			events = append(events, event)
 		}
 	}
-	return events, nil
+	return events, corrupt, nil
 }
 
 func scopeExcludesKey(cfg workspace.Config, key store.PullRequestKeyV1) bool {
@@ -184,14 +190,19 @@ func scopeExcludesKey(cfg workspace.Config, key store.PullRequestKeyV1) bool {
 	return excluded
 }
 
-func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Resolution, key store.PullRequestKeyV1, snapshot domain.PullRequestSnapshot, now time.Time) (Item, bool, error) {
+func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Resolution, key store.PullRequestKeyV1, snapshot domain.PullRequestSnapshot, now time.Time) (Item, bool, []string, error) {
 	if resolved, found := matchingResolvedRepository(resolution, key); found && resolved.Status == repos.StatusExcluded {
-		return Item{}, false, nil
+		return Item{}, false, nil, nil
 	}
 
-	runSchemas, _, err := store.NewFilesystemRunStore(dataDir).ListRuns(key)
+	var warnings []string
+
+	runSchemas, corruptRuns, err := store.NewFilesystemRunStore(dataDir).ListRuns(key)
 	if err != nil {
-		return Item{}, false, fmt.Errorf("load review runs: %w", err)
+		return Item{}, false, nil, fmt.Errorf("load review runs: %w", err)
+	}
+	if len(corruptRuns) > 0 {
+		warnings = append(warnings, fmt.Sprintf("%s: %d stored review run(s) could not be read; classification may be based on incomplete history", key.String(), len(corruptRuns)))
 	}
 	runs := make([]domain.ReviewRun, 0, len(runSchemas))
 	for _, schema := range runSchemas {
@@ -202,9 +213,12 @@ func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Res
 		runs = append(runs, run)
 	}
 
-	events, err := loadDomainEvents(dataDir, key)
+	events, corruptEvents, err := loadDomainEvents(dataDir, key)
 	if err != nil {
-		return Item{}, false, fmt.Errorf("load review events: %w", err)
+		return Item{}, false, nil, fmt.Errorf("load review events: %w", err)
+	}
+	if len(corruptEvents) > 0 {
+		warnings = append(warnings, fmt.Sprintf("%s: %d stored review event(s) could not be read; classification may be based on incomplete history", key.String(), len(corruptEvents)))
 	}
 
 	repositoryAvailable, repositoryPath := repositoryAvailability(resolution, key)
@@ -221,7 +235,7 @@ func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Res
 	})
 
 	if !classification.Tracked {
-		return Item{}, false, nil
+		return Item{}, false, warnings, nil
 	}
 
 	item := Item{
@@ -244,7 +258,7 @@ func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Res
 		DeskState:        classification.State,
 		Reason:           classification.Reason,
 	}
-	return item, true, nil
+	return item, true, warnings, nil
 }
 
 func repositoryAvailability(resolution repos.Resolution, key store.PullRequestKeyV1) (bool, string) {
@@ -290,6 +304,10 @@ func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg 
 	for _, team := range cfg.Scope.Teams {
 		if strings.Contains(team, "/") {
 			search(github.SearchQuery{Kind: github.SearchKindTeamReviewRequested, Team: team}, fmt.Sprintf("team-requested search for %s", team))
+			continue
+		}
+		if len(cfg.Scope.Organizations) == 0 {
+			warnings = append(warnings, fmt.Sprintf("scope.teams: %q is not qualified as org/team and scope.organizations is empty; skipping this team search", team))
 			continue
 		}
 		for _, org := range cfg.Scope.Organizations {

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -67,7 +67,7 @@ func Refresh(ctx context.Context, cfg workspace.Config, dataDir string, discover
 		return Inbox{}, err
 	}
 	for _, key := range tracked {
-		keys = appendUniqueKey(keys, key.ToDomain())
+		keys = mergeTrackedKey(keys, key.ToDomain())
 	}
 
 	snapshotStore := store.NewFilesystemSnapshotStore(dataDir)
@@ -329,6 +329,16 @@ func appendUniqueKey(keys []domain.PullRequestKey, key domain.PullRequestKey) []
 		}
 	}
 	return append(keys, key)
+}
+
+func mergeTrackedKey(keys []domain.PullRequestKey, tracked domain.PullRequestKey) []domain.PullRequestKey {
+	for i, existing := range keys {
+		if sameRepositoryIdentity(existing, tracked) && existing.Number == tracked.Number {
+			keys[i] = tracked
+			return keys
+		}
+	}
+	return append(keys, tracked)
 }
 
 func sameRepositoryIdentity(a, b domain.PullRequestKey) bool {

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -1,0 +1,295 @@
+package desk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/repos"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+type Item struct {
+	Key              store.PullRequestKeyV1 `json:"key"`
+	URL              string                 `json:"url"`
+	Title            string                 `json:"title"`
+	Author           string                 `json:"author"`
+	State            string                 `json:"state"`
+	Draft            bool                   `json:"draft"`
+	HeadObjectID     string                 `json:"head_object_id"`
+	BaseObjectID     string                 `json:"base_object_id"`
+	ReviewDecision   string                 `json:"review_decision,omitempty"`
+	CheckRollupState string                 `json:"check_rollup_state,omitempty"`
+	MergeState       string                 `json:"merge_state,omitempty"`
+	UpdatedAt        time.Time              `json:"updated_at"`
+	CapturedAt       time.Time              `json:"captured_at"`
+	SnapshotStale    bool                   `json:"snapshot_stale"`
+	OwnPR            bool                   `json:"own_pr"`
+	RepositoryPath   string                 `json:"repository_path,omitempty"`
+	DeskState        domain.DeskState       `json:"desk_state"`
+	Reason           string                 `json:"reason"`
+}
+
+func (item Item) SnapshotAge(now time.Time) time.Duration {
+	if item.CapturedAt.IsZero() {
+		return 0
+	}
+	age := now.Sub(item.CapturedAt)
+	if age < 0 {
+		return 0
+	}
+	return age
+}
+
+type Inbox struct {
+	GeneratedAt  time.Time `json:"generated_at"`
+	FromLiveLock bool      `json:"from_live_lock"`
+	Items        []Item    `json:"items"`
+	Warnings     []string  `json:"warnings,omitempty"`
+}
+
+func Refresh(ctx context.Context, cfg workspace.Config, dataDir string, discovery github.Discovery, now time.Time) (Inbox, error) {
+	resolution, err := repos.Resolve(ctx, cfg.Scope)
+	if err != nil {
+		return Inbox{}, fmt.Errorf("resolve configured repositories: %w", err)
+	}
+
+	keys, warnings := discoverCandidateKeys(ctx, discovery, cfg)
+
+	tracked, err := store.ListTrackedPullRequests(dataDir)
+	if err != nil {
+		return Inbox{}, err
+	}
+	for _, key := range tracked {
+		keys = appendUniqueKey(keys, key.ToDomain())
+	}
+
+	snapshotStore := store.NewFilesystemSnapshotStore(dataDir)
+
+	inbox := Inbox{GeneratedAt: now}
+	inbox.Warnings = append(inbox.Warnings, warnings...)
+
+	for _, key := range keys {
+		schemaKey := store.ToPullRequestKeySchema(key)
+
+		var previous *domain.PullRequestSnapshot
+		if storedSchema, loadErr := snapshotStore.LoadSnapshot(schemaKey); loadErr == nil {
+			if domainSnapshot, convertErr := storedSchema.ToDomain(); convertErr == nil {
+				previous = &domainSnapshot
+			}
+		}
+
+		snapshot, err := github.ObserveSnapshot(ctx, discovery, key, previous)
+		if err != nil {
+			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: %v", key.String(), err))
+			continue
+		}
+
+		if !snapshot.Stale {
+			if saveErr := snapshotStore.SaveSnapshot(store.ToPRSnapshotSchema(snapshot)); saveErr != nil {
+				inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: failed to persist snapshot: %v", key.String(), saveErr))
+			}
+		}
+
+		item, ok, itemErr := classifySnapshot(dataDir, cfg, resolution, schemaKey, snapshot, now)
+		if itemErr != nil {
+			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: %v", key.String(), itemErr))
+			continue
+		}
+		if ok {
+			inbox.Items = append(inbox.Items, item)
+		}
+	}
+
+	sortItems(inbox.Items)
+	return inbox, nil
+}
+
+func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, error) {
+	resolution, err := repos.Resolve(context.Background(), cfg.Scope)
+	if err != nil {
+		return Inbox{}, fmt.Errorf("resolve configured repositories: %w", err)
+	}
+
+	tracked, err := store.ListTrackedPullRequests(dataDir)
+	if err != nil {
+		return Inbox{}, err
+	}
+
+	snapshotStore := store.NewFilesystemSnapshotStore(dataDir)
+	inbox := Inbox{GeneratedAt: now, FromLiveLock: true}
+
+	for _, schemaKey := range tracked {
+		storedSchema, err := snapshotStore.LoadSnapshot(schemaKey)
+		if err != nil {
+			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: no stored snapshot: %v", schemaKey.String(), err))
+			continue
+		}
+		snapshot, err := storedSchema.ToDomain()
+		if err != nil {
+			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: stored snapshot is corrupt: %v", schemaKey.String(), err))
+			continue
+		}
+
+		item, ok, itemErr := classifySnapshot(dataDir, cfg, resolution, schemaKey, snapshot, now)
+		if itemErr != nil {
+			inbox.Warnings = append(inbox.Warnings, fmt.Sprintf("%s: %v", schemaKey.String(), itemErr))
+			continue
+		}
+		if ok {
+			inbox.Items = append(inbox.Items, item)
+		}
+	}
+
+	sortItems(inbox.Items)
+	return inbox, nil
+}
+
+func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Resolution, key store.PullRequestKeyV1, snapshot domain.PullRequestSnapshot, now time.Time) (Item, bool, error) {
+	runSchemas, _, err := store.NewFilesystemRunStore(dataDir).ListRuns(key)
+	if err != nil {
+		return Item{}, false, fmt.Errorf("load review runs: %w", err)
+	}
+	runs := make([]domain.ReviewRun, 0, len(runSchemas))
+	for _, schema := range runSchemas {
+		run, _, convertErr := store.FromReviewRunSchema(schema)
+		if convertErr != nil {
+			continue
+		}
+		runs = append(runs, run)
+	}
+
+	eventSchemas, _, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	if err != nil {
+		return Item{}, false, fmt.Errorf("load review events: %w", err)
+	}
+	events := make([]domain.LifecycleEvent, 0, len(eventSchemas))
+	for _, schema := range eventSchemas {
+		event, ok := schema.ToLifecycleEvent()
+		if ok {
+			events = append(events, event)
+		}
+	}
+
+	repositoryAvailable, repositoryPath := repositoryAvailability(resolution, key)
+
+	classification := domain.Classify(domain.ClassificationInput{
+		Snapshot:            snapshot,
+		RepositoryAvailable: repositoryAvailable,
+		ExpectedUser:        cfg.Identity.ExpectedUser,
+		ReviewOwnPRs:        cfg.Behavior.OwnPRPolicy == workspace.OwnPRPolicyCommentOnly,
+		SettleTime:          cfg.Behavior.SettleTime.AsDuration(),
+		Now:                 now,
+		Runs:                runs,
+		Events:              events,
+	})
+
+	if !classification.Tracked {
+		return Item{}, false, nil
+	}
+
+	item := Item{
+		Key:              key,
+		URL:              snapshot.URL,
+		Title:            snapshot.Title,
+		Author:           snapshot.Author,
+		State:            string(snapshot.State),
+		Draft:            snapshot.Draft,
+		HeadObjectID:     snapshot.HeadObjectID,
+		BaseObjectID:     snapshot.BaseObjectID,
+		ReviewDecision:   snapshot.ReviewDecision,
+		CheckRollupState: snapshot.CheckRollupState,
+		MergeState:       snapshot.MergeState,
+		UpdatedAt:        snapshot.UpdatedAt,
+		CapturedAt:       snapshot.CapturedAt,
+		SnapshotStale:    snapshot.Stale,
+		OwnPR:            cfg.Identity.ExpectedUser != "" && strings.EqualFold(snapshot.Author, cfg.Identity.ExpectedUser),
+		RepositoryPath:   repositoryPath,
+		DeskState:        classification.State,
+		Reason:           classification.Reason,
+	}
+	return item, true, nil
+}
+
+func repositoryAvailability(resolution repos.Resolution, key store.PullRequestKeyV1) (bool, string) {
+	for _, repository := range resolution.Repositories {
+		if repository.Identity.Host == key.Host && repository.Identity.Owner == key.Owner && repository.Identity.Name == key.Repository {
+			return repository.Status == repos.StatusReviewable, repository.LocalPath
+		}
+	}
+	return false, ""
+}
+
+func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg workspace.Config) ([]domain.PullRequestKey, []string) {
+	var keys []domain.PullRequestKey
+	var warnings []string
+
+	search := func(query github.SearchQuery, label string) {
+		found, err := discovery.Search(ctx, query)
+		if err != nil {
+			if !errors.Is(err, github.ErrTransient) {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", label, err))
+			}
+			return
+		}
+		for _, key := range found {
+			keys = appendUniqueKey(keys, key)
+		}
+	}
+
+	for _, org := range cfg.Scope.Organizations {
+		if cfg.Identity.ExpectedUser != "" {
+			search(github.SearchQuery{Kind: github.SearchKindReviewRequested, Organization: org, Login: cfg.Identity.ExpectedUser}, fmt.Sprintf("review-requested search in %s", org))
+			search(github.SearchQuery{Kind: github.SearchKindAuthored, Organization: org, Login: cfg.Identity.ExpectedUser}, fmt.Sprintf("authored search in %s", org))
+		}
+	}
+	for _, team := range cfg.Scope.Teams {
+		search(github.SearchQuery{Kind: github.SearchKindTeamReviewRequested, Team: team}, fmt.Sprintf("team-requested search for %s", team))
+	}
+
+	return keys, warnings
+}
+
+func appendUniqueKey(keys []domain.PullRequestKey, key domain.PullRequestKey) []domain.PullRequestKey {
+	if slices.Contains(keys, key) {
+		return keys
+	}
+	return append(keys, key)
+}
+
+var DeskStateDisplayOrder = []domain.DeskState{
+	domain.DeskStateFailed,
+	domain.DeskStateFindingsReady,
+	domain.DeskStateDecisionReady,
+	domain.DeskStateNeedsReview,
+	domain.DeskStateNeedsRereview,
+	domain.DeskStateRunning,
+	domain.DeskStateQueued,
+	domain.DeskStateStale,
+	domain.DeskStateWaitingOnOthers,
+	domain.DeskStateRepositoryUnavailable,
+	domain.DeskStateResolved,
+}
+
+func sortItems(items []Item) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].DeskState != items[j].DeskState {
+			return deskStateRank(items[i].DeskState) < deskStateRank(items[j].DeskState)
+		}
+		return items[i].Key.String() < items[j].Key.String()
+	})
+}
+
+func deskStateRank(state domain.DeskState) int {
+	if i := slices.Index(DeskStateDisplayOrder, state); i >= 0 {
+		return i
+	}
+	return len(DeskStateDisplayOrder)
+}

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -2,7 +2,6 @@ package desk
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -153,6 +152,10 @@ func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, err
 }
 
 func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Resolution, key store.PullRequestKeyV1, snapshot domain.PullRequestSnapshot, now time.Time) (Item, bool, error) {
+	if resolved, found := matchingResolvedRepository(resolution, key); found && resolved.Status == repos.StatusExcluded {
+		return Item{}, false, nil
+	}
+
 	runSchemas, _, err := store.NewFilesystemRunStore(dataDir).ListRuns(key)
 	if err != nil {
 		return Item{}, false, fmt.Errorf("load review runs: %w", err)
@@ -219,12 +222,22 @@ func classifySnapshot(dataDir string, cfg workspace.Config, resolution repos.Res
 }
 
 func repositoryAvailability(resolution repos.Resolution, key store.PullRequestKeyV1) (bool, string) {
+	resolved, found := matchingResolvedRepository(resolution, key)
+	if !found {
+		return false, ""
+	}
+	return resolved.Status == repos.StatusReviewable, resolved.LocalPath
+}
+
+func matchingResolvedRepository(resolution repos.Resolution, key store.PullRequestKeyV1) (repos.ResolvedRepository, bool) {
 	for _, repository := range resolution.Repositories {
-		if repository.Identity.Host == key.Host && repository.Identity.Owner == key.Owner && repository.Identity.Name == key.Repository {
-			return repository.Status == repos.StatusReviewable, repository.LocalPath
+		if strings.EqualFold(repository.Identity.Host, key.Host) &&
+			strings.EqualFold(repository.Identity.Owner, key.Owner) &&
+			strings.EqualFold(repository.Identity.Name, key.Repository) {
+			return repository, true
 		}
 	}
-	return false, ""
+	return repos.ResolvedRepository{}, false
 }
 
 func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg workspace.Config) ([]domain.PullRequestKey, []string) {
@@ -234,9 +247,7 @@ func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg 
 	search := func(query github.SearchQuery, label string) {
 		found, err := discovery.Search(ctx, query)
 		if err != nil {
-			if !errors.Is(err, github.ErrTransient) {
-				warnings = append(warnings, fmt.Sprintf("%s: %v", label, err))
-			}
+			warnings = append(warnings, fmt.Sprintf("%s: %v", label, err))
 			return
 		}
 		for _, key := range found {
@@ -251,7 +262,13 @@ func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg 
 		}
 	}
 	for _, team := range cfg.Scope.Teams {
-		search(github.SearchQuery{Kind: github.SearchKindTeamReviewRequested, Team: team}, fmt.Sprintf("team-requested search for %s", team))
+		if strings.Contains(team, "/") {
+			search(github.SearchQuery{Kind: github.SearchKindTeamReviewRequested, Team: team}, fmt.Sprintf("team-requested search for %s", team))
+			continue
+		}
+		for _, org := range cfg.Scope.Organizations {
+			search(github.SearchQuery{Kind: github.SearchKindTeamReviewRequested, Team: team, Organization: org}, fmt.Sprintf("team-requested search for %s/%s", org, team))
+		}
 	}
 
 	return keys, warnings

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -30,11 +30,12 @@ func initGitRepoWithRemote(t *testing.T, dir, remoteURL string) {
 }
 
 type fixtureDiscovery struct {
-	search    map[github.SearchKind][]domain.PullRequestKey
-	searchErr error
-	enrich    map[domain.PullRequestKey]domain.PullRequestSnapshot
-	err       map[domain.PullRequestKey]error
-	calls     []github.SearchQuery
+	search      map[github.SearchKind][]domain.PullRequestKey
+	searchErr   error
+	enrich      map[domain.PullRequestKey]domain.PullRequestSnapshot
+	err         map[domain.PullRequestKey]error
+	calls       []github.SearchQuery
+	enrichCalls []domain.PullRequestKey
 }
 
 func (f *fixtureDiscovery) Search(ctx context.Context, query github.SearchQuery) ([]domain.PullRequestKey, error) {
@@ -46,6 +47,7 @@ func (f *fixtureDiscovery) Search(ctx context.Context, query github.SearchQuery)
 }
 
 func (f *fixtureDiscovery) Enrich(ctx context.Context, key domain.PullRequestKey) (domain.PullRequestSnapshot, error) {
+	f.enrichCalls = append(f.enrichCalls, key)
 	if err, ok := f.err[key]; ok {
 		return domain.PullRequestSnapshot{}, err
 	}
@@ -552,5 +554,94 @@ func TestRefresh_ScopeExcludedRepositoryIsOmittedEntirely(t *testing.T) {
 	}
 	if len(inbox.Items) != 0 {
 		t.Fatalf("expected a scope-excluded repository's PR to be omitted entirely rather than shown as repository_unavailable, got %+v", inbox.Items)
+	}
+}
+
+func TestRefresh_ScopeExcludedPRSkippedBeforeEnrichment(t *testing.T) {
+	cfg := baseWorkspaceConfig(t, t.TempDir())
+	cfg.Scope.Exclude = []string{"acme/widgets"}
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 22}
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 0 {
+		t.Fatalf("expected a scope-excluded PR with no local repo to be omitted, got %+v", inbox.Items)
+	}
+	if len(inbox.Warnings) != 0 {
+		t.Errorf("expected no warnings for a scope-excluded PR, got %+v", inbox.Warnings)
+	}
+	if len(discovery.enrichCalls) != 0 {
+		t.Errorf("expected a scope-excluded PR to be skipped before enrichment, got enrich calls %+v", discovery.enrichCalls)
+	}
+}
+
+func TestRefresh_ReleasedPRSkippedBeforeEnrichment(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 23}
+	schemaKey := store.ToPullRequestKeySchema(key)
+	if _, err := store.NewFilesystemEventStore(dataDir).AppendEvent(store.ReviewEventV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "event-1",
+		PullRequest:   schemaKey,
+		Type:          store.EventTypeUserReleased,
+		OccurredAt:    now.Add(-time.Minute),
+		Actor:         "me",
+	}); err != nil {
+		t.Fatalf("append release event: %v", err)
+	}
+
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 0 {
+		t.Fatalf("expected a released PR to be omitted, got %+v", inbox.Items)
+	}
+	if len(discovery.enrichCalls) != 0 {
+		t.Errorf("expected a released PR to be skipped before enrichment, got enrich calls %+v", discovery.enrichCalls)
+	}
+}
+
+func TestRefresh_SurfacesRepositoryRootScanWarnings(t *testing.T) {
+	missingRoot := filepath.Join(t.TempDir(), "does-not-exist")
+	cfg := baseWorkspaceConfig(t, missingRoot)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	discovery := &fixtureDiscovery{search: map[github.SearchKind][]domain.PullRequestKey{}}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Warnings) == 0 {
+		t.Fatal("expected a warning about the missing repository root")
 	}
 }

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -645,3 +645,79 @@ func TestRefresh_SurfacesRepositoryRootScanWarnings(t *testing.T) {
 		t.Fatal("expected a warning about the missing repository root")
 	}
 }
+
+func TestLoadStored_RespectsScopeExclusion(t *testing.T) {
+	cfg := baseWorkspaceConfig(t, t.TempDir())
+	cfg.Scope.Exclude = []string{"acme/widgets"}
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 24}
+	captured := time.Date(2026, 7, 25, 11, 0, 0, 0, time.UTC)
+	if err := store.NewFilesystemSnapshotStore(dataDir).SaveSnapshot(store.ToPRSnapshotSchema(fixtureSnapshot(key, "someone-else", "head-1", captured))); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	inbox, err := LoadStored(dataDir, cfg, captured.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 0 {
+		t.Fatalf("expected a scope-excluded stored PR to be omitted from the locked/read-only path, got %+v", inbox.Items)
+	}
+}
+
+func TestRefresh_CorruptStoredHistorySurfacesWarning(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 25}
+	runsPath := filepath.Join(dataDir, "prs", "github.com", "acme", "widgets", "25", "runs")
+	if err := os.MkdirAll(runsPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corruptRun := filepath.Join(runsPath, "20260725T110000.000000000Z-run-bad.json")
+	if err := os.WriteFile(corruptRun, []byte(`{"schema_version": 1, "id": "run-bad", "truncated`), 0o644); err != nil {
+		t.Fatalf("seed corrupt run: %v", err)
+	}
+
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Warnings) == 0 {
+		t.Fatal("expected a warning about the corrupt stored run rather than silently classifying from incomplete history")
+	}
+}
+
+func TestDiscoverCandidateKeys_BareTeamWithNoOrganizationsWarns(t *testing.T) {
+	cfg := workspace.Config{
+		Identity: workspace.IdentityConfig{ExpectedUser: "me"},
+		Scope: workspace.ScopeConfig{
+			Teams: []string{"reviewers"},
+		},
+	}
+	discovery := &fixtureDiscovery{search: map[github.SearchKind][]domain.PullRequestKey{}}
+
+	_, warnings := discoverCandidateKeys(context.Background(), discovery, cfg)
+
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning that a bare team could not be searched without a configured organization")
+	}
+	for _, call := range discovery.calls {
+		if call.Kind == github.SearchKindTeamReviewRequested {
+			t.Errorf("expected no team search to be attempted for an unqualifiable bare team, got %+v", call)
+		}
+	}
+}

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -1,0 +1,447 @@
+package desk
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func initGitRepoWithRemote(t *testing.T, dir, remoteURL string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", dir, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "remote", "add", "origin", remoteURL).CombinedOutput(); err != nil {
+		t.Fatalf("git remote add failed: %v: %s", err, out)
+	}
+}
+
+type fixtureDiscovery struct {
+	search map[github.SearchKind][]domain.PullRequestKey
+	enrich map[domain.PullRequestKey]domain.PullRequestSnapshot
+	err    map[domain.PullRequestKey]error
+}
+
+func (f *fixtureDiscovery) Search(ctx context.Context, query github.SearchQuery) ([]domain.PullRequestKey, error) {
+	return f.search[query.Kind], nil
+}
+
+func (f *fixtureDiscovery) Enrich(ctx context.Context, key domain.PullRequestKey) (domain.PullRequestSnapshot, error) {
+	if err, ok := f.err[key]; ok {
+		return domain.PullRequestSnapshot{}, err
+	}
+	if snapshot, ok := f.enrich[key]; ok {
+		return snapshot, nil
+	}
+	return domain.PullRequestSnapshot{}, errors.New("no fixture for this key")
+}
+
+func baseWorkspaceConfig(t *testing.T, reviewableRoot string) workspace.Config {
+	t.Helper()
+	return workspace.Config{
+		Identity: workspace.IdentityConfig{ExpectedUser: "me"},
+		Scope: workspace.ScopeConfig{
+			Organizations:   []string{"acme"},
+			RepositoryRoots: []string{reviewableRoot},
+		},
+		Behavior: workspace.BehaviorConfig{
+			SettleTime:  config.Duration(10 * time.Minute),
+			OwnPRPolicy: workspace.OwnPRPolicyDisabled,
+		},
+	}
+}
+
+func fixtureSnapshot(key domain.PullRequestKey, author, head string, now time.Time) domain.PullRequestSnapshot {
+	return domain.PullRequestSnapshot{
+		PullRequest:  key,
+		URL:          "https://github.com/acme/widgets/pull/" + string(rune('0'+key.Number)),
+		Title:        "a pull request",
+		Author:       author,
+		State:        domain.PullRequestStateOpen,
+		HeadObjectID: head,
+		BaseObjectID: "base-sha",
+		UpdatedAt:    now.Add(-time.Hour),
+		CapturedAt:   now,
+	}
+}
+
+func TestRefresh_FirstReviewNeedsReview(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 1}
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected 1 item, got %+v", inbox.Items)
+	}
+	if inbox.Items[0].DeskState != domain.DeskStateNeedsReview {
+		t.Errorf("expected needs_review, got %q", inbox.Items[0].DeskState)
+	}
+
+	stored, err := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(store.ToPullRequestKeySchema(key))
+	if err != nil {
+		t.Fatalf("expected the fresh snapshot to be persisted: %v", err)
+	}
+	if stored.HeadObjectID != "head-1" {
+		t.Errorf("unexpected persisted snapshot: %+v", stored)
+	}
+}
+
+func TestRefresh_OwnPRDefaultsToWaitingOnOthers(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 2}
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindAuthored: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "me", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected 1 item, got %+v", inbox.Items)
+	}
+	item := inbox.Items[0]
+	if !item.OwnPR {
+		t.Error("expected OwnPR to be true")
+	}
+	if item.DeskState != domain.DeskStateWaitingOnOthers {
+		t.Errorf("expected waiting_on_others for an own PR with review disabled, got %q", item.DeskState)
+	}
+}
+
+func TestRefresh_RepositoryUnavailableRemainsVisible(t *testing.T) {
+	cfg := baseWorkspaceConfig(t, t.TempDir())
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 3}
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected 1 item, got %+v", inbox.Items)
+	}
+	item := inbox.Items[0]
+	if item.DeskState != domain.DeskStateRepositoryUnavailable {
+		t.Errorf("expected repository_unavailable, got %q", item.DeskState)
+	}
+	if item.Title == "" || item.URL == "" {
+		t.Errorf("expected an unavailable repository's PR to still show its title/url, got %+v", item)
+	}
+}
+
+func TestRefresh_TransientFailureFallsBackToStaleStoredSnapshot(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 4}
+	schemaKey := store.ToPullRequestKeySchema(key)
+	previous := fixtureSnapshot(key, "someone-else", "head-1", now.Add(-time.Hour))
+	if err := store.NewFilesystemSnapshotStore(dataDir).SaveSnapshot(store.ToPRSnapshotSchema(previous)); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		err: map[domain.PullRequestKey]error{
+			key: transientTestError{},
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected 1 item, got %+v", inbox.Items)
+	}
+	item := inbox.Items[0]
+	if !item.SnapshotStale {
+		t.Error("expected the fallback snapshot to be marked stale")
+	}
+	if item.HeadObjectID != "head-1" {
+		t.Errorf("expected the previous snapshot's data to be retained, got %+v", item)
+	}
+
+	reloaded, err := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(schemaKey)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !reloaded.CapturedAt.Equal(previous.CapturedAt) {
+		t.Error("expected the stale fallback to not overwrite the stored snapshot")
+	}
+}
+
+type transientTestError struct{}
+
+func (transientTestError) Error() string { return "transient test failure" }
+func (transientTestError) Unwrap() error { return github.ErrTransient }
+
+func TestRefresh_ContinuingResponsibilitySurvivesDroppedSearchResult(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 5}
+	previous := fixtureSnapshot(key, "someone-else", "head-1", now.Add(-time.Hour))
+	if err := store.NewFilesystemSnapshotStore(dataDir).SaveSnapshot(store.ToPRSnapshotSchema(previous)); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{}, // search no longer returns this PR
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-2", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected the previously tracked PR to still be refreshed even though search dropped it, got %+v", inbox.Items)
+	}
+	if inbox.Items[0].HeadObjectID != "head-2" {
+		t.Errorf("expected a fresh enrichment, got %+v", inbox.Items[0])
+	}
+}
+
+func TestRefresh_ReleasedPRIsExcluded(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 6}
+	schemaKey := store.ToPullRequestKeySchema(key)
+	if _, err := store.NewFilesystemEventStore(dataDir).AppendEvent(store.ReviewEventV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "event-1",
+		PullRequest:   schemaKey,
+		Type:          store.EventTypeUserReleased,
+		OccurredAt:    now.Add(-time.Minute),
+		Actor:         "me",
+	}); err != nil {
+		t.Fatalf("append release event: %v", err)
+	}
+	if err := store.NewFilesystemSnapshotStore(dataDir).SaveSnapshot(store.ToPRSnapshotSchema(fixtureSnapshot(key, "someone-else", "head-1", now.Add(-time.Hour)))); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 0 {
+		t.Fatalf("expected a released PR to be excluded from the inbox, got %+v", inbox.Items)
+	}
+}
+
+func TestLoadStored_RendersWithoutDiscoveryAndReportsAge(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	dataDir := t.TempDir()
+
+	captured := time.Date(2026, 7, 25, 11, 0, 0, 0, time.UTC)
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 7}
+	if err := store.NewFilesystemSnapshotStore(dataDir).SaveSnapshot(store.ToPRSnapshotSchema(fixtureSnapshot(key, "someone-else", "head-1", captured))); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	now := captured.Add(37 * time.Minute)
+	inbox, err := LoadStored(dataDir, cfg, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !inbox.FromLiveLock {
+		t.Error("expected FromLiveLock to be true for the read-only path")
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected 1 item, got %+v", inbox.Items)
+	}
+	if age := inbox.Items[0].SnapshotAge(now); age != 37*time.Minute {
+		t.Errorf("expected a 37m snapshot age, got %v", age)
+	}
+}
+
+func TestRefresh_FailedFindingsReadyAndResolvedStates(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		number     int
+		status     domain.ReviewStatus
+		conclusion domain.ReviewConclusion
+		findings   []domain.ReviewFinding
+		resolved   bool
+		want       domain.DeskState
+	}{
+		{"failed", 10, domain.ReviewStatusFailed, domain.ReviewConclusionNone, nil, false, domain.DeskStateFailed},
+		{"findings ready", 11, domain.ReviewStatusCompleted, domain.ReviewConclusionFindings, []domain.ReviewFinding{{ID: "f1", Kind: domain.ReviewFindingActionable}}, false, domain.DeskStateFindingsReady},
+		{"resolved", 12, domain.ReviewStatusCompleted, domain.ReviewConclusionFindings, []domain.ReviewFinding{{ID: "f1", Kind: domain.ReviewFindingActionable}}, true, domain.DeskStateResolved},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: tt.number}
+			schemaKey := store.ToPullRequestKeySchema(key)
+			pr := key
+
+			reviewConfig, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+				Reviewers:         1,
+				Concurrency:       1,
+				Timeout:           time.Minute,
+				ReviewerAgents:    []string{"codex"},
+				SummarizerAgent:   "codex",
+				SummarizerTimeout: time.Minute,
+				FPFilterTimeout:   time.Minute,
+				FPThreshold:       75,
+			})
+			if err != nil {
+				t.Fatalf("NewReviewConfiguration: %v", err)
+			}
+
+			run := domain.ReviewRun{
+				ID:      "run-1",
+				Trigger: domain.ReviewTriggerDesk,
+				Target: domain.ReviewTarget{
+					RepositoryRoot: "/repo",
+					WorktreeRoot:   "/repo",
+					Revision: domain.RevisionEvidence{
+						RequestedBaseRef: "main",
+						ResolvedBaseRef:  "main",
+						HeadObjectID:     "head-1",
+						BaseObjectID:     "base-sha",
+					},
+					PullRequest: &pr,
+				},
+				Engine:                   domain.ReviewEngine{Name: "acr", Version: "test"},
+				StartedAt:                now.Add(-2 * time.Hour),
+				CompletedAt:              now.Add(-2 * time.Hour),
+				Configuration:            reviewConfig,
+				ConfigurationSource:      domain.ConfigurationSourceIdentity{Kind: "defaults"},
+				ConfigurationFingerprint: reviewConfig.Fingerprint(),
+				Status:                   tt.status,
+				Conclusion:               tt.conclusion,
+				Findings:                 tt.findings,
+			}
+			if tt.status == domain.ReviewStatusFailed {
+				run.Failure = &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: "all reviewers failed"}
+			}
+			schema, err := store.ToReviewRunSchema(run, store.RenderedOutcomeV1{})
+			if err != nil {
+				t.Fatalf("ToReviewRunSchema: %v", err)
+			}
+			if _, err := store.NewFilesystemRunStore(dataDir).SaveRun(schema); err != nil {
+				t.Fatalf("save run: %v", err)
+			}
+
+			if tt.resolved {
+				if _, err := store.NewFilesystemEventStore(dataDir).AppendEvent(store.ReviewEventV1{
+					SchemaVersion: store.CurrentSchemaVersion,
+					ID:            "event-resolved",
+					PullRequest:   schemaKey,
+					Type:          store.EventTypeUserResolved,
+					OccurredAt:    now.Add(-time.Minute),
+					HeadObjectID:  "head-1",
+					BaseObjectID:  "base-sha",
+					Actor:         "me",
+				}); err != nil {
+					t.Fatalf("append resolved event: %v", err)
+				}
+			}
+
+			discovery := &fixtureDiscovery{
+				search: map[github.SearchKind][]domain.PullRequestKey{
+					github.SearchKindReviewRequested: {key},
+				},
+				enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+					key: fixtureSnapshot(key, "someone-else", "head-1", now),
+				},
+			}
+
+			inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(inbox.Items) != 1 {
+				t.Fatalf("expected 1 item, got %+v", inbox.Items)
+			}
+			if inbox.Items[0].DeskState != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, inbox.Items[0].DeskState)
+			}
+		})
+	}
+}

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -747,3 +747,25 @@ func TestDiscoverCandidateKeys_UnscopedDirectUserSearchWhenNoOrganizationsConfig
 		t.Fatalf("expected unscoped review-requested and authored searches when no organizations are configured, got calls %+v", discovery.calls)
 	}
 }
+
+func TestAppendUniqueKey_DeduplicatesCaseInsensitively(t *testing.T) {
+	keys := []domain.PullRequestKey{
+		{Host: "github.com", Owner: "Acme", Repository: "Widgets", Number: 1},
+	}
+	keys = appendUniqueKey(keys, domain.PullRequestKey{Host: "GitHub.com", Owner: "acme", Repository: "widgets", Number: 1})
+
+	if len(keys) != 1 {
+		t.Fatalf("expected a case-variant of an existing key to be deduplicated, got %+v", keys)
+	}
+}
+
+func TestAppendUniqueKey_DistinctRepositoriesAreNotMerged(t *testing.T) {
+	keys := []domain.PullRequestKey{
+		{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 1},
+	}
+	keys = appendUniqueKey(keys, domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "gadgets", Number: 1})
+
+	if len(keys) != 2 {
+		t.Fatalf("expected genuinely distinct repositories to both be kept, got %+v", keys)
+	}
+}

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -30,12 +30,18 @@ func initGitRepoWithRemote(t *testing.T, dir, remoteURL string) {
 }
 
 type fixtureDiscovery struct {
-	search map[github.SearchKind][]domain.PullRequestKey
-	enrich map[domain.PullRequestKey]domain.PullRequestSnapshot
-	err    map[domain.PullRequestKey]error
+	search    map[github.SearchKind][]domain.PullRequestKey
+	searchErr error
+	enrich    map[domain.PullRequestKey]domain.PullRequestSnapshot
+	err       map[domain.PullRequestKey]error
+	calls     []github.SearchQuery
 }
 
 func (f *fixtureDiscovery) Search(ctx context.Context, query github.SearchQuery) ([]domain.PullRequestKey, error) {
+	f.calls = append(f.calls, query)
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
 	return f.search[query.Kind], nil
 }
 
@@ -245,7 +251,7 @@ func TestRefresh_ContinuingResponsibilitySurvivesDroppedSearchResult(t *testing.
 	}
 
 	discovery := &fixtureDiscovery{
-		search: map[github.SearchKind][]domain.PullRequestKey{}, // search no longer returns this PR
+		search: map[github.SearchKind][]domain.PullRequestKey{},
 		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
 			key: fixtureSnapshot(key, "someone-else", "head-2", now),
 		},
@@ -443,5 +449,108 @@ func TestRefresh_FailedFindingsReadyAndResolvedStates(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.want, inbox.Items[0].DeskState)
 			}
 		})
+	}
+}
+
+func TestDiscoverCandidateKeys_QualifiesBareTeamWithEveryConfiguredOrganization(t *testing.T) {
+	cfg := workspace.Config{
+		Identity: workspace.IdentityConfig{ExpectedUser: "me"},
+		Scope: workspace.ScopeConfig{
+			Organizations: []string{"acme", "widgets-inc"},
+			Teams:         []string{"reviewers", "other-org/qualified-team"},
+		},
+	}
+	discovery := &fixtureDiscovery{search: map[github.SearchKind][]domain.PullRequestKey{}}
+
+	discoverCandidateKeys(context.Background(), discovery, cfg)
+
+	var teamQueries []github.SearchQuery
+	for _, call := range discovery.calls {
+		if call.Kind == github.SearchKindTeamReviewRequested {
+			teamQueries = append(teamQueries, call)
+		}
+	}
+	if len(teamQueries) != 3 {
+		t.Fatalf("expected 3 team queries (bare team x 2 orgs + 1 pre-qualified), got %+v", teamQueries)
+	}
+	for _, q := range teamQueries {
+		if err := q.Validate(); err != nil {
+			t.Errorf("expected every issued team query to be valid, got %v for %+v", err, q)
+		}
+	}
+}
+
+func TestRefresh_TransientSearchFailureIsSurfacedAsWarning(t *testing.T) {
+	cfg := baseWorkspaceConfig(t, t.TempDir())
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	discovery := &fixtureDiscovery{
+		search:    map[github.SearchKind][]domain.PullRequestKey{},
+		searchErr: transientTestError{},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Warnings) == 0 {
+		t.Fatal("expected a transient search failure to be surfaced as a warning rather than silently producing an empty, seemingly-clean inbox")
+	}
+}
+
+func TestRefresh_RepositoryIdentityMatchIsCaseInsensitive(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/Acme/Widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "Acme", Repository: "Widgets", Number: 20}
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected 1 item, got %+v", inbox.Items)
+	}
+	if inbox.Items[0].DeskState == domain.DeskStateRepositoryUnavailable {
+		t.Errorf("expected a differently-cased but locally available repository to not report repository_unavailable, got %+v", inbox.Items[0])
+	}
+}
+
+func TestRefresh_ScopeExcludedRepositoryIsOmittedEntirely(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	cfg.Scope.Exclude = []string{"acme/widgets"}
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	key := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 21}
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {key},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			key: fixtureSnapshot(key, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 0 {
+		t.Fatalf("expected a scope-excluded repository's PR to be omitted entirely rather than shown as repository_unavailable, got %+v", inbox.Items)
 	}
 }

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -769,3 +769,99 @@ func TestAppendUniqueKey_DistinctRepositoriesAreNotMerged(t *testing.T) {
 		t.Fatalf("expected genuinely distinct repositories to both be kept, got %+v", keys)
 	}
 }
+
+func TestMergeTrackedKey_PrefersStoredCasingOverLiveDiscoveryCasing(t *testing.T) {
+	keys := []domain.PullRequestKey{
+		{Host: "github.com", Owner: "Acme", Repository: "Widgets", Number: 1},
+	}
+	stored := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 1}
+	keys = mergeTrackedKey(keys, stored)
+
+	if len(keys) != 1 {
+		t.Fatalf("expected the case-variant to be merged into one entry, got %+v", keys)
+	}
+	if keys[0] != stored {
+		t.Errorf("expected the stored/tracked key's casing to win over the live-discovered casing, got %+v", keys[0])
+	}
+}
+
+func TestRefresh_UsesStoredCasingForHistoryLookupDespiteLiveCasingDifference(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoWithRemote(t, filepath.Join(root, "widgets"), "https://github.com/acme/widgets.git")
+	cfg := baseWorkspaceConfig(t, root)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	dataDir := t.TempDir()
+
+	storedKey := domain.PullRequestKey{Host: "github.com", Owner: "acme", Repository: "widgets", Number: 30}
+	storedSchemaKey := store.ToPullRequestKeySchema(storedKey)
+	if err := store.NewFilesystemSnapshotStore(dataDir).SaveSnapshot(store.ToPRSnapshotSchema(fixtureSnapshot(storedKey, "someone-else", "head-1", now.Add(-time.Hour)))); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	reviewConfig, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"codex"},
+		SummarizerAgent:   "codex",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatalf("NewReviewConfiguration: %v", err)
+	}
+	run := domain.ReviewRun{
+		ID:      "run-1",
+		Trigger: domain.ReviewTriggerDesk,
+		Target: domain.ReviewTarget{
+			RepositoryRoot: "/repo",
+			WorktreeRoot:   "/repo",
+			Revision: domain.RevisionEvidence{
+				RequestedBaseRef: "main",
+				ResolvedBaseRef:  "main",
+				HeadObjectID:     "head-1",
+				BaseObjectID:     "base-sha",
+			},
+			PullRequest: &storedKey,
+		},
+		Engine:                   domain.ReviewEngine{Name: "acr", Version: "test"},
+		StartedAt:                now.Add(-2 * time.Hour),
+		CompletedAt:              now.Add(-2 * time.Hour),
+		Configuration:            reviewConfig,
+		ConfigurationSource:      domain.ConfigurationSourceIdentity{Kind: "defaults"},
+		ConfigurationFingerprint: reviewConfig.Fingerprint(),
+		Status:                   domain.ReviewStatusCompleted,
+		Conclusion:               domain.ReviewConclusionClean,
+	}
+	schema, err := store.ToReviewRunSchema(run, store.RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatalf("ToReviewRunSchema: %v", err)
+	}
+	if _, err := store.NewFilesystemRunStore(dataDir).SaveRun(schema); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+
+	liveKey := domain.PullRequestKey{Host: "github.com", Owner: "Acme", Repository: "Widgets", Number: 30}
+	discovery := &fixtureDiscovery{
+		search: map[github.SearchKind][]domain.PullRequestKey{
+			github.SearchKindReviewRequested: {liveKey},
+		},
+		enrich: map[domain.PullRequestKey]domain.PullRequestSnapshot{
+			storedKey: fixtureSnapshot(storedKey, "someone-else", "head-1", now),
+		},
+	}
+
+	inbox, err := Refresh(context.Background(), cfg, dataDir, discovery, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inbox.Items) != 1 {
+		t.Fatalf("expected 1 item, got %+v", inbox.Items)
+	}
+	if inbox.Items[0].DeskState != domain.DeskStateDecisionReady {
+		t.Errorf("expected decision_ready from the existing completed run under the stored casing, got %q (a casing bug would report needs_review instead)", inbox.Items[0].DeskState)
+	}
+	if inbox.Items[0].Key != storedSchemaKey {
+		t.Errorf("expected the item to keep the stored key's casing, got %+v", inbox.Items[0].Key)
+	}
+}

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -721,3 +721,29 @@ func TestDiscoverCandidateKeys_BareTeamWithNoOrganizationsWarns(t *testing.T) {
 		}
 	}
 }
+
+func TestDiscoverCandidateKeys_UnscopedDirectUserSearchWhenNoOrganizationsConfigured(t *testing.T) {
+	cfg := workspace.Config{
+		Identity: workspace.IdentityConfig{ExpectedUser: "me"},
+		Scope:    workspace.ScopeConfig{Include: []string{"acme/widgets"}},
+	}
+	discovery := &fixtureDiscovery{search: map[github.SearchKind][]domain.PullRequestKey{}}
+
+	discoverCandidateKeys(context.Background(), discovery, cfg)
+
+	var reviewRequested, authored bool
+	for _, call := range discovery.calls {
+		if call.Organization != "" {
+			continue
+		}
+		switch call.Kind {
+		case github.SearchKindReviewRequested:
+			reviewRequested = true
+		case github.SearchKindAuthored:
+			authored = true
+		}
+	}
+	if !reviewRequested || !authored {
+		t.Fatalf("expected unscoped review-requested and authored searches when no organizations are configured, got calls %+v", discovery.calls)
+	}
+}

--- a/internal/domain/desk_state.go
+++ b/internal/domain/desk_state.go
@@ -68,7 +68,7 @@ type Classification struct {
 }
 
 func Classify(input ClassificationInput) Classification {
-	if isReleased(input.Events) {
+	if IsReleased(input.Events) {
 		return Classification{Tracked: false, Reason: "released by user"}
 	}
 
@@ -150,7 +150,7 @@ func latestLifecycleEvent(events []LifecycleEvent, kinds ...LifecycleEventKind) 
 	return latest
 }
 
-func isReleased(events []LifecycleEvent) bool {
+func IsReleased(events []LifecycleEvent) bool {
 	latest := latestLifecycleEvent(events, LifecycleEventUserReleased, LifecycleEventUserResumed)
 	return latest != nil && latest.Kind == LifecycleEventUserReleased
 }

--- a/internal/repos/repos.go
+++ b/internal/repos/repos.go
@@ -138,7 +138,7 @@ func Resolve(ctx context.Context, scope workspace.ScopeConfig) (Resolution, erro
 	}
 
 	for identity, result := range results {
-		if excluded, reason := matchesExclusion(identity, scope.Include, scope.Exclude); excluded {
+		if excluded, reason := MatchesExclusion(identity, scope.Include, scope.Exclude); excluded {
 			result.Status = StatusExcluded
 			result.Reason = reason
 			results[identity] = result
@@ -318,7 +318,7 @@ func matchesPattern(identity Identity, pattern string) bool {
 	return matched
 }
 
-func matchesExclusion(identity Identity, include, exclude []string) (bool, string) {
+func MatchesExclusion(identity Identity, include, exclude []string) (bool, string) {
 	for _, pattern := range exclude {
 		if matchesPattern(identity, pattern) {
 			return true, fmt.Sprintf("%s matches exclude pattern %q", identity, pattern)

--- a/internal/store/tracked.go
+++ b/internal/store/tracked.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+)
+
+func ListTrackedPullRequests(dataDir string) ([]PullRequestKeyV1, error) {
+	root := filepath.Join(dataDir, prsDirName)
+	hosts, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list tracked pull requests: %w", err)
+	}
+
+	var keys []PullRequestKeyV1
+	for _, host := range hosts {
+		if !host.IsDir() {
+			continue
+		}
+		owners, err := os.ReadDir(filepath.Join(root, host.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("list tracked pull requests: %w", err)
+		}
+		for _, owner := range owners {
+			if !owner.IsDir() {
+				continue
+			}
+			repositories, err := os.ReadDir(filepath.Join(root, host.Name(), owner.Name()))
+			if err != nil {
+				return nil, fmt.Errorf("list tracked pull requests: %w", err)
+			}
+			for _, repository := range repositories {
+				if !repository.IsDir() {
+					continue
+				}
+				numbers, err := os.ReadDir(filepath.Join(root, host.Name(), owner.Name(), repository.Name()))
+				if err != nil {
+					return nil, fmt.Errorf("list tracked pull requests: %w", err)
+				}
+				for _, number := range numbers {
+					if !number.IsDir() {
+						continue
+					}
+					parsed, err := strconv.Atoi(number.Name())
+					if err != nil {
+						continue
+					}
+					key := PullRequestKeyV1{Host: host.Name(), Owner: owner.Name(), Repository: repository.Name(), Number: parsed}
+					if key.Validate() != nil {
+						continue
+					}
+					keys = append(keys, key)
+				}
+			}
+		}
+	}
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+	return keys, nil
+}

--- a/internal/store/tracked_test.go
+++ b/internal/store/tracked_test.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListTrackedPullRequests_EmptyDataDir(t *testing.T) {
+	dir := t.TempDir()
+	keys, err := ListTrackedPullRequests(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected no tracked pull requests, got %+v", keys)
+	}
+}
+
+func TestListTrackedPullRequests_FindsSavedSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFilesystemSnapshotStore(dir)
+
+	first := validSnapshot()
+	if err := store.SaveSnapshot(first); err != nil {
+		t.Fatalf("save first: %v", err)
+	}
+	second := validSnapshot()
+	second.PullRequest.Number = 5
+	second.PullRequest.Owner = "other-owner"
+	if err := store.SaveSnapshot(second); err != nil {
+		t.Fatalf("save second: %v", err)
+	}
+
+	keys, err := ListTrackedPullRequests(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 tracked pull requests, got %+v", keys)
+	}
+	if keys[0].Owner != "other-owner" || keys[1] != first.PullRequest {
+		t.Errorf("unexpected sort order or keys: %+v", keys)
+	}
+}
+
+func TestListTrackedPullRequests_SkipsMalformedEntries(t *testing.T) {
+	dir := t.TempDir()
+	malformed := filepath.Join(dir, prsDirName, "github.com", "owner", "repo", "not-a-number")
+	if err := os.MkdirAll(malformed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewFilesystemSnapshotStore(dir)
+	valid := validSnapshot()
+	if err := store.SaveSnapshot(valid); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	keys, err := ListTrackedPullRequests(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(keys) != 1 || keys[0] != valid.PullRequest {
+		t.Fatalf("expected only the valid entry, got %+v", keys)
+	}
+}
+
+func TestListTrackedPullRequests_MissingDataDirIsNotAnError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+	keys, err := ListTrackedPullRequests(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected no tracked pull requests, got %+v", keys)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `acr desk --once` (with `--json`): the first independently useful workspace capability. Discovers candidate PRs via `github.Discovery` across configured organizations/teams, merges in already-tracked PRs (`store.ListTrackedPullRequests`, new in this PR) so continuing responsibility survives GitHub search dropping a PR (e.g. after submitting a review), enriches each candidate, classifies with `domain.Classify` (#203), and renders a deterministic, state-grouped, actionable snapshot.
- `internal/desk.Refresh` is the full read-write cycle, run behind the existing `desk.lock` single-writer lock (#197/#199). `internal/desk.LoadStored` is the read-only fallback used when another `acr` process already owns the lock — it renders the last persisted per-PR snapshots with their age, without refreshing or touching GitHub.
- Both share `classifySnapshot`, which loads each PR's runs/events, converts them to the pure domain types this initiative already established (`store.FromReviewRunSchema`, `store.ReviewEventV1.ToLifecycleEvent`), and calls `domain.Classify`. No review execution, no GitHub mutation, anywhere in this path.

## Design notes

- **Continuing responsibility via `ListTrackedPullRequests`.** The store had no way to answer "what do we already know about" without a specific `PullRequestKey` in hand — every existing store API required the caller to already know the key. Added a straightforward directory-walk over `prs/<host>/<owner>/<repo>/<number>`. This is what makes both continuing responsibility (a PR search no longer surfaces stays tracked as long as it has a stored snapshot) and the no-refresh render path possible.
- **`repository_unavailable` needed no special-casing.** A repository with no configured root or path override simply never appears in `repos.Resolve`'s results, so `repositoryAvailability` returns `false` for it automatically, and `domain.Classify` already handles that case (it was built with exactly this in mind in #203). The PR's title/URL/state still render normally since enrichment is GitHub-API-only and needs no local checkout.
- **Stale fallback snapshots are never re-persisted.** `github.ObserveSnapshot` (#202) returns a copy of the last snapshot with `Stale: true` on a transient failure; since `store.PRSnapshotV1` deliberately has no `Stale` field (staleness-from-fetch-failure is a runtime concept, not persisted state), re-saving it would just rewrite identical bytes. `Refresh` skips the save whenever `snapshot.Stale` is true.
- **Human and JSON views share one `desk.Inbox`.** `--json` is a direct `json.MarshalIndent` of the same struct the human renderer walks — there's no separate JSON-shaping step that could drift from what's printed to the terminal.

## Test plan

- [x] `make check` (fmt, lint, vet, staticcheck, full test suite)
- [x] Re-ran `make check` under `HOME=$(mktemp -d) GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` to simulate CI's absent git identity
- [x] Fixture-based `internal/desk` tests using a stub `github.Discovery` (no live GitHub or agents): first review, own-PR default, repository-unavailable visibility, transient-failure stale fallback (and that it isn't re-persisted), continuing responsibility after a dropped search result, released-PR exclusion, failed/findings-ready/resolved via stored runs
- [x] Manual smoke test of the actual built binary: `acr desk config init` → `acr desk --once` (empty scope, zero live GitHub calls) → `--json` output → simulated lock conflict (flock held externally) correctly falls back to the stored-snapshot render path with an explicit notice

Closes #204