### PR TITLE
fix: scope unconfigured discovery search to personal account

### DIFF
--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -297,8 +297,8 @@ func discoverCandidateKeys(ctx context.Context, discovery github.Discovery, cfg 
 
 	if cfg.Identity.ExpectedUser != "" {
 		if len(cfg.Scope.Organizations) == 0 {
-			search(github.SearchQuery{Kind: github.SearchKindReviewRequested, Login: cfg.Identity.ExpectedUser}, "review-requested search (no organization scope configured)")
-			search(github.SearchQuery{Kind: github.SearchKindAuthored, Login: cfg.Identity.ExpectedUser}, "authored search (no organization scope configured)")
+			search(github.SearchQuery{Kind: github.SearchKindReviewRequested, Organization: cfg.Identity.ExpectedUser, Login: cfg.Identity.ExpectedUser}, "review-requested search (no organization scope configured, restricted to personal repositories)")
+			search(github.SearchQuery{Kind: github.SearchKindAuthored, Organization: cfg.Identity.ExpectedUser, Login: cfg.Identity.ExpectedUser}, "authored search (no organization scope configured, restricted to personal repositories)")
 		}
 		for _, org := range cfg.Scope.Organizations {
 			search(github.SearchQuery{Kind: github.SearchKindReviewRequested, Organization: org, Login: cfg.Identity.ExpectedUser}, fmt.Sprintf("review-requested search in %s", org))

--- a/internal/desk/inbox_test.go
+++ b/internal/desk/inbox_test.go
@@ -722,7 +722,7 @@ func TestDiscoverCandidateKeys_BareTeamWithNoOrganizationsWarns(t *testing.T) {
 	}
 }
 
-func TestDiscoverCandidateKeys_UnscopedDirectUserSearchWhenNoOrganizationsConfigured(t *testing.T) {
+func TestDiscoverCandidateKeys_RestrictsToPersonalAccountWhenNoOrganizationsConfigured(t *testing.T) {
 	cfg := workspace.Config{
 		Identity: workspace.IdentityConfig{ExpectedUser: "me"},
 		Scope:    workspace.ScopeConfig{Include: []string{"acme/widgets"}},
@@ -733,7 +733,7 @@ func TestDiscoverCandidateKeys_UnscopedDirectUserSearchWhenNoOrganizationsConfig
 
 	var reviewRequested, authored bool
 	for _, call := range discovery.calls {
-		if call.Organization != "" {
+		if call.Organization != "me" {
 			continue
 		}
 		switch call.Kind {
@@ -744,7 +744,12 @@ func TestDiscoverCandidateKeys_UnscopedDirectUserSearchWhenNoOrganizationsConfig
 		}
 	}
 	if !reviewRequested || !authored {
-		t.Fatalf("expected unscoped review-requested and authored searches when no organizations are configured, got calls %+v", discovery.calls)
+		t.Fatalf("expected review-requested and authored searches scoped to the user's own account when no organizations are configured, got calls %+v", discovery.calls)
+	}
+	for _, call := range discovery.calls {
+		if call.Kind != github.SearchKindTeamReviewRequested && call.Organization == "" {
+			t.Errorf("expected no globally-unscoped search when no organizations are configured, got %+v", call)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `acr desk --once` with no `scope.organizations` configured was searching **all of GitHub** for review-requested/authored PRs (no `--owner` filter at all), surfacing PRs from orgs the user never configured (e.g. an unrelated employer org) as "repository unavailable" desk items.
- Issue #202's acceptance criteria explicitly require: "Scope filters prevent unrelated visible repositories from entering the workspace." The unscoped fallback violated this.
- Fix: when no organizations are configured, scope the review-requested/authored searches to the user's own account (`--owner <expected_user>`) instead of leaving them global. Configuring `scope.organizations` still works exactly as before.

## Test plan
- [x] `make check`
- [x] CI-simulated run with isolated `HOME`/git config
- [x] Updated `TestDiscoverCandidateKeys_UnscopedDirectUserSearchWhenNoOrganizationsConfigured` → `TestDiscoverCandidateKeys_RestrictsToPersonalAccountWhenNoOrganizationsConfigured`, asserting searches are scoped to the user's own login and that no globally-unscoped (non-team) search is issued

🤖 Generated with [Claude Code](https://claude.com/claude-code)