### PR TITLE
fix: workspace config dir should use XDG path, not macOS Library path

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -67,11 +67,14 @@ func ConfigDir() (string, error) {
 	if dir := os.Getenv(ConfigDirEnvVar); dir != "" {
 		return dir, nil
 	}
-	base, err := os.UserConfigDir()
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "acr"), nil
+	}
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve workspace configuration directory: %w", err)
 	}
-	return filepath.Join(base, "acr"), nil
+	return filepath.Join(home, ".config", "acr"), nil
 }
 
 func ConfigPath(configDir string) string {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -19,15 +19,32 @@ func TestConfigDir_UsesEnvOverride(t *testing.T) {
 	}
 }
 
-func TestConfigDir_DefaultsUnderOSConfigDir(t *testing.T) {
+func TestConfigDir_DefaultsUnderXDGConfigHome(t *testing.T) {
 	t.Setenv(ConfigDirEnvVar, "")
+	t.Setenv("XDG_CONFIG_HOME", "/xdg/config")
 
 	dir, err := ConfigDir()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if filepath.Base(dir) != "acr" {
-		t.Fatalf("expected default config dir to end in acr, got %q", dir)
+	if dir != "/xdg/config/acr" {
+		t.Fatalf("expected XDG_CONFIG_HOME to be honored, got %q", dir)
+	}
+}
+
+func TestConfigDir_DefaultsUnderDotConfigWhenXDGUnset(t *testing.T) {
+	t.Setenv(ConfigDirEnvVar, "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(home, ".config", "acr")
+	if dir != want {
+		t.Fatalf("expected %q, got %q", want, dir)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `acr desk config init` (added in #204) resolved its config directory via `os.UserConfigDir()`, which maps to `~/Library/Application Support/acr` on macOS — the convention for GUI apps, not this project's CLI tools.
- This repo's tools use XDG Base Directory conventions on every platform. `ConfigDir()` now honors `$XDG_CONFIG_HOME`, falling back to `~/.config/acr`.
- `$ACR_CONFIG_DIR` override behavior is unchanged.

No users have relied on the old macOS path yet (the feature merged this week), so no migration is needed — anyone who already ran `config init` on macOS should delete `~/Library/Application Support/acr` and re-run it.

## Test plan
- [x] `make check` (fmt, lint, vet, staticcheck, unit tests)
- [x] CI-simulated run with isolated `HOME`/git config
- [x] Updated `TestConfigDir_DefaultsUnderOSConfigDir` → two tests covering `XDG_CONFIG_HOME` override and the `~/.config` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)