### PR TITLE
feat: add acr desk dispatch for manual, decision-ready reviews

### DIFF
--- a/cmd/acr/config_source.go
+++ b/cmd/acr/config_source.go
@@ -18,6 +18,10 @@ func resolveTrustedReviewConfigSource(ctx context.Context, disabled bool) (confi
 	if err != nil {
 		return nil, err
 	}
+	return resolveTrustedReviewConfigSourceForRoot(ctx, repositoryRoot)
+}
+
+func resolveTrustedReviewConfigSourceForRoot(ctx context.Context, repositoryRoot string) (config.Source, error) {
 	remotes, err := git.Remotes(ctx, repositoryRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect trusted review configuration remote: %w", err)

--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -34,6 +34,7 @@ func newDeskCmd() *cobra.Command {
 	cmd.AddCommand(newDeskHistoryCmd())
 	cmd.AddCommand(newDeskForgetCmd())
 	cmd.AddCommand(newDeskConfigCmd())
+	cmd.AddCommand(newDeskDispatchCmd())
 
 	return cmd
 }

--- a/cmd/acr/desk_dispatch.go
+++ b/cmd/acr/desk_dispatch.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/git"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	reviewpkg "github.com/richhaase/agentic-code-reviewer/internal/review"
+	"github.com/richhaase/agentic-code-reviewer/internal/runner"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func newDeskDispatchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "dispatch <[host/]owner/repo#number>",
+		Short: "Run a headless review for one desk item and persist the result",
+		Long: "Resolve an eligible desk item's trusted repository, run its review in an isolated worktree, " +
+			"and persist the result without posting to GitHub. Use `acr desk history` to inspect it afterward.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := desk.ParsePullRequestRef(args[0])
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				cancel()
+			}()
+
+			return runDeskDispatch(ctx, key, github.NewDiscovery(), defaultDispatchService)
+		},
+	}
+}
+
+func runDeskDispatch(ctx context.Context, key store.PullRequestKeyV1, discovery github.Discovery, newService dispatchServiceFactory) error {
+	if !terminal.IsStdoutTTY() {
+		terminal.DisableColors()
+	}
+
+	configDir, err := workspace.ConfigDir()
+	if err != nil {
+		return err
+	}
+	cfg, err := workspace.Load(configDir)
+	if err != nil {
+		return err
+	}
+	if errs := cfg.Validate(); len(errs) > 0 {
+		return fmt.Errorf("workspace configuration has %d error(s): %s", len(errs), strings.Join(errs, "; "))
+	}
+
+	dataDir, err := store.DataDir()
+	if err != nil {
+		return err
+	}
+
+	lock, err := store.AcquireWriteLock(dataDir)
+	if err != nil {
+		if errors.Is(err, store.ErrWriterLocked) {
+			return fmt.Errorf("cannot dispatch %s: %w", key.String(), err)
+		}
+		return err
+	}
+	released := false
+	release := func() error {
+		if released {
+			return nil
+		}
+		released = true
+		return lock.Release()
+	}
+	defer func() { _ = release() }()
+
+	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
+	}
+
+	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+	if err != nil {
+		return err
+	}
+
+	item, ok := findDeskItem(inbox, key)
+	if !ok {
+		return fmt.Errorf("%s is not in the current desk view; run `acr desk --once` first", key.String())
+	}
+	if eligibleErr := checkDispatchEligible(item); eligibleErr != nil {
+		return eligibleErr
+	}
+
+	logger := terminal.NewLogger()
+	run, dispatchErr := dispatchReview(ctx, item, logger, newService)
+
+	var saveErr error
+	if run != nil {
+		saveErr = persistDispatchRun(dataDir, *run)
+	}
+
+	refreshed, refreshErr := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+
+	if releaseErr := release(); releaseErr != nil {
+		return releaseErr
+	}
+
+	if dispatchErr != nil {
+		return dispatchErr
+	}
+	if run == nil {
+		return errors.New("dispatch failed: no review result was produced")
+	}
+	if saveErr != nil {
+		return fmt.Errorf("review completed but could not be saved: %w", saveErr)
+	}
+
+	fmt.Println(runner.RenderReviewRun(*run))
+
+	if refreshErr != nil {
+		fmt.Printf("\nwarning: could not refresh desk state after dispatch: %v\n", refreshErr)
+		return nil
+	}
+	if resultItem, ok := findDeskItem(refreshed, key); ok {
+		fmt.Printf("\nDesk state: %s — %s\n", resultItem.DeskState, resultItem.Reason)
+	}
+	fmt.Printf("Run `acr desk history %s` for the full timeline.\n", key.String())
+	return nil
+}
+
+func findDeskItem(inbox desk.Inbox, key store.PullRequestKeyV1) (desk.Item, bool) {
+	for _, item := range inbox.Items {
+		if item.Key == key {
+			return item, true
+		}
+	}
+	return desk.Item{}, false
+}
+
+func checkDispatchEligible(item desk.Item) error {
+	switch item.DeskState {
+	case domain.DeskStateResolved:
+		return fmt.Errorf("%s is already resolved", item.Key.String())
+	case domain.DeskStateRepositoryUnavailable:
+		return fmt.Errorf("%s: repository is not available locally", item.Key.String())
+	case domain.DeskStateWaitingOnOthers:
+		return fmt.Errorf("%s: %s", item.Key.String(), item.Reason)
+	case domain.DeskStateRunning, domain.DeskStateQueued:
+		return fmt.Errorf("%s: a review is already %s", item.Key.String(), item.DeskState)
+	}
+	if item.RepositoryPath == "" {
+		return fmt.Errorf("%s has no local repository path", item.Key.String())
+	}
+	return nil
+}
+
+type dispatchServiceFactory func(ReviewOpts, *terminal.Logger) (semanticReviewService, error)
+
+func dispatchReview(ctx context.Context, item desk.Item, logger *terminal.Logger, newService dispatchServiceFactory) (*domain.ReviewRun, error) {
+	_ = git.PruneStaleWorktrees(item.RepositoryPath)
+
+	prNumber := strconv.Itoa(item.Key.Number)
+
+	remote, err := github.FindRepoRemote(ctx, item.RepositoryPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve PR fetch remote: %w", err)
+	}
+
+	detectedBase, _ := github.GetPRBaseRef(ctx, item.RepositoryPath, prNumber)
+
+	logger.Logf(terminal.StyleInfo, "Fetching PR %s#%s%s",
+		terminal.Color(terminal.Bold), prNumber, terminal.Color(terminal.Reset))
+
+	wt, err := git.CreateWorktreeFromPR(ctx, item.RepositoryPath, remote, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("create review worktree: %w", err)
+	}
+	defer func() {
+		logger.Log("Cleaning up worktree", terminal.StyleDim)
+		_ = wt.Remove()
+	}()
+
+	configSource, err := resolveTrustedReviewConfigSourceForRoot(ctx, item.RepositoryPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve trusted review configuration: %w", err)
+	}
+	loadResult, err := configSource.LoadWithWarnings(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load trusted review configuration: %w", err)
+	}
+	for _, warning := range loadResult.Warnings {
+		logger.Logf(terminal.StyleWarning, "Warning: %s", warning)
+	}
+
+	envState, envWarnings := config.LoadEnvState()
+	for _, warning := range envWarnings {
+		logger.Logf(terminal.StyleWarning, "Warning: %s", warning)
+	}
+
+	flagState := config.FlagState{BaseSet: detectedBase != ""}
+	flagValues := config.ResolvedConfig{Base: detectedBase}
+	resolved := config.Resolve(loadResult.Config, envState, flagState, flagValues)
+
+	wtResult := worktreeResult{
+		workDir:          wt.Path,
+		repositoryRoot:   item.RepositoryPath,
+		detectedBase:     detectedBase,
+		baseAutoDetected: detectedBase != "",
+		prRemote:         remote,
+		prRepoRoot:       item.RepositoryPath,
+	}
+	prepareReviewBase(ctx, wtResult, &resolved, logger)
+
+	if err := resolved.Validate(); err != nil {
+		return nil, err
+	}
+	if resolved.Concurrency <= 0 {
+		resolved.Concurrency = resolved.Reviewers
+	}
+	if resolved.Concurrency > resolved.Reviewers {
+		resolved.Concurrency = resolved.Reviewers
+	}
+
+	resolvedGuidance, err := config.ResolveGuidanceFromLoadResult(ctx, loadResult, envState, flagState, flagValues)
+	if err != nil {
+		return nil, fmt.Errorf("resolve review guidance: %w", err)
+	}
+	resolved.Guidance = resolvedGuidance
+	excludePatterns := config.Merge(loadResult.Config, nil)
+
+	pullRequestKey := item.Key.ToDomain()
+	opts := ReviewOpts{
+		ResolvedConfig:  resolved,
+		PRNumber:        prNumber,
+		DetectedPR:      prNumber,
+		ExcludePatterns: excludePatterns,
+		RepositoryRoot:  item.RepositoryPath,
+		WorkDir:         wt.Path,
+		PullRequest:     &pullRequestKey,
+		ConfigSource:    loadResult.Source,
+		Trigger:         domain.ReviewTriggerDesk,
+	}
+
+	if err := agent.ValidateAgentNames(opts.ReviewerAgents); err != nil {
+		return nil, fmt.Errorf("invalid agent: %w", err)
+	}
+
+	resolvedBaseRef := resolveReviewBase(ctx, opts, logger)
+
+	events := newCLIReviewEvents(opts, logger)
+	defer events.Close()
+
+	service, err := newService(opts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("initialize review service: %w", err)
+	}
+
+	request, err := newReviewRequest(opts, resolvedBaseRef, events)
+	if err != nil {
+		return nil, err
+	}
+
+	run, err := service.Run(ctx, request)
+	if run == nil && err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func defaultDispatchService(opts ReviewOpts, logger *terminal.Logger) (semanticReviewService, error) {
+	return reviewpkg.NewService(reviewpkg.WithDiffProvider(newGitDiffProvider(opts, logger)))
+}
+
+func persistDispatchRun(dataDir string, run domain.ReviewRun) error {
+	schema, err := store.ToReviewRunSchema(run, store.RenderedOutcomeV1{})
+	if err != nil {
+		return err
+	}
+	_, err = store.NewFilesystemRunStore(dataDir).SaveRun(schema)
+	return err
+}

--- a/cmd/acr/desk_dispatch.go
+++ b/cmd/acr/desk_dispatch.go
@@ -137,12 +137,17 @@ func runDeskDispatch(ctx context.Context, key store.PullRequestKeyV1, discovery 
 
 	if refreshErr != nil {
 		fmt.Printf("\nwarning: could not refresh desk state after dispatch: %v\n", refreshErr)
-		return nil
-	}
-	if resultItem, ok := findDeskItem(refreshed, key); ok {
+	} else if resultItem, ok := findDeskItem(refreshed, key); ok {
 		fmt.Printf("\nDesk state: %s — %s\n", resultItem.DeskState, resultItem.Reason)
 	}
 	fmt.Printf("Run `acr desk history %s` for the full timeline.\n", key.String())
+
+	if run.Status != domain.ReviewStatusCompleted {
+		if run.Failure != nil {
+			return fmt.Errorf("review did not complete (status %s): %s", run.Status, run.Failure.Message)
+		}
+		return fmt.Errorf("review did not complete: status %s", run.Status)
+	}
 	return nil
 }
 

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -267,10 +268,27 @@ func newDispatchGitFixture(t *testing.T, prNumber int) dispatchGitFixture {
 	}
 }
 
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 func startGitDaemon(t *testing.T, baseDir string) {
 	t.Helper()
 
-	var stderr bytes.Buffer
+	stderr := &syncBuffer{}
 	cmd := exec.Command("git", "daemon",
 		"--reuseaddr",
 		"--export-all",
@@ -278,7 +296,7 @@ func startGitDaemon(t *testing.T, baseDir string) {
 		"--port="+gitDaemonPort,
 		"--listen=127.0.0.1",
 	)
-	cmd.Stderr = &stderr
+	cmd.Stderr = stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("failed to start git daemon: %v", err)

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -494,6 +494,64 @@ func TestRunDeskDispatch_PersistsRunAndReportsDecisionReady(t *testing.T) {
 	}
 }
 
+func TestRunDeskDispatch_ReturnsErrorForFailedReview(t *testing.T) {
+	fixture := newDispatchGitFixture(t, 11)
+
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfig(t, configDir, "me", []string{fixture.repoRoot})
+	withFakeGH(t, fakeGHResponses{
+		user:        "me",
+		repoURL:     fixture.remoteURL,
+		repoSSHURL:  fixture.remoteURL,
+		baseRefName: "main",
+	})
+
+	key := dispatchPullRequestKey(fixture.host, 11)
+	now := time.Now()
+	discovery := &dispatchFixtureDiscovery{
+		searchResult: []domain.PullRequestKey{key.ToDomain()},
+		enrichResponses: []domain.PullRequestSnapshot{
+			dispatchSnapshot(key, fixture.prHeadSHA, fixture.baseSHA, now),
+			dispatchSnapshot(key, fixture.prHeadSHA, fixture.baseSHA, now.Add(time.Minute)),
+		},
+	}
+
+	target := domain.ReviewTarget{
+		RepositoryRoot: fixture.repoRoot,
+		Revision: domain.RevisionEvidence{
+			HeadObjectID: fixture.prHeadSHA,
+			BaseObjectID: fixture.baseSHA,
+		},
+	}
+
+	run := fakeReviewRun(t, target)
+	run.Status = domain.ReviewStatusFailed
+	run.Conclusion = ""
+	run.Failure = &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: "all reviewers failed"}
+
+	err := runDeskDispatch(context.Background(), key, discovery, fakeDispatchService(run))
+	if err == nil {
+		t.Fatal("expected runDeskDispatch to return an error for a failed review run")
+	}
+
+	runs, corrupt, listErr := store.NewFilesystemRunStore(dataDir).ListRuns(key)
+	if listErr != nil {
+		t.Fatalf("ListRuns failed: %v", listErr)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("unexpected corrupt runs: %v", corrupt)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected the failed run to still be persisted for history, got %d", len(runs))
+	}
+	if runs[0].Status != string(domain.ReviewStatusFailed) {
+		t.Fatalf("persisted run status = %q, want %q", runs[0].Status, domain.ReviewStatusFailed)
+	}
+}
+
 func TestRunDeskDispatch_MarksResultStaleWhenHeadMovesAfterReview(t *testing.T) {
 	fixture := newDispatchGitFixture(t, 9)
 

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -1,0 +1,532 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/review"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func TestCheckDispatchEligible(t *testing.T) {
+	cases := []struct {
+		name    string
+		item    desk.Item
+		wantErr bool
+	}{
+		{"resolved", desk.Item{DeskState: domain.DeskStateResolved}, true},
+		{"repository unavailable", desk.Item{DeskState: domain.DeskStateRepositoryUnavailable}, true},
+		{"waiting on others", desk.Item{DeskState: domain.DeskStateWaitingOnOthers, Reason: "own pull request"}, true},
+		{"running", desk.Item{DeskState: domain.DeskStateRunning, RepositoryPath: "/repo"}, true},
+		{"queued", desk.Item{DeskState: domain.DeskStateQueued, RepositoryPath: "/repo"}, true},
+		{"needs review is eligible", desk.Item{DeskState: domain.DeskStateNeedsReview, RepositoryPath: "/repo"}, false},
+		{"findings ready is eligible", desk.Item{DeskState: domain.DeskStateFindingsReady, RepositoryPath: "/repo"}, false},
+		{"no local repository path", desk.Item{DeskState: domain.DeskStateNeedsReview, RepositoryPath: ""}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkDispatchEligible(tc.item)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("checkDispatchEligible() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFindDeskItem(t *testing.T) {
+	key := store.PullRequestKeyV1{Host: "fakehub.test", Owner: "acme", Repository: "widgets", Number: 7}
+	inbox := desk.Inbox{Items: []desk.Item{{Key: key, Title: "widgets PR"}}}
+
+	if _, ok := findDeskItem(inbox, key); !ok {
+		t.Fatal("expected to find the item by key")
+	}
+
+	other := key
+	other.Number = 8
+	if _, ok := findDeskItem(inbox, other); ok {
+		t.Fatal("expected not to find a non-matching key")
+	}
+}
+
+func TestRunDeskDispatch_RejectsUnknownPullRequest(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfig(t, configDir, "me", nil)
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	key := store.PullRequestKeyV1{Host: "fakehub.test", Owner: "acme", Repository: "widgets", Number: 7}
+	discovery := &dispatchFixtureDiscovery{}
+
+	err := runDeskDispatch(context.Background(), key, discovery, unusedDispatchService(t))
+	if err == nil {
+		t.Fatal("expected an error for a PR not in the current desk view")
+	}
+}
+
+type dispatchFixtureDiscovery struct {
+	searchResult    []domain.PullRequestKey
+	enrichResponses []domain.PullRequestSnapshot
+	enrichCalls     int
+}
+
+func (f *dispatchFixtureDiscovery) Search(ctx context.Context, query github.SearchQuery) ([]domain.PullRequestKey, error) {
+	if query.Kind != github.SearchKindReviewRequested {
+		return nil, nil
+	}
+	return f.searchResult, nil
+}
+
+func (f *dispatchFixtureDiscovery) Enrich(ctx context.Context, key domain.PullRequestKey) (domain.PullRequestSnapshot, error) {
+	if len(f.enrichResponses) == 0 {
+		return domain.PullRequestSnapshot{}, errors.New("no fixture enrich response configured")
+	}
+	idx := f.enrichCalls
+	if idx >= len(f.enrichResponses) {
+		idx = len(f.enrichResponses) - 1
+	}
+	f.enrichCalls++
+	return f.enrichResponses[idx], nil
+}
+
+func unusedDispatchService(t *testing.T) dispatchServiceFactory {
+	t.Helper()
+	return func(ReviewOpts, *terminal.Logger) (semanticReviewService, error) {
+		t.Fatal("review service should not have been invoked")
+		return nil, nil
+	}
+}
+
+func writeWorkspaceConfig(t *testing.T, configDir, expectedUser string, repositoryRoots []string) {
+	t.Helper()
+	rootsYAML := "[]"
+	if len(repositoryRoots) > 0 {
+		quoted := make([]string, len(repositoryRoots))
+		for i, root := range repositoryRoots {
+			quoted[i] = fmt.Sprintf("%q", root)
+		}
+		rootsYAML = "[" + joinStrings(quoted, ", ") + "]"
+	}
+	yamlContent := fmt.Sprintf(`schema_version: 1
+identity:
+  expected_user: %q
+scope:
+  organizations: []
+  teams: []
+  repository_roots: %s
+  include: []
+  exclude: []
+  path_overrides: {}
+behavior:
+  poll_interval: 1m
+  settle_time: 10m
+  concurrency: 0
+  auto_review: false
+  re_review: false
+  own_pr_policy: disabled
+posting:
+  enabled: false
+notifications:
+  enabled: false
+`, expectedUser, rootsYAML)
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, workspace.ConfigFileName), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func joinStrings(parts []string, sep string) string {
+	out := ""
+	for i, part := range parts {
+		if i > 0 {
+			out += sep
+		}
+		out += part
+	}
+	return out
+}
+
+type fakeGHResponses struct {
+	user        string
+	repoURL     string
+	repoSSHURL  string
+	baseRefName string
+}
+
+func withFakeGH(t *testing.T, responses fakeGHResponses) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1 $2" in
+  "api user")
+    echo %q
+    ;;
+  "repo view")
+    echo '{"url":%q,"sshUrl":%q}'
+    ;;
+  "pr view")
+    echo '{"baseRefName":%q}'
+    ;;
+  *)
+    echo "fake gh: unhandled invocation: $*" >&2
+    exit 1
+    ;;
+esac
+`, responses.user, responses.repoURL, responses.repoSSHURL, responses.baseRefName)
+
+	path := filepath.Join(binDir, "gh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+originalPath)
+}
+
+type dispatchGitFixture struct {
+	repoRoot  string
+	host      string
+	remoteURL string
+	baseSHA   string
+	prHeadSHA string
+	staleSHA  string
+}
+
+const gitDaemonPort = "9418"
+
+func newDispatchGitFixture(t *testing.T, prNumber int) dispatchGitFixture {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	bareDir := filepath.Join(baseDir, "acme", "widgets.git")
+	if err := os.MkdirAll(filepath.Dir(bareDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "", "init", "--bare", "-q", bareDir)
+	runGit(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	startGitDaemon(t, baseDir)
+
+	host := "127.0.0.1"
+	remoteURL := fmt.Sprintf("git://127.0.0.1:%s/acme/widgets.git", gitDaemonPort)
+
+	repoRoot := filepath.Join(t.TempDir(), "work")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoRoot, "init", "-q", "-b", "main")
+	runGit(t, repoRoot, "config", "user.email", "test@example.com")
+	runGit(t, repoRoot, "config", "user.name", "Test")
+	runGit(t, repoRoot, "remote", "add", "origin", remoteURL)
+
+	writeFile(t, filepath.Join(repoRoot, "README.md"), "hello\n")
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-q", "-m", "initial commit")
+	runGit(t, repoRoot, "push", "-q", bareDir, "main:refs/heads/main")
+	baseSHA := runGitOutput(t, repoRoot, "rev-parse", "HEAD")
+
+	runGit(t, repoRoot, "checkout", "-q", "-b", "pr-branch")
+	writeFile(t, filepath.Join(repoRoot, "README.md"), "hello\nchanged\n")
+	runGit(t, repoRoot, "commit", "-q", "-am", "pr change")
+	prHeadSHA := runGitOutput(t, repoRoot, "rev-parse", "HEAD")
+	runGit(t, repoRoot, "push", "-q", bareDir, fmt.Sprintf("pr-branch:refs/pull/%d/head", prNumber))
+
+	writeFile(t, filepath.Join(repoRoot, "README.md"), "hello\nchanged\nagain\n")
+	runGit(t, repoRoot, "commit", "-q", "-am", "post-review push")
+	staleSHA := runGitOutput(t, repoRoot, "rev-parse", "HEAD")
+	runGit(t, repoRoot, "push", "-q", "-f", bareDir, fmt.Sprintf("pr-branch:refs/pull/%d/head", prNumber))
+
+	runGit(t, repoRoot, "checkout", "-q", "main")
+
+	return dispatchGitFixture{
+		repoRoot:  repoRoot,
+		host:      host,
+		remoteURL: remoteURL,
+		baseSHA:   baseSHA,
+		prHeadSHA: prHeadSHA,
+		staleSHA:  staleSHA,
+	}
+}
+
+func startGitDaemon(t *testing.T, baseDir string) {
+	t.Helper()
+
+	var stderr bytes.Buffer
+	cmd := exec.Command("git", "daemon",
+		"--reuseaddr",
+		"--export-all",
+		"--base-path="+baseDir,
+		"--port="+gitDaemonPort,
+		"--listen=127.0.0.1",
+	)
+	cmd.Stderr = &stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start git daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.Dial("tcp", "127.0.0.1:"+gitDaemonPort)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		if strings.Contains(stderr.String(), "Address already in use") {
+			t.Skipf("port %s unavailable for git daemon: %s", gitDaemonPort, stderr.String())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("git daemon did not become ready: %s", stderr.String())
+	t.Fatal("git daemon did not become ready")
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd = exec.Command("git", append([]string{"-C", dir}, args...)...)
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v: %s", args, err, out)
+	}
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v failed: %v", args, err)
+	}
+	return trimNewline(string(out))
+}
+
+func trimNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func dispatchPullRequestKey(host string, prNumber int) store.PullRequestKeyV1 {
+	return store.PullRequestKeyV1{Host: host, Owner: "acme", Repository: "widgets", Number: prNumber}
+}
+
+func dispatchSnapshot(key store.PullRequestKeyV1, head, base string, now time.Time) domain.PullRequestSnapshot {
+	return domain.PullRequestSnapshot{
+		PullRequest:  key.ToDomain(),
+		URL:          fmt.Sprintf("https://%s/acme/widgets/pull/%d", key.Host, key.Number),
+		Title:        "widgets PR",
+		Author:       "someone-else",
+		State:        domain.PullRequestStateOpen,
+		HeadObjectID: head,
+		BaseObjectID: base,
+		UpdatedAt:    now.Add(-time.Hour),
+		CapturedAt:   now,
+	}
+}
+
+func fakeReviewRun(t *testing.T, target domain.ReviewTarget) *domain.ReviewRun {
+	t.Helper()
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"codex"},
+		SummarizerAgent:   "codex",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &domain.ReviewRun{
+		ID:                       "run-1",
+		Target:                   target,
+		Trigger:                  domain.ReviewTriggerDesk,
+		Engine:                   domain.ReviewEngine{Name: "acr", Version: "test"},
+		Configuration:            configuration,
+		ConfigurationFingerprint: configuration.Fingerprint(),
+		ConfigurationSource:      domain.ConfigurationSourceIdentity{Kind: "defaults", Locator: "test"},
+		StartedAt:                time.Now(),
+		CompletedAt:              time.Now(),
+		Status:                   domain.ReviewStatusCompleted,
+		Conclusion:               domain.ReviewConclusionClean,
+	}
+}
+
+func fakeDispatchService(run *domain.ReviewRun) dispatchServiceFactory {
+	return func(ReviewOpts, *terminal.Logger) (semanticReviewService, error) {
+		return fakeSemanticReviewService{run: run}, nil
+	}
+}
+
+type fakeSemanticReviewService struct {
+	run *domain.ReviewRun
+}
+
+func (s fakeSemanticReviewService) Run(ctx context.Context, request review.Request) (*domain.ReviewRun, error) {
+	run := *s.run
+	run.Target.RepositoryRoot = request.Target.RepositoryRoot
+	run.Target.WorktreeRoot = request.Target.WorktreeRoot
+	run.Target.PullRequest = request.Target.PullRequest
+	run.Target.Revision.RequestedBaseRef = request.Target.Revision.RequestedBaseRef
+	run.Target.Revision.ResolvedBaseRef = request.Target.Revision.ResolvedBaseRef
+	return &run, nil
+}
+
+func TestRunDeskDispatch_PersistsRunAndReportsDecisionReady(t *testing.T) {
+	fixture := newDispatchGitFixture(t, 7)
+
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfig(t, configDir, "me", []string{fixture.repoRoot})
+	withFakeGH(t, fakeGHResponses{
+		user:        "me",
+		repoURL:     fixture.remoteURL,
+		repoSSHURL:  fixture.remoteURL,
+		baseRefName: "main",
+	})
+
+	key := dispatchPullRequestKey(fixture.host, 7)
+	now := time.Now()
+	discovery := &dispatchFixtureDiscovery{
+		searchResult: []domain.PullRequestKey{key.ToDomain()},
+		enrichResponses: []domain.PullRequestSnapshot{
+			dispatchSnapshot(key, fixture.prHeadSHA, fixture.baseSHA, now),
+			dispatchSnapshot(key, fixture.prHeadSHA, fixture.baseSHA, now.Add(time.Minute)),
+		},
+	}
+
+	target := domain.ReviewTarget{
+		RepositoryRoot: fixture.repoRoot,
+		Revision: domain.RevisionEvidence{
+			HeadObjectID: fixture.prHeadSHA,
+			BaseObjectID: fixture.baseSHA,
+		},
+	}
+
+	err := runDeskDispatch(context.Background(), key, discovery, fakeDispatchService(fakeReviewRun(t, target)))
+	if err != nil {
+		t.Fatalf("runDeskDispatch failed: %v", err)
+	}
+
+	runs, corrupt, err := store.NewFilesystemRunStore(dataDir).ListRuns(key)
+	if err != nil {
+		t.Fatalf("ListRuns failed: %v", err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("unexpected corrupt runs: %v", corrupt)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected exactly one persisted run, got %d", len(runs))
+	}
+	if runs[0].Target.Revision.HeadObjectID != fixture.prHeadSHA {
+		t.Fatalf("persisted run head = %q, want %q", runs[0].Target.Revision.HeadObjectID, fixture.prHeadSHA)
+	}
+
+	cfg, err := workspace.Load(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := desk.LoadStored(dataDir, *cfg, time.Now())
+	if err != nil {
+		t.Fatalf("LoadStored failed: %v", err)
+	}
+	item, ok := findDeskItem(inbox, key)
+	if !ok {
+		t.Fatal("expected the dispatched PR to still be tracked")
+	}
+	if item.DeskState != domain.DeskStateDecisionReady {
+		t.Fatalf("desk state = %q, reason = %q, want decision_ready", item.DeskState, item.Reason)
+	}
+}
+
+func TestRunDeskDispatch_MarksResultStaleWhenHeadMovesAfterReview(t *testing.T) {
+	fixture := newDispatchGitFixture(t, 9)
+
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfig(t, configDir, "me", []string{fixture.repoRoot})
+	withFakeGH(t, fakeGHResponses{
+		user:        "me",
+		repoURL:     fixture.remoteURL,
+		repoSSHURL:  fixture.remoteURL,
+		baseRefName: "main",
+	})
+
+	key := dispatchPullRequestKey(fixture.host, 9)
+	now := time.Now()
+	discovery := &dispatchFixtureDiscovery{
+		searchResult: []domain.PullRequestKey{key.ToDomain()},
+		enrichResponses: []domain.PullRequestSnapshot{
+			dispatchSnapshot(key, fixture.prHeadSHA, fixture.baseSHA, now),
+			dispatchSnapshot(key, fixture.staleSHA, fixture.baseSHA, now.Add(time.Minute)),
+		},
+	}
+
+	target := domain.ReviewTarget{
+		RepositoryRoot: fixture.repoRoot,
+		Revision: domain.RevisionEvidence{
+			HeadObjectID: fixture.prHeadSHA,
+			BaseObjectID: fixture.baseSHA,
+		},
+	}
+
+	err := runDeskDispatch(context.Background(), key, discovery, fakeDispatchService(fakeReviewRun(t, target)))
+	if err != nil {
+		t.Fatalf("runDeskDispatch failed: %v", err)
+	}
+
+	cfg, err := workspace.Load(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := desk.LoadStored(dataDir, *cfg, time.Now())
+	if err != nil {
+		t.Fatalf("LoadStored failed: %v", err)
+	}
+	item, ok := findDeskItem(inbox, key)
+	if !ok {
+		t.Fatal("expected the dispatched PR to still be tracked")
+	}
+	if item.DeskState == domain.DeskStateDecisionReady || item.DeskState == domain.DeskStateFindingsReady {
+		t.Fatalf("desk state = %q, want the result to read as stale/needing re-review since the head moved after the review completed", item.DeskState)
+	}
+}

--- a/cmd/acr/review_typed.go
+++ b/cmd/acr/review_typed.go
@@ -46,7 +46,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	events := newCLIReviewEvents(opts, logger)
 	defer events.Close()
 
-	service, err := reviewpkg.NewService(reviewpkg.WithDiffProvider(func(ctx context.Context, target domain.ReviewTarget) (string, error) {
+	service, err := reviewpkg.NewService(reviewpkg.WithDiffProvider(newGitDiffProvider(opts, logger)))
+	if err != nil {
+		logger.Logf(terminal.StyleError, "Review failed: %v", err)
+		return nil, domain.ExitError
+	}
+
+	return executeTypedReview(ctx, opts, resolvedBaseRef, service, events, logger)
+}
+
+func newGitDiffProvider(opts ReviewOpts, logger *terminal.Logger) func(context.Context, domain.ReviewTarget) (string, error) {
+	return func(ctx context.Context, target domain.ReviewTarget) (string, error) {
 		diff, err := git.GetDiff(ctx, target.Revision.BaseObjectID, target.WorktreeRoot)
 		if err != nil {
 			return "", err
@@ -58,13 +68,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			}
 		}
 		return diff, nil
-	}))
-	if err != nil {
-		logger.Logf(terminal.StyleError, "Review failed: %v", err)
-		return nil, domain.ExitError
 	}
-
-	return executeTypedReview(ctx, opts, resolvedBaseRef, service, events, logger)
 }
 
 func logReviewStart(opts ReviewOpts, logger *terminal.Logger) {


### PR DESCRIPTION
## Summary

- Adds `acr desk dispatch <[host/]owner/repo#number>`, the first Phase 5 vertical slice from #205: select an eligible desk item, run its review headlessly in an isolated worktree, and persist the resulting run **without posting to GitHub**.
- Reuses existing machinery rather than duplicating it: `internal/review.Service` (typed review), `git.CreateWorktreeFromPR`/`ValidateWorktreeRepository`, the trusted-config resolution used by the plain `acr` command (extracted a cwd-independent `resolveTrustedReviewConfigSourceForRoot`), and `runner.RenderReviewRun`/`acr desk history` for rendering.
- No new persistence schema. Saving the `domain.ReviewRun` via the existing `FilesystemRunStore` is sufficient: `domain.Classify` already derives decision-ready/findings-ready state from stored runs, so a pending decision survives a restart for free.
- Staleness ("new commits make the result visibly stale") falls out of the same mechanism: dispatch re-refreshes the desk inbox after the run completes, so if the PR head moved during or after the review, the next classification naturally reports `stale`/`needs_rereview` instead of `decision_ready` — no new domain concept needed. A head move *during* the review is already caught by `reviewpkg.Service.Run` itself (fails the run), and the mismatched revision means the stale run simply doesn't match the current head on reclassification, so it reads as history, not an actionable result.

## Test plan

- [x] `make check` (build, lint, vet, staticcheck, full unit test suite)
- [x] CI-simulated: `HOME=$(mktemp -d) GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null make check`
- [x] New `cmd/acr/desk_dispatch_test.go`:
  - Eligibility unit tests (`checkDispatchEligible`, `findDeskItem`)
  - End-to-end integration test against a **real** temporary git repo served over the real git protocol (`git daemon`, via a fake `gh` binary shimmed onto `PATH` and an injected `github.Discovery` fake) with a fake review service returning a canned `domain.ReviewRun` — asserts the run is persisted and the desk state reports `decision_ready`
  - A second end-to-end test where the post-run discovery re-check reports a moved head — asserts the desk state reads `stale`/`needs_rereview`, not `decision_ready`

Closes #205.