### PR TITLE
fix: data dir should use XDG path, not macOS Caches path

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -117,7 +117,9 @@ for sharing. In particular:
 ## Filesystem storage (issue #197)
 
 `store.DataDir()` resolves the application-data directory: an `ACR_DATA_DIR`
-environment variable override, or `os.UserCacheDir()/acr` by default. Every
+environment variable override, `$XDG_DATA_HOME/acr` if set, or
+`~/.local/share/acr` by default (matching the XDG Base Directory convention
+used across this project's tools, on every platform). Every
 write goes through `atomicWriteFile`: content is written to a hidden temporary
 sibling file (`.tmp-<name>-*`) in the same directory, `fsync`'d, `chmod`'d,
 then atomically renamed over the destination; the containing directory is

--- a/internal/store/datadir.go
+++ b/internal/store/datadir.go
@@ -12,9 +12,12 @@ func DataDir() (string, error) {
 	if dir := os.Getenv(DataDirEnvVar); dir != "" {
 		return dir, nil
 	}
-	base, err := os.UserCacheDir()
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "acr"), nil
+	}
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve application data directory: %w", err)
 	}
-	return filepath.Join(base, "acr"), nil
+	return filepath.Join(home, ".local", "share", "acr"), nil
 }

--- a/internal/store/datadir_test.go
+++ b/internal/store/datadir_test.go
@@ -17,17 +17,31 @@ func TestDataDir_EnvVarOverride(t *testing.T) {
 	}
 }
 
-func TestDataDir_DefaultsUnderUserCacheDir(t *testing.T) {
+func TestDataDir_DefaultsUnderXDGDataHome(t *testing.T) {
 	t.Setenv(DataDirEnvVar, "")
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "/xdg/data")
 
 	dir, err := DataDir()
 	if err != nil {
 		t.Fatalf("DataDir: %v", err)
 	}
-	if filepath.Base(dir) != "acr" {
-		t.Fatalf("expected data dir to be named acr, got %q", dir)
+	if dir != "/xdg/data/acr" {
+		t.Fatalf("expected XDG_DATA_HOME to be honored, got %q", dir)
+	}
+}
+
+func TestDataDir_DefaultsUnderDotLocalShareWhenXDGUnset(t *testing.T) {
+	t.Setenv(DataDirEnvVar, "")
+	t.Setenv("XDG_DATA_HOME", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	want := filepath.Join(home, ".local", "share", "acr")
+	if dir != want {
+		t.Fatalf("expected %q, got %q", want, dir)
 	}
 }


### PR DESCRIPTION
## Summary
- Same anti-pattern as the workspace config dir fix: `store.DataDir()` resolved via `os.UserCacheDir()`, landing at `~/Library/Caches/acr` on macOS instead of an XDG path.
- Now honors `$XDG_DATA_HOME` (falling back to `~/.local/share/acr`) rather than the cache-directory convention. Persisted PR snapshots/runs/events/adjudications are durable review history the desk depends on for state classification — not disposable cache — so `XDG_DATA_HOME` is the correct category, not `XDG_CACHE_HOME`.
- `$ACR_DATA_DIR` override is unchanged.
- Updated `docs/persistence.md`'s description of `DataDir()`.

No migration needed — this feature has no external users yet; existing local data under `~/Library/Caches/acr` can be moved or deleted and will be recreated fresh under the new path.

## Test plan
- [x] `make check`
- [x] CI-simulated run with isolated `HOME`/git config
- [x] Updated `TestDataDir_DefaultsUnderUserCacheDir` → two tests covering `XDG_DATA_HOME` override and the `~/.local/share` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)