### PR TITLE
feat: add acr desk act and lifecycle actions for guarded review posting

### DIFF
--- a/cmd/acr/desk.go
+++ b/cmd/acr/desk.go
@@ -35,6 +35,11 @@ func newDeskCmd() *cobra.Command {
 	cmd.AddCommand(newDeskForgetCmd())
 	cmd.AddCommand(newDeskConfigCmd())
 	cmd.AddCommand(newDeskDispatchCmd())
+	cmd.AddCommand(newDeskActCmd())
+	cmd.AddCommand(newDeskResolveCmd())
+	cmd.AddCommand(newDeskReleaseCmd())
+	cmd.AddCommand(newDeskResumeCmd())
+	cmd.AddCommand(newDeskSnoozeCmd())
 
 	return cmd
 }

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+type deskActAction int
+
+const (
+	deskActApprove deskActAction = iota
+	deskActComment
+	deskActRequestChanges
+)
+
+func newDeskActCmd() *cobra.Command {
+	var approve, comment, requestChanges, autoYes bool
+
+	cmd := &cobra.Command{
+		Use:   "act <[host/]owner/repo#number>",
+		Short: "Post a guarded review action for a decision-ready desk item",
+		Long: "Post a comment, request-changes, or approval review for a pull request with a decision-ready " +
+			"stored result. Identity, posting capability, repository availability, and the current PR head are " +
+			"revalidated immediately before any GitHub mutation, and self-authored pull requests can only receive " +
+			"a comment.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := desk.ParsePullRequestRef(args[0])
+			if err != nil {
+				return err
+			}
+			action, err := parseDeskActAction(approve, comment, requestChanges)
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				cancel()
+			}()
+
+			return runDeskAct(ctx, key, action, autoYes, github.NewDiscovery())
+		},
+	}
+
+	cmd.Flags().BoolVar(&approve, "approve", false, "Approve the pull request (only valid when the review found no issues)")
+	cmd.Flags().BoolVar(&comment, "comment", false, "Post a comment-only review")
+	cmd.Flags().BoolVar(&requestChanges, "request-changes", false, "Request changes (only valid when the review has findings)")
+	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "Skip the interactive confirmation prompt")
+
+	return cmd
+}
+
+func parseDeskActAction(approve, comment, requestChanges bool) (deskActAction, error) {
+	var action deskActAction
+	count := 0
+	if approve {
+		action = deskActApprove
+		count++
+	}
+	if comment {
+		action = deskActComment
+		count++
+	}
+	if requestChanges {
+		action = deskActRequestChanges
+		count++
+	}
+	if count != 1 {
+		return 0, errors.New("exactly one of --approve, --comment, or --request-changes is required")
+	}
+	return action, nil
+}
+
+func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActAction, autoYes bool, discovery github.Discovery) error {
+	if !terminal.IsStdoutTTY() {
+		terminal.DisableColors()
+	}
+
+	configDir, err := workspace.ConfigDir()
+	if err != nil {
+		return err
+	}
+	cfg, err := workspace.Load(configDir)
+	if err != nil {
+		return err
+	}
+	if errs := cfg.Validate(); len(errs) > 0 {
+		return fmt.Errorf("workspace configuration has %d error(s): %v", len(errs), errs)
+	}
+
+	if postingErr := cfg.RequirePosting(); postingErr != nil {
+		return postingErr
+	}
+
+	dataDir, err := store.DataDir()
+	if err != nil {
+		return err
+	}
+
+	lock, err := store.AcquireWriteLock(dataDir)
+	if err != nil {
+		if errors.Is(err, store.ErrWriterLocked) {
+			return fmt.Errorf("cannot act on %s: %w", key.String(), err)
+		}
+		return err
+	}
+	released := false
+	release := func() error {
+		if released {
+			return nil
+		}
+		released = true
+		return lock.Release()
+	}
+	defer func() { _ = release() }()
+
+	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
+	}
+
+	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+	if err != nil {
+		return err
+	}
+
+	item, ok := findDeskItem(inbox, key)
+	if !ok {
+		return fmt.Errorf("%s is not in the current desk view; run `acr desk --once` first", key.String())
+	}
+	if item.DeskState != domain.DeskStateFindingsReady && item.DeskState != domain.DeskStateDecisionReady {
+		return fmt.Errorf("%s has no decision-ready result (current state: %s); run `acr desk dispatch %s` first",
+			key.String(), item.DeskState, key.String())
+	}
+
+	run, err := loadCurrentRun(dataDir, item)
+	if err != nil {
+		return err
+	}
+	if run == nil {
+		return fmt.Errorf("%s: no stored review run matches the current head", key.String())
+	}
+	if actionErr := validateActionForConclusion(action, run.Conclusion); actionErr != nil {
+		return actionErr
+	}
+
+	prNumber := strconv.Itoa(item.Key.Number)
+	logger := terminal.NewLogger()
+	outcome := &CycleOutcome{}
+	opts := ReviewOpts{
+		RepositoryRoot:   item.RepositoryPath,
+		PRNumber:         prNumber,
+		AutoYes:          autoYes,
+		ForcePostComment: action == deskActComment,
+		ExpectedHeadSHA:  run.Target.Revision.HeadObjectID,
+		Outcome:          outcome,
+	}
+
+	handleTypedReviewRun(ctx, opts, run, logger)
+
+	var recordErr error
+	switch outcome.Kind {
+	case OutcomeLGTMApproved:
+		recordErr = appendActionEvent(dataDir, key, store.EventTypeActionApprovalPosted, run, cfg.Identity.ExpectedUser)
+	case OutcomeLGTMComment, OutcomeReviewComment:
+		recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, cfg.Identity.ExpectedUser)
+	case OutcomeReviewRequestChanges:
+		recordErr = appendActionEvent(dataDir, key, store.EventTypeActionRequestChangesPosted, run, cfg.Identity.ExpectedUser)
+	case OutcomeStaleHead:
+		recordErr = recordStaleResult(ctx, dataDir, key, run, discovery)
+	}
+
+	refreshed, refreshErr := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+
+	if releaseErr := release(); releaseErr != nil {
+		return releaseErr
+	}
+
+	if recordErr != nil {
+		return fmt.Errorf("action completed but could not be recorded: %w", recordErr)
+	}
+
+	if refreshErr == nil {
+		if resultItem, found := findDeskItem(refreshed, key); found {
+			fmt.Printf("\nDesk state: %s — %s\n", resultItem.DeskState, resultItem.Reason)
+		}
+	}
+
+	switch outcome.Kind {
+	case OutcomeStaleHead:
+		return errors.New("the pull request head moved since this review; nothing was posted")
+	case OutcomeReviewSkipped, OutcomeLGTMDeclined, OutcomeLGTMSkipped:
+		return errors.New("action was not posted")
+	}
+	return nil
+}
+
+func validateActionForConclusion(action deskActAction, conclusion domain.ReviewConclusion) error {
+	switch action {
+	case deskActApprove:
+		if conclusion == domain.ReviewConclusionFindings {
+			return errors.New("cannot approve while the review has unresolved findings; use --comment or --request-changes instead")
+		}
+	case deskActRequestChanges:
+		if conclusion != domain.ReviewConclusionFindings {
+			return errors.New("--request-changes requires a review with findings; use --approve or --comment instead")
+		}
+	}
+	return nil
+}
+
+func loadCurrentRun(dataDir string, item desk.Item) (*domain.ReviewRun, error) {
+	schemas, _, err := store.NewFilesystemRunStore(dataDir).ListRuns(item.Key)
+	if err != nil {
+		return nil, err
+	}
+	var latest *domain.ReviewRun
+	for _, schema := range schemas {
+		if schema.Target.Revision.HeadObjectID != item.HeadObjectID || schema.Target.Revision.BaseObjectID != item.BaseObjectID {
+			continue
+		}
+		run, _, convErr := store.FromReviewRunSchema(schema)
+		if convErr != nil {
+			continue
+		}
+		if latest == nil || runResultTimestamp(run).After(runResultTimestamp(*latest)) {
+			candidate := run
+			latest = &candidate
+		}
+	}
+	return latest, nil
+}
+
+func runResultTimestamp(run domain.ReviewRun) time.Time {
+	if !run.CompletedAt.IsZero() {
+		return run.CompletedAt
+	}
+	return run.StartedAt
+}
+
+func appendActionEvent(dataDir string, key store.PullRequestKeyV1, eventType store.ReviewEventTypeV1, run *domain.ReviewRun, actor string) error {
+	now := time.Now()
+	id, err := newDeskEventID(now)
+	if err != nil {
+		return err
+	}
+	event := store.ReviewEventV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            id,
+		PullRequest:   key,
+		Type:          eventType,
+		OccurredAt:    now,
+		RunID:         run.ID,
+		HeadObjectID:  run.Target.Revision.HeadObjectID,
+		BaseObjectID:  run.Target.Revision.BaseObjectID,
+		Actor:         actor,
+	}
+	_, err = store.NewFilesystemEventStore(dataDir).AppendEvent(event)
+	return err
+}
+
+func recordStaleResult(ctx context.Context, dataDir string, key store.PullRequestKeyV1, run *domain.ReviewRun, discovery github.Discovery) error {
+	snapshot, err := discovery.Enrich(ctx, key.ToDomain())
+	if err != nil {
+		return fmt.Errorf("re-check current PR head: %w", err)
+	}
+	now := time.Now()
+	id, err := newDeskEventID(now)
+	if err != nil {
+		return err
+	}
+	event := store.ReviewEventV1{
+		SchemaVersion:     store.CurrentSchemaVersion,
+		ID:                id,
+		PullRequest:       key,
+		Type:              store.EventTypeReviewStale,
+		OccurredAt:        now,
+		RunID:             run.ID,
+		HeadObjectID:      snapshot.HeadObjectID,
+		PriorHeadObjectID: run.Target.Revision.HeadObjectID,
+	}
+	_, err = store.NewFilesystemEventStore(dataDir).AppendEvent(event)
+	return err
+}
+
+func newDeskEventID(now time.Time) (string, error) {
+	var random [8]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", err
+	}
+	return now.UTC().Format("20060102T150405.000000000Z") + "-" + hex.EncodeToString(random[:]), nil
+}

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -136,10 +136,6 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	}
 	defer func() { _ = release() }()
 
-	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
-		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
-	}
-
 	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
 	if err != nil {
 		return err
@@ -152,6 +148,9 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if item.DeskState != domain.DeskStateFindingsReady && item.DeskState != domain.DeskStateDecisionReady {
 		return fmt.Errorf("%s has no decision-ready result (current state: %s); run `acr desk dispatch %s` first",
 			key.String(), item.DeskState, key.String())
+	}
+	if identityErr := workspace.CheckIdentity(ctx, *cfg, item.RepositoryPath); identityErr != nil {
+		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
 	}
 	if _, corruptEvents, eventsErr := store.NewFilesystemEventStore(dataDir).ListEvents(key); eventsErr != nil {
 		return eventsErr
@@ -207,7 +206,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if postingErr := freshCfg.RequirePosting(); postingErr != nil {
 		return fmt.Errorf("posting was disabled before this action could be posted: %w", postingErr)
 	}
-	if identityErr := workspace.CheckIdentity(ctx, *freshCfg); identityErr != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *freshCfg, item.RepositoryPath); identityErr != nil {
 		return fmt.Errorf("GitHub identity could not be verified before posting: %w", identityErr)
 	}
 
@@ -432,14 +431,14 @@ func revalidateDeskEligibility(ctx context.Context, configDir, dataDir string, k
 	if err := cfg.RequirePosting(); err != nil {
 		return "", err
 	}
-	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
-		return "", err
-	}
 	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
 	if err != nil {
 		return "", fmt.Errorf("could not re-check desk eligibility: %w", err)
 	}
 	item, ok := findDeskItem(inbox, key)
+	if err := workspace.CheckIdentity(ctx, *cfg, item.RepositoryPath); err != nil {
+		return "", err
+	}
 	if ok && (item.DeskState == domain.DeskStateStale || item.DeskState == domain.DeskStateNeedsRereview) {
 		return "", errRevisionMovedSinceReview
 	}

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -171,7 +171,9 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	prNumber := strconv.Itoa(item.Key.Number)
 	logger := terminal.NewLogger()
 
-	if !autoYes && !confirmDeskAction(action, prNumber) {
+	isSelfReview := github.IsSelfReview(ctx, item.RepositoryPath, prNumber)
+
+	if !autoYes && !confirmDeskAction(action, prNumber, isSelfReview) {
 		return errors.New("action was not confirmed; nothing was posted")
 	}
 
@@ -180,7 +182,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		return fmt.Errorf("could not verify the current pull request head before posting: %w", enrichErr)
 	}
 	if liveSnapshot.HeadObjectID != run.Target.Revision.HeadObjectID || liveSnapshot.BaseObjectID != run.Target.Revision.BaseObjectID {
-		if staleErr := appendStaleEvent(dataDir, key, run, liveSnapshot.HeadObjectID); staleErr != nil {
+		if staleErr := appendStaleEvent(dataDir, key, run, liveSnapshot.HeadObjectID, liveSnapshot.BaseObjectID); staleErr != nil {
 			return fmt.Errorf("the pull request revision moved since this review, and the stale result could not be recorded: %w", staleErr)
 		}
 		return errors.New("the pull request's head or base moved since this review; nothing was posted")
@@ -210,6 +212,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		ForcePostComment:              action == deskActComment,
 		ExpectedHeadSHA:               run.Target.Revision.HeadObjectID,
 		ExpectedBaseSHA:               run.Target.Revision.BaseObjectID,
+		PreSubmitCheck:                func() error { return revalidatePostingPolicyAndIdentity(ctx, configDir) },
 		Outcome:                       outcome,
 	}
 
@@ -269,16 +272,20 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	return nil
 }
 
-func confirmDeskAction(action deskActAction, prNumber string) bool {
+func confirmDeskAction(action deskActAction, prNumber string, isSelfReview bool) bool {
 	if !terminal.IsStdinTTY() {
 		return false
 	}
 	label := "post a comment on"
-	switch action {
-	case deskActApprove:
-		label = "approve"
-	case deskActRequestChanges:
-		label = "request changes on"
+	if !isSelfReview {
+		switch action {
+		case deskActApprove:
+			label = "approve"
+		case deskActRequestChanges:
+			label = "request changes on"
+		}
+	} else if action != deskActComment {
+		label = "post a comment on (self-authored PRs cannot be approved or receive request-changes)"
 	}
 	fmt.Print(formatPrompt(fmt.Sprintf("About to %s PR %s", label, formatPRRef(prNumber)), "[y/N]:"))
 	response := readUserInput()
@@ -358,10 +365,10 @@ func recordStaleResult(ctx context.Context, dataDir string, key store.PullReques
 	if err != nil {
 		return fmt.Errorf("re-check current PR head: %w", err)
 	}
-	return appendStaleEvent(dataDir, key, run, snapshot.HeadObjectID)
+	return appendStaleEvent(dataDir, key, run, snapshot.HeadObjectID, snapshot.BaseObjectID)
 }
 
-func appendStaleEvent(dataDir string, key store.PullRequestKeyV1, run *domain.ReviewRun, currentHeadObjectID string) error {
+func appendStaleEvent(dataDir string, key store.PullRequestKeyV1, run *domain.ReviewRun, currentHeadObjectID, currentBaseObjectID string) error {
 	now := time.Now()
 	id, err := newDeskEventID(now)
 	if err != nil {
@@ -375,10 +382,28 @@ func appendStaleEvent(dataDir string, key store.PullRequestKeyV1, run *domain.Re
 		OccurredAt:        now,
 		RunID:             run.ID,
 		HeadObjectID:      currentHeadObjectID,
+		BaseObjectID:      currentBaseObjectID,
 		PriorHeadObjectID: run.Target.Revision.HeadObjectID,
 	}
 	_, err = store.NewFilesystemEventStore(dataDir).AppendEvent(event)
 	return err
+}
+
+func revalidatePostingPolicyAndIdentity(ctx context.Context, configDir string) error {
+	cfg, err := workspace.Load(configDir)
+	if err != nil {
+		return fmt.Errorf("could not reload workspace configuration: %w", err)
+	}
+	if errs := cfg.Validate(); len(errs) > 0 {
+		return fmt.Errorf("workspace configuration has %d error(s): %v", len(errs), errs)
+	}
+	if err := cfg.RequirePosting(); err != nil {
+		return err
+	}
+	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
+		return err
+	}
+	return nil
 }
 
 func newDeskEventID(now time.Time) (string, error) {

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -202,13 +202,15 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 
 	outcome := &CycleOutcome{}
 	opts := ReviewOpts{
-		RepositoryRoot:       item.RepositoryPath,
-		PRNumber:             prNumber,
-		AutoYes:              autoYes,
-		SkipReviewTypePrompt: true,
-		ForcePostComment:     action == deskActComment,
-		ExpectedHeadSHA:      run.Target.Revision.HeadObjectID,
-		Outcome:              outcome,
+		RepositoryRoot:                item.RepositoryPath,
+		PRNumber:                      prNumber,
+		AutoYes:                       autoYes,
+		SkipReviewTypePrompt:          true,
+		SuppressZeroSelectionFallback: action == deskActRequestChanges,
+		ForcePostComment:              action == deskActComment,
+		ExpectedHeadSHA:               run.Target.Revision.HeadObjectID,
+		ExpectedBaseSHA:               run.Target.Revision.BaseObjectID,
+		Outcome:                       outcome,
 	}
 
 	code := handleTypedReviewRun(ctx, opts, run, logger)

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -179,25 +179,36 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if enrichErr != nil || liveSnapshot.HeadObjectID == "" {
 		return fmt.Errorf("could not verify the current pull request head before posting: %w", enrichErr)
 	}
-	if liveSnapshot.HeadObjectID != run.Target.Revision.HeadObjectID {
+	if liveSnapshot.HeadObjectID != run.Target.Revision.HeadObjectID || liveSnapshot.BaseObjectID != run.Target.Revision.BaseObjectID {
 		if staleErr := appendStaleEvent(dataDir, key, run, liveSnapshot.HeadObjectID); staleErr != nil {
-			return fmt.Errorf("the pull request head moved since this review, and the stale result could not be recorded: %w", staleErr)
+			return fmt.Errorf("the pull request revision moved since this review, and the stale result could not be recorded: %w", staleErr)
 		}
-		return errors.New("the pull request head moved since this review; nothing was posted")
+		return errors.New("the pull request's head or base moved since this review; nothing was posted")
 	}
 
-	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+	freshCfg, freshErr := workspace.Load(configDir)
+	if freshErr != nil {
+		return fmt.Errorf("could not reload workspace configuration before posting: %w", freshErr)
+	}
+	if errs := freshCfg.Validate(); len(errs) > 0 {
+		return fmt.Errorf("workspace configuration has %d error(s): %v", len(errs), errs)
+	}
+	if postingErr := freshCfg.RequirePosting(); postingErr != nil {
+		return fmt.Errorf("posting was disabled before this action could be posted: %w", postingErr)
+	}
+	if identityErr := workspace.CheckIdentity(ctx, *freshCfg); identityErr != nil {
 		return fmt.Errorf("GitHub identity could not be verified before posting: %w", identityErr)
 	}
 
 	outcome := &CycleOutcome{}
 	opts := ReviewOpts{
-		RepositoryRoot:   item.RepositoryPath,
-		PRNumber:         prNumber,
-		AutoYes:          true,
-		ForcePostComment: action == deskActComment,
-		ExpectedHeadSHA:  run.Target.Revision.HeadObjectID,
-		Outcome:          outcome,
+		RepositoryRoot:       item.RepositoryPath,
+		PRNumber:             prNumber,
+		AutoYes:              autoYes,
+		SkipReviewTypePrompt: true,
+		ForcePostComment:     action == deskActComment,
+		ExpectedHeadSHA:      run.Target.Revision.HeadObjectID,
+		Outcome:              outcome,
 	}
 
 	code := handleTypedReviewRun(ctx, opts, run, logger)
@@ -210,17 +221,17 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	} else {
 		switch outcome.Kind {
 		case OutcomeLGTMApproved:
-			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionApprovalPosted, run, cfg.Identity.ExpectedUser)
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionApprovalPosted, run, freshCfg.Identity.ExpectedUser)
 		case OutcomeLGTMComment:
 			if outcome.CIDowngraded {
 				deferredForCI = true
 			} else {
-				recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, cfg.Identity.ExpectedUser)
+				recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, freshCfg.Identity.ExpectedUser)
 			}
 		case OutcomeReviewComment:
-			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, cfg.Identity.ExpectedUser)
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, freshCfg.Identity.ExpectedUser)
 		case OutcomeReviewRequestChanges:
-			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionRequestChangesPosted, run, cfg.Identity.ExpectedUser)
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionRequestChangesPosted, run, freshCfg.Identity.ExpectedUser)
 		case OutcomeStaleHead:
 			if staleErr := recordStaleResult(ctx, dataDir, key, run, discovery); staleErr != nil {
 				actionErrResult = fmt.Errorf("the pull request head moved since this review, and the stale result could not be recorded: %w", staleErr)
@@ -232,7 +243,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		}
 	}
 
-	refreshed, refreshErr := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+	refreshed, refreshErr := desk.Refresh(ctx, *freshCfg, dataDir, discovery, time.Now())
 
 	if releaseErr := release(); releaseErr != nil {
 		return releaseErr
@@ -287,9 +298,13 @@ func validateActionForConclusion(action deskActAction, conclusion domain.ReviewC
 }
 
 func loadCurrentRun(dataDir string, item desk.Item) (*domain.ReviewRun, error) {
-	schemas, _, err := store.NewFilesystemRunStore(dataDir).ListRuns(item.Key)
+	schemas, corrupt, err := store.NewFilesystemRunStore(dataDir).ListRuns(item.Key)
 	if err != nil {
 		return nil, err
+	}
+	if len(corrupt) > 0 {
+		return nil, fmt.Errorf("%d stored review run(s) could not be read; run `acr desk history %s` to investigate before acting",
+			len(corrupt), item.Key.String())
 	}
 	var latest *domain.ReviewRun
 	for _, schema := range schemas {

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -208,6 +208,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		return fmt.Errorf("GitHub identity could not be verified before posting: %w", identityErr)
 	}
 
+	verifiedActor := freshCfg.Identity.ExpectedUser
 	outcome := &CycleOutcome{}
 	opts := ReviewOpts{
 		RepositoryRoot:                item.RepositoryPath,
@@ -218,16 +219,19 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		ForcePostComment:              action == deskActComment || isSelfReview,
 		ExpectedHeadSHA:               run.Target.Revision.HeadObjectID,
 		ExpectedBaseSHA:               run.Target.Revision.BaseObjectID,
-		PreSubmitCheck:                func() error { return revalidateDeskEligibility(ctx, configDir, dataDir, key, discovery) },
-		Outcome:                       outcome,
+		PreSubmitCheck: func() error {
+			actor, checkErr := revalidateDeskEligibility(ctx, configDir, dataDir, key, discovery)
+			if checkErr == nil {
+				verifiedActor = actor
+			}
+			return checkErr
+		},
+		Outcome: outcome,
 	}
 
 	code := handleTypedReviewRun(ctx, opts, run, logger)
 
-	actor := freshCfg.Identity.ExpectedUser
-	if finalCfg, finalErr := workspace.Load(configDir); finalErr == nil {
-		actor = finalCfg.Identity.ExpectedUser
-	}
+	actor := verifiedActor
 
 	var recordErr error
 	var deferredForCI bool
@@ -411,29 +415,32 @@ func appendStaleEvent(dataDir string, key store.PullRequestKeyV1, run *domain.Re
 	return err
 }
 
-func revalidateDeskEligibility(ctx context.Context, configDir, dataDir string, key store.PullRequestKeyV1, discovery github.Discovery) error {
+func revalidateDeskEligibility(ctx context.Context, configDir, dataDir string, key store.PullRequestKeyV1, discovery github.Discovery) (string, error) {
 	cfg, err := workspace.Load(configDir)
 	if err != nil {
-		return fmt.Errorf("could not reload workspace configuration: %w", err)
+		return "", fmt.Errorf("could not reload workspace configuration: %w", err)
 	}
 	if errs := cfg.Validate(); len(errs) > 0 {
-		return fmt.Errorf("workspace configuration has %d error(s): %v", len(errs), errs)
+		return "", fmt.Errorf("workspace configuration has %d error(s): %v", len(errs), errs)
 	}
 	if err := cfg.RequirePosting(); err != nil {
-		return err
+		return "", err
 	}
 	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
-		return err
+		return "", err
 	}
 	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
 	if err != nil {
-		return fmt.Errorf("could not re-check desk eligibility: %w", err)
+		return "", fmt.Errorf("could not re-check desk eligibility: %w", err)
 	}
 	item, ok := findDeskItem(inbox, key)
-	if !ok || (item.DeskState != domain.DeskStateFindingsReady && item.DeskState != domain.DeskStateDecisionReady) {
-		return fmt.Errorf("%s is no longer eligible for this action under the current workspace configuration", key.String())
+	if ok && (item.DeskState == domain.DeskStateStale || item.DeskState == domain.DeskStateNeedsRereview) {
+		return "", errRevisionMovedSinceReview
 	}
-	return nil
+	if !ok || (item.DeskState != domain.DeskStateFindingsReady && item.DeskState != domain.DeskStateDecisionReady) {
+		return "", fmt.Errorf("%s is no longer eligible for this action under the current workspace configuration", key.String())
+	}
+	return cfg.Identity.ExpectedUser, nil
 }
 
 func newDeskEventID(now time.Time) (string, error) {

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -224,6 +224,11 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 
 	code := handleTypedReviewRun(ctx, opts, run, logger)
 
+	actor := freshCfg.Identity.ExpectedUser
+	if finalCfg, finalErr := workspace.Load(configDir); finalErr == nil {
+		actor = finalCfg.Identity.ExpectedUser
+	}
+
 	var recordErr error
 	var deferredForCI bool
 	var actionErrResult error
@@ -232,22 +237,26 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	} else {
 		switch outcome.Kind {
 		case OutcomeLGTMApproved:
-			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionApprovalPosted, run, freshCfg.Identity.ExpectedUser)
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionApprovalPosted, run, actor)
 		case OutcomeLGTMComment:
 			if outcome.CIDowngraded {
 				deferredForCI = true
 			} else {
-				recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, freshCfg.Identity.ExpectedUser)
+				recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, actor)
 			}
 		case OutcomeReviewComment:
-			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, freshCfg.Identity.ExpectedUser)
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, actor)
 		case OutcomeReviewRequestChanges:
-			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionRequestChangesPosted, run, freshCfg.Identity.ExpectedUser)
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionRequestChangesPosted, run, actor)
 		case OutcomeStaleHead:
-			if staleErr := recordStaleResult(ctx, dataDir, key, run, discovery); staleErr != nil {
-				actionErrResult = fmt.Errorf("the pull request head moved since this review, and the stale result could not be recorded: %w", staleErr)
-			} else {
-				actionErrResult = errors.New("the pull request head moved since this review; nothing was posted")
+			moved, staleErr := recordStaleResult(ctx, dataDir, key, run, discovery)
+			switch {
+			case staleErr != nil:
+				actionErrResult = fmt.Errorf("could not verify whether the pull request revision moved: %w", staleErr)
+			case moved:
+				actionErrResult = errors.New("the pull request head or base moved since this review; nothing was posted")
+			default:
+				actionErrResult = errors.New("the revision check could not be completed reliably while posting, but a follow-up check found the pull request unchanged; nothing was posted — please retry")
 			}
 		default:
 			actionErrResult = fmt.Errorf("action was not posted (outcome: %d)", outcome.Kind)
@@ -273,7 +282,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		}
 	}
 	if deferredForCI {
-		fmt.Println("CI is not green; posted a comment instead of approving. The item remains actionable — run `acr desk act --approve` again once CI passes.")
+		fmt.Printf("CI is not green; posted a comment instead of approving. The item remains actionable — run `acr desk act %s --approve` again once CI passes.\n", key.String())
 	}
 	return nil
 }
@@ -366,12 +375,19 @@ func appendActionEvent(dataDir string, key store.PullRequestKeyV1, eventType sto
 	return err
 }
 
-func recordStaleResult(ctx context.Context, dataDir string, key store.PullRequestKeyV1, run *domain.ReviewRun, discovery github.Discovery) error {
+func recordStaleResult(ctx context.Context, dataDir string, key store.PullRequestKeyV1, run *domain.ReviewRun, discovery github.Discovery) (bool, error) {
 	snapshot, err := discovery.Enrich(ctx, key.ToDomain())
 	if err != nil {
-		return fmt.Errorf("re-check current PR head: %w", err)
+		return false, fmt.Errorf("re-check current PR head: %w", err)
 	}
-	return appendStaleEvent(dataDir, key, run, snapshot.HeadObjectID, snapshot.BaseObjectID)
+	moved := snapshot.HeadObjectID != run.Target.Revision.HeadObjectID || snapshot.BaseObjectID != run.Target.Revision.BaseObjectID
+	if !moved {
+		return false, nil
+	}
+	if appendErr := appendStaleEvent(dataDir, key, run, snapshot.HeadObjectID, snapshot.BaseObjectID); appendErr != nil {
+		return true, appendErr
+	}
+	return true, nil
 }
 
 func appendStaleEvent(dataDir string, key store.PullRequestKeyV1, run *domain.ReviewRun, currentHeadObjectID, currentBaseObjectID string) error {

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -136,6 +136,10 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	}
 	defer func() { _ = release() }()
 
+	if identityErr := workspace.CheckIdentity(ctx, *cfg, key.Host); identityErr != nil {
+		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
+	}
+
 	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
 	if err != nil {
 		return err
@@ -148,9 +152,6 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if item.DeskState != domain.DeskStateFindingsReady && item.DeskState != domain.DeskStateDecisionReady {
 		return fmt.Errorf("%s has no decision-ready result (current state: %s); run `acr desk dispatch %s` first",
 			key.String(), item.DeskState, key.String())
-	}
-	if identityErr := workspace.CheckIdentity(ctx, *cfg, item.RepositoryPath); identityErr != nil {
-		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
 	}
 	if _, corruptEvents, eventsErr := store.NewFilesystemEventStore(dataDir).ListEvents(key); eventsErr != nil {
 		return eventsErr
@@ -176,7 +177,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	prNumber := strconv.Itoa(item.Key.Number)
 	logger := terminal.NewLogger()
 
-	isSelfReview := github.IsSelfReview(ctx, item.RepositoryPath, prNumber)
+	isSelfReview := item.OwnPR
 
 	if !autoYes && !confirmDeskAction(action, prNumber, isSelfReview) {
 		return errors.New("action was not confirmed; nothing was posted")
@@ -206,7 +207,7 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if postingErr := freshCfg.RequirePosting(); postingErr != nil {
 		return fmt.Errorf("posting was disabled before this action could be posted: %w", postingErr)
 	}
-	if identityErr := workspace.CheckIdentity(ctx, *freshCfg, item.RepositoryPath); identityErr != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *freshCfg, key.Host); identityErr != nil {
 		return fmt.Errorf("GitHub identity could not be verified before posting: %w", identityErr)
 	}
 
@@ -431,14 +432,14 @@ func revalidateDeskEligibility(ctx context.Context, configDir, dataDir string, k
 	if err := cfg.RequirePosting(); err != nil {
 		return "", err
 	}
+	if err := workspace.CheckIdentity(ctx, *cfg, key.Host); err != nil {
+		return "", err
+	}
 	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
 	if err != nil {
 		return "", fmt.Errorf("could not re-check desk eligibility: %w", err)
 	}
 	item, ok := findDeskItem(inbox, key)
-	if err := workspace.CheckIdentity(ctx, *cfg, item.RepositoryPath); err != nil {
-		return "", err
-	}
 	if ok && (item.DeskState == domain.DeskStateStale || item.DeskState == domain.DeskStateNeedsRereview) {
 		return "", errRevisionMovedSinceReview
 	}

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -229,7 +229,8 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 			}
 			return checkErr
 		},
-		Outcome: outcome,
+		Outcome:         outcome,
+		KnownSelfReview: &isSelfReview,
 	}
 
 	code := handleTypedReviewRun(ctx, opts, run, logger)

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -153,6 +153,12 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		return fmt.Errorf("%s has no decision-ready result (current state: %s); run `acr desk dispatch %s` first",
 			key.String(), item.DeskState, key.String())
 	}
+	if _, corruptEvents, eventsErr := store.NewFilesystemEventStore(dataDir).ListEvents(key); eventsErr != nil {
+		return eventsErr
+	} else if len(corruptEvents) > 0 {
+		return fmt.Errorf("%d stored event(s) could not be read; run `acr desk history %s` to investigate before acting",
+			len(corruptEvents), key.String())
+	}
 
 	run, err := loadCurrentRun(dataDir, item)
 	if err != nil {
@@ -209,10 +215,10 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 		AutoYes:                       autoYes,
 		SkipReviewTypePrompt:          true,
 		SuppressZeroSelectionFallback: action == deskActRequestChanges,
-		ForcePostComment:              action == deskActComment,
+		ForcePostComment:              action == deskActComment || isSelfReview,
 		ExpectedHeadSHA:               run.Target.Revision.HeadObjectID,
 		ExpectedBaseSHA:               run.Target.Revision.BaseObjectID,
-		PreSubmitCheck:                func() error { return revalidatePostingPolicyAndIdentity(ctx, configDir) },
+		PreSubmitCheck:                func() error { return revalidateDeskEligibility(ctx, configDir, dataDir, key, discovery) },
 		Outcome:                       outcome,
 	}
 
@@ -389,7 +395,7 @@ func appendStaleEvent(dataDir string, key store.PullRequestKeyV1, run *domain.Re
 	return err
 }
 
-func revalidatePostingPolicyAndIdentity(ctx context.Context, configDir string) error {
+func revalidateDeskEligibility(ctx context.Context, configDir, dataDir string, key store.PullRequestKeyV1, discovery github.Discovery) error {
 	cfg, err := workspace.Load(configDir)
 	if err != nil {
 		return fmt.Errorf("could not reload workspace configuration: %w", err)
@@ -402,6 +408,14 @@ func revalidatePostingPolicyAndIdentity(ctx context.Context, configDir string) e
 	}
 	if err := workspace.CheckIdentity(ctx, *cfg); err != nil {
 		return err
+	}
+	inbox, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+	if err != nil {
+		return fmt.Errorf("could not re-check desk eligibility: %w", err)
+	}
+	item, ok := findDeskItem(inbox, key)
+	if !ok || (item.DeskState != domain.DeskStateFindingsReady && item.DeskState != domain.DeskStateDecisionReady) {
+		return fmt.Errorf("%s is no longer eligible for this action under the current workspace configuration", key.String())
 	}
 	return nil
 }

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -161,34 +161,75 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if run == nil {
 		return fmt.Errorf("%s: no stored review run matches the current head", key.String())
 	}
+	if run.Conclusion == domain.ReviewConclusionNoChanges {
+		return fmt.Errorf("%s: the stored review found no changes to act on", key.String())
+	}
 	if actionErr := validateActionForConclusion(action, run.Conclusion); actionErr != nil {
 		return actionErr
 	}
 
 	prNumber := strconv.Itoa(item.Key.Number)
 	logger := terminal.NewLogger()
+
+	if !autoYes && !confirmDeskAction(action, prNumber) {
+		return errors.New("action was not confirmed; nothing was posted")
+	}
+
+	liveSnapshot, enrichErr := discovery.Enrich(ctx, key.ToDomain())
+	if enrichErr != nil || liveSnapshot.HeadObjectID == "" {
+		return fmt.Errorf("could not verify the current pull request head before posting: %w", enrichErr)
+	}
+	if liveSnapshot.HeadObjectID != run.Target.Revision.HeadObjectID {
+		if staleErr := appendStaleEvent(dataDir, key, run, liveSnapshot.HeadObjectID); staleErr != nil {
+			return fmt.Errorf("the pull request head moved since this review, and the stale result could not be recorded: %w", staleErr)
+		}
+		return errors.New("the pull request head moved since this review; nothing was posted")
+	}
+
+	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+		return fmt.Errorf("GitHub identity could not be verified before posting: %w", identityErr)
+	}
+
 	outcome := &CycleOutcome{}
 	opts := ReviewOpts{
 		RepositoryRoot:   item.RepositoryPath,
 		PRNumber:         prNumber,
-		AutoYes:          autoYes,
+		AutoYes:          true,
 		ForcePostComment: action == deskActComment,
 		ExpectedHeadSHA:  run.Target.Revision.HeadObjectID,
 		Outcome:          outcome,
 	}
 
-	handleTypedReviewRun(ctx, opts, run, logger)
+	code := handleTypedReviewRun(ctx, opts, run, logger)
 
 	var recordErr error
-	switch outcome.Kind {
-	case OutcomeLGTMApproved:
-		recordErr = appendActionEvent(dataDir, key, store.EventTypeActionApprovalPosted, run, cfg.Identity.ExpectedUser)
-	case OutcomeLGTMComment, OutcomeReviewComment:
-		recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, cfg.Identity.ExpectedUser)
-	case OutcomeReviewRequestChanges:
-		recordErr = appendActionEvent(dataDir, key, store.EventTypeActionRequestChangesPosted, run, cfg.Identity.ExpectedUser)
-	case OutcomeStaleHead:
-		recordErr = recordStaleResult(ctx, dataDir, key, run, discovery)
+	var deferredForCI bool
+	var actionErrResult error
+	if code == domain.ExitError || code == domain.ExitInterrupted {
+		actionErrResult = errors.New("posting failed; see the log above for details")
+	} else {
+		switch outcome.Kind {
+		case OutcomeLGTMApproved:
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionApprovalPosted, run, cfg.Identity.ExpectedUser)
+		case OutcomeLGTMComment:
+			if outcome.CIDowngraded {
+				deferredForCI = true
+			} else {
+				recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, cfg.Identity.ExpectedUser)
+			}
+		case OutcomeReviewComment:
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionCommentPosted, run, cfg.Identity.ExpectedUser)
+		case OutcomeReviewRequestChanges:
+			recordErr = appendActionEvent(dataDir, key, store.EventTypeActionRequestChangesPosted, run, cfg.Identity.ExpectedUser)
+		case OutcomeStaleHead:
+			if staleErr := recordStaleResult(ctx, dataDir, key, run, discovery); staleErr != nil {
+				actionErrResult = fmt.Errorf("the pull request head moved since this review, and the stale result could not be recorded: %w", staleErr)
+			} else {
+				actionErrResult = errors.New("the pull request head moved since this review; nothing was posted")
+			}
+		default:
+			actionErrResult = fmt.Errorf("action was not posted (outcome: %d)", outcome.Kind)
+		}
 	}
 
 	refreshed, refreshErr := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
@@ -200,20 +241,35 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if recordErr != nil {
 		return fmt.Errorf("action completed but could not be recorded: %w", recordErr)
 	}
+	if actionErrResult != nil {
+		return actionErrResult
+	}
 
 	if refreshErr == nil {
 		if resultItem, found := findDeskItem(refreshed, key); found {
 			fmt.Printf("\nDesk state: %s — %s\n", resultItem.DeskState, resultItem.Reason)
 		}
 	}
-
-	switch outcome.Kind {
-	case OutcomeStaleHead:
-		return errors.New("the pull request head moved since this review; nothing was posted")
-	case OutcomeReviewSkipped, OutcomeLGTMDeclined, OutcomeLGTMSkipped:
-		return errors.New("action was not posted")
+	if deferredForCI {
+		fmt.Println("CI is not green; posted a comment instead of approving. The item remains actionable — run `acr desk act --approve` again once CI passes.")
 	}
 	return nil
+}
+
+func confirmDeskAction(action deskActAction, prNumber string) bool {
+	if !terminal.IsStdinTTY() {
+		return false
+	}
+	label := "post a comment on"
+	switch action {
+	case deskActApprove:
+		label = "approve"
+	case deskActRequestChanges:
+		label = "request changes on"
+	}
+	fmt.Print(formatPrompt(fmt.Sprintf("About to %s PR %s", label, formatPRRef(prNumber)), "[y/N]:"))
+	response := readUserInput()
+	return response == "y" || response == "yes"
 }
 
 func validateActionForConclusion(action deskActAction, conclusion domain.ReviewConclusion) error {
@@ -285,6 +341,10 @@ func recordStaleResult(ctx context.Context, dataDir string, key store.PullReques
 	if err != nil {
 		return fmt.Errorf("re-check current PR head: %w", err)
 	}
+	return appendStaleEvent(dataDir, key, run, snapshot.HeadObjectID)
+}
+
+func appendStaleEvent(dataDir string, key store.PullRequestKeyV1, run *domain.ReviewRun, currentHeadObjectID string) error {
 	now := time.Now()
 	id, err := newDeskEventID(now)
 	if err != nil {
@@ -297,7 +357,7 @@ func recordStaleResult(ctx context.Context, dataDir string, key store.PullReques
 		Type:              store.EventTypeReviewStale,
 		OccurredAt:        now,
 		RunID:             run.ID,
-		HeadObjectID:      snapshot.HeadObjectID,
+		HeadObjectID:      currentHeadObjectID,
 		PriorHeadObjectID: run.Target.Revision.HeadObjectID,
 	}
 	_, err = store.NewFilesystemEventStore(dataDir).AppendEvent(event)

--- a/cmd/acr/desk_act.go
+++ b/cmd/acr/desk_act.go
@@ -187,6 +187,9 @@ func runDeskAct(ctx context.Context, key store.PullRequestKeyV1, action deskActA
 	if enrichErr != nil || liveSnapshot.HeadObjectID == "" {
 		return fmt.Errorf("could not verify the current pull request head before posting: %w", enrichErr)
 	}
+	if liveSnapshot.BaseObjectID == "" {
+		return errors.New("could not verify the current pull request base before posting: enrichment returned an incomplete revision")
+	}
 	if liveSnapshot.HeadObjectID != run.Target.Revision.HeadObjectID || liveSnapshot.BaseObjectID != run.Target.Revision.BaseObjectID {
 		if staleErr := appendStaleEvent(dataDir, key, run, liveSnapshot.HeadObjectID, liveSnapshot.BaseObjectID); staleErr != nil {
 			return fmt.Errorf("the pull request revision moved since this review, and the stale result could not be recorded: %w", staleErr)
@@ -383,6 +386,9 @@ func recordStaleResult(ctx context.Context, dataDir string, key store.PullReques
 	snapshot, err := discovery.Enrich(ctx, key.ToDomain())
 	if err != nil {
 		return false, fmt.Errorf("re-check current PR head: %w", err)
+	}
+	if snapshot.HeadObjectID == "" || snapshot.BaseObjectID == "" {
+		return false, errors.New("re-check current PR head: enrichment returned an incomplete revision")
 	}
 	moved := snapshot.HeadObjectID != run.Target.Revision.HeadObjectID || snapshot.BaseObjectID != run.Target.Revision.BaseObjectID
 	if !moved {

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -340,3 +340,95 @@ func TestRunDeskAct_StaleHeadPreventsPostingAndRecordsAuditEvent(t *testing.T) {
 		t.Fatalf("expected prior_head_object_id = %q, got %q", env.fixture.prHeadSHA, events[0].PriorHeadObjectID)
 	}
 }
+
+func TestRunDeskAct_DeclinedConfirmationDoesNotPost(t *testing.T) {
+	env := setupDeskActTest(t, 28, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, false, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the action is not confirmed")
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation without confirmation, got %q", posted)
+	}
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no events to be recorded, got %+v", events)
+	}
+}
+
+func TestRunDeskAct_CIDowngradedApprovalStaysActionable(t *testing.T) {
+	env := setupDeskActTest(t, 29, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "fail",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err != nil {
+		t.Fatalf("runDeskAct failed: %v", err)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if !strings.Contains(posted, "--comment") {
+		t.Fatalf("expected a CI-downgraded approval to post --comment, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no action-posted event for a CI-downgraded approval (item must stay actionable), got %+v", events)
+	}
+
+	cfg, err := workspace.Load(env.configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := desk.LoadStored(env.dataDir, *cfg, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	item, ok := findDeskItem(inbox, env.key)
+	if !ok || item.DeskState != domain.DeskStateDecisionReady {
+		t.Fatalf("expected the item to remain decision_ready after a CI-downgraded approval, got %+v (found=%v)", item, ok)
+	}
+}
+
+func TestRunDeskAct_RejectsNoChangesRun(t *testing.T) {
+	run := fakeReviewRun(t, domain.ReviewTarget{})
+	run.Conclusion = domain.ReviewConclusionNoChanges
+	env := setupDeskActTest(t, 30, run, "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the stored run found no changes")
+	}
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation for a no-changes run, got %q", posted)
+	}
+}

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -420,6 +420,80 @@ func TestRunDeskAct_UnverifiableRevisionDoesNotRecordFalseStaleEvent(t *testing.
 	}
 }
 
+func TestRunDeskAct_EmptyLiveBaseIsUnverifiableNotStale(t *testing.T) {
+	env := setupDeskActTest(t, 275, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	now := time.Now()
+	env.discovery.enrichResponses = []domain.PullRequestSnapshot{
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now),
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, "", now.Add(time.Minute)),
+	}
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the live base object id could not be verified")
+	}
+	if !strings.Contains(err.Error(), "verify") {
+		t.Fatalf("expected an unverifiable-revision error, not a false moved/stale report, got %q", err.Error())
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation when the base could not be verified, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no false review_stale audit event when the base could not be verified (only unverifiable), got %+v", events)
+	}
+}
+
+func TestRunDeskAct_RecordStaleResultTreatsEmptyBaseAsUnverifiableNotMoved(t *testing.T) {
+	env := setupDeskActTest(t, 276, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	now := time.Now()
+	env.discovery.enrichResponses = []domain.PullRequestSnapshot{
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now),
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, "", now.Add(time.Minute)),
+	}
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.staleSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the stale re-check's live base object id could not be verified")
+	}
+	if !strings.Contains(err.Error(), "verify") {
+		t.Fatalf("expected an unverifiable-revision error, not a false moved/stale report, got %q", err.Error())
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no false review_stale audit event when the re-check base could not be verified, got %+v", events)
+	}
+}
+
 func TestRunDeskAct_RevisionMovedDuringPreSubmitCheckRoutesToStaleOutcome(t *testing.T) {
 	env := setupDeskActTest(t, 272, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	now := time.Now()

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -748,6 +748,34 @@ func TestRunDeskAct_FinalCheckCatchesBaseMoveMissedByPreflight(t *testing.T) {
 	}
 }
 
+func TestRunDeskAct_FinalCheckBlocksPostingWhenPRClosedDuringSubmissionWindow(t *testing.T) {
+	oldDelay := submissionRetryDelay
+	submissionRetryDelay = 0
+	defer func() { submissionRetryDelay = oldDelay }()
+
+	env := setupDeskActTest(t, 371, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
+		watchState:    "CLOSED",
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the pull request closed before the final submission check")
+	}
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation when the pull request closed during the submission window, got %q", posted)
+	}
+}
+
 func TestRunDeskAct_FinalCheckFailsClosedWhenLiveLookupIsUnavailable(t *testing.T) {
 	oldDelay := submissionRetryDelay
 	submissionRetryDelay = 0

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -509,6 +509,37 @@ func TestRunDeskAct_RejectsWhenRunHistoryHasCorruptRecords(t *testing.T) {
 	}
 }
 
+func TestRunDeskAct_RejectsWhenEventHistoryHasCorruptRecords(t *testing.T) {
+	env := setupDeskActTest(t, 36, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
+		prAuthor:      "someone-else",
+		postReviewLog: env.postReviewLog,
+	})
+
+	eventsDir := filepath.Join(env.dataDir, "prs", env.key.Host, env.key.Owner, env.key.Repository, "36", "events")
+	if err := os.MkdirAll(eventsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corruptPath := filepath.Join(eventsDir, "20260101T000000.000000000Z-corrupt.json")
+	if err := os.WriteFile(corruptPath, []byte("not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when stored event history has an unreadable record")
+	}
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation with corrupt event history present, got %q", posted)
+	}
+}
+
 func TestRunDeskAct_FinalCheckCatchesBaseMoveMissedByPreflight(t *testing.T) {
 	oldDelay := submissionRetryDelay
 	submissionRetryDelay = 0

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -348,6 +348,42 @@ func TestRunDeskAct_StaleHeadPreventsPostingAndRecordsAuditEvent(t *testing.T) {
 	}
 }
 
+func TestRunDeskAct_UnverifiableRevisionDoesNotRecordFalseStaleEvent(t *testing.T) {
+	env := setupDeskActTest(t, 271, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	now := time.Now()
+	env.discovery.enrichResponses = []domain.PullRequestSnapshot{
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now),
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now.Add(time.Minute)),
+	}
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchFail:     true,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the revision could not be verified before posting")
+	}
+	if !strings.Contains(err.Error(), "unchanged") {
+		t.Fatalf("expected the error to explain the revision was actually unchanged, got %q", err.Error())
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation when the revision could not be verified, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no false review_stale audit event when the revision was actually unchanged, got %+v", events)
+	}
+}
+
 func TestRunDeskAct_DeclinedConfirmationDoesNotPost(t *testing.T) {
 	env := setupDeskActTest(t, 28, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	withFakeGH(t, fakeGHResponses{

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -384,6 +384,41 @@ func TestRunDeskAct_UnverifiableRevisionDoesNotRecordFalseStaleEvent(t *testing.
 	}
 }
 
+func TestRunDeskAct_RevisionMovedDuringPreSubmitCheckRoutesToStaleOutcome(t *testing.T) {
+	env := setupDeskActTest(t, 272, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	now := time.Now()
+	env.discovery.enrichResponses = []domain.PullRequestSnapshot{
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now),
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now.Add(time.Minute)),
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.staleSHA, env.fixture.baseSHA, now.Add(2*time.Minute)),
+	}
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the revision moved during the pre-submit eligibility recheck")
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation when the pre-submit recheck finds a moved revision, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeReviewStale {
+		t.Fatalf("expected exactly one review_stale audit event routed through the stale outcome, got %+v", events)
+	}
+}
+
 func TestRunDeskAct_DeclinedConfirmationDoesNotPost(t *testing.T) {
 	env := setupDeskActTest(t, 28, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	withFakeGH(t, fakeGHResponses{

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -238,6 +238,35 @@ func TestRunDeskAct_PostsRequestChangesForFindingsReview(t *testing.T) {
 	}
 }
 
+func TestRunDeskAct_RequestChangesSurvivesFailedLiveAuthorLookup(t *testing.T) {
+	env := setupDeskActTest(t, 221, fakeFindingsReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
+		prAuthor:      "",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActRequestChanges, true, env.discovery)
+	if err != nil {
+		t.Fatalf("runDeskAct failed: %v", err)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if !strings.Contains(posted, "--request-changes") {
+		t.Fatalf("expected the confirmed --request-changes action to survive a failed live PR-author lookup, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeActionRequestChangesPosted {
+		t.Fatalf("expected exactly one action_request_changes_posted event, got %+v", events)
+	}
+}
+
 func TestRunDeskAct_PostsCommentForFindingsReview(t *testing.T) {
 	env := setupDeskActTest(t, 23, fakeFindingsReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	withFakeGH(t, fakeGHResponses{

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -347,6 +347,31 @@ func TestRunDeskAct_SelfAuthoredPRForcesComment(t *testing.T) {
 	}
 }
 
+func TestRunDeskAct_SelfReviewClassificationUsesDeskStateNotLiveLookup(t *testing.T) {
+	env := setupDeskActTest(t, 261, fakeReviewRun(t, domain.ReviewTarget{}), "me", "comment-only", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
+		prAuthor:      "someone-entirely-different",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err != nil {
+		t.Fatalf("runDeskAct failed: %v", err)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if !strings.Contains(posted, "--comment") || strings.Contains(posted, "--approve") {
+		t.Fatalf("expected the self-authored PR to be downgraded to --comment based on desk classification even though a live PR-author lookup would disagree, got %q", posted)
+	}
+}
+
 func TestRunDeskAct_StaleHeadPreventsPostingAndRecordsAuditEvent(t *testing.T) {
 	env := setupDeskActTest(t, 27, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	now := time.Now()

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -473,6 +473,9 @@ func TestRunDeskAct_BaseMismatchPreventsPosting(t *testing.T) {
 	if len(events) != 1 || events[0].Type != store.EventTypeReviewStale {
 		t.Fatalf("expected exactly one review_stale audit event for the base mismatch, got %+v", events)
 	}
+	if events[0].BaseObjectID != "a-different-base-sha" {
+		t.Fatalf("expected the stale event to record the live base that actually moved, got base=%q", events[0].BaseObjectID)
+	}
 }
 
 func TestRunDeskAct_RejectsWhenRunHistoryHasCorruptRecords(t *testing.T) {
@@ -507,6 +510,10 @@ func TestRunDeskAct_RejectsWhenRunHistoryHasCorruptRecords(t *testing.T) {
 }
 
 func TestRunDeskAct_FinalCheckCatchesBaseMoveMissedByPreflight(t *testing.T) {
+	oldDelay := submissionRetryDelay
+	submissionRetryDelay = 0
+	defer func() { submissionRetryDelay = oldDelay }()
+
 	env := setupDeskActTest(t, 33, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	withFakeGH(t, fakeGHResponses{
 		user:          "me",
@@ -530,6 +537,10 @@ func TestRunDeskAct_FinalCheckCatchesBaseMoveMissedByPreflight(t *testing.T) {
 }
 
 func TestRunDeskAct_FinalCheckFailsClosedWhenLiveLookupIsUnavailable(t *testing.T) {
+	oldDelay := submissionRetryDelay
+	submissionRetryDelay = 0
+	defer func() { submissionRetryDelay = oldDelay }()
+
 	env := setupDeskActTest(t, 34, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	withFakeGH(t, fakeGHResponses{
 		user:          "me",

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -432,3 +432,64 @@ func TestRunDeskAct_RejectsNoChangesRun(t *testing.T) {
 		t.Fatalf("expected no GitHub mutation for a no-changes run, got %q", posted)
 	}
 }
+
+func TestRunDeskAct_BaseMismatchPreventsPosting(t *testing.T) {
+	env := setupDeskActTest(t, 31, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	now := time.Now()
+	env.discovery.enrichResponses = []domain.PullRequestSnapshot{
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now),
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, "a-different-base-sha", now.Add(time.Minute)),
+	}
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the base moved since the review even though the head did not")
+	}
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation for a base mismatch, got %q", posted)
+	}
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeReviewStale {
+		t.Fatalf("expected exactly one review_stale audit event for the base mismatch, got %+v", events)
+	}
+}
+
+func TestRunDeskAct_RejectsWhenRunHistoryHasCorruptRecords(t *testing.T) {
+	env := setupDeskActTest(t, 32, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		postReviewLog: env.postReviewLog,
+	})
+
+	runsDir := filepath.Join(env.dataDir, "prs", env.key.Host, env.key.Owner, env.key.Repository, "32", "runs")
+	if err := os.MkdirAll(runsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corruptPath := filepath.Join(runsDir, "20260101T000000.000000000Z-corrupt.json")
+	if err := os.WriteFile(corruptPath, []byte("not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when stored run history has an unreadable record")
+	}
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation with corrupt run history present, got %q", posted)
+	}
+}

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -138,6 +138,7 @@ func TestRunDeskAct_PostsApprovalForCleanReview(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		ciBucket:      "pass",
 		postReviewLog: env.postReviewLog,
@@ -180,6 +181,7 @@ func TestRunDeskAct_PostsRequestChangesForFindingsReview(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		postReviewLog: env.postReviewLog,
 	})
@@ -208,6 +210,7 @@ func TestRunDeskAct_PostsCommentForFindingsReview(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		postReviewLog: env.postReviewLog,
 	})
@@ -236,6 +239,7 @@ func TestRunDeskAct_RejectsWhenPostingDisabled(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		postReviewLog: env.postReviewLog,
 	})
@@ -262,6 +266,7 @@ func TestRunDeskAct_FailsClosedOnIdentityMismatch(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		postReviewLog: env.postReviewLog,
 	})
@@ -284,6 +289,7 @@ func TestRunDeskAct_SelfAuthoredPRForcesComment(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "me",
 		ciBucket:      "pass",
 		postReviewLog: env.postReviewLog,
@@ -318,6 +324,7 @@ func TestRunDeskAct_StaleHeadPreventsPostingAndRecordsAuditEvent(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.staleSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		ciBucket:      "pass",
 		postReviewLog: env.postReviewLog,
@@ -349,6 +356,7 @@ func TestRunDeskAct_DeclinedConfirmationDoesNotPost(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		ciBucket:      "pass",
 		postReviewLog: env.postReviewLog,
@@ -376,6 +384,7 @@ func TestRunDeskAct_CIDowngradedApprovalStaysActionable(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		ciBucket:      "fail",
 		postReviewLog: env.postReviewLog,
@@ -420,6 +429,7 @@ func TestRunDeskAct_RejectsNoChangesRun(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		postReviewLog: env.postReviewLog,
 	})
@@ -446,6 +456,7 @@ func TestRunDeskAct_BaseMismatchPreventsPosting(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		ciBucket:      "pass",
 		postReviewLog: env.postReviewLog,
@@ -472,6 +483,7 @@ func TestRunDeskAct_RejectsWhenRunHistoryHasCorruptRecords(t *testing.T) {
 		repoSSHURL:    env.fixture.remoteURL,
 		baseRefName:   "main",
 		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  env.fixture.baseSHA,
 		prAuthor:      "someone-else",
 		postReviewLog: env.postReviewLog,
 	})
@@ -491,5 +503,51 @@ func TestRunDeskAct_RejectsWhenRunHistoryHasCorruptRecords(t *testing.T) {
 	}
 	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
 		t.Fatalf("expected no GitHub mutation with corrupt run history present, got %q", posted)
+	}
+}
+
+func TestRunDeskAct_FinalCheckCatchesBaseMoveMissedByPreflight(t *testing.T) {
+	env := setupDeskActTest(t, 33, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		watchBaseSHA:  "a-base-that-moved-after-the-preflight-check",
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the final live check finds a base mismatch the preflight discovery check missed")
+	}
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation, got %q", posted)
+	}
+}
+
+func TestRunDeskAct_FinalCheckFailsClosedWhenLiveLookupIsUnavailable(t *testing.T) {
+	env := setupDeskActTest(t, 34, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  "",
+		watchBaseSHA:  "",
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the final live revision lookup returns no data")
+	}
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation, got %q", posted)
 	}
 }

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -173,6 +173,42 @@ func TestRunDeskAct_PostsApprovalForCleanReview(t *testing.T) {
 	}
 }
 
+func TestRunDeskAct_DoesNotRetryAfterAmbiguousSubmissionFailure(t *testing.T) {
+	env := setupDeskActTest(t, 21, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:              "me",
+		repoURL:           env.fixture.remoteURL,
+		repoSSHURL:        env.fixture.remoteURL,
+		baseRefName:       "main",
+		watchHeadSHA:      env.fixture.prHeadSHA,
+		watchBaseSHA:      env.fixture.baseSHA,
+		prAuthor:          "someone-else",
+		ciBucket:          "pass",
+		postReviewLog:     env.postReviewLog,
+		postReviewFailFor: 1,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected runDeskAct to fail when the first gh pr review invocation fails")
+	}
+
+	attempts := readPostReviewLog(t, env.postReviewLog+".count")
+	if strings.TrimSpace(attempts) != "1" {
+		t.Fatalf("desk act must not retry a non-idempotent submission after an ambiguous failure; expected exactly 1 gh invocation, got count file %q", attempts)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if posted != "" {
+		t.Fatalf("no review should have been recorded as posted, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no action event to be recorded for a failed post, got %+v", events)
+	}
+}
+
 func TestRunDeskAct_PostsRequestChangesForFindingsReview(t *testing.T) {
 	env := setupDeskActTest(t, 22, fakeFindingsReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
 	withFakeGH(t, fakeGHResponses{

--- a/cmd/acr/desk_act_test.go
+++ b/cmd/acr/desk_act_test.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func fakeFindingsReviewRun(t *testing.T, target domain.ReviewTarget) *domain.ReviewRun {
+	t.Helper()
+	run := fakeReviewRun(t, target)
+	run.Conclusion = domain.ReviewConclusionFindings
+	run.Findings = []domain.ReviewFinding{
+		{
+			ID:   "finding-1",
+			Kind: domain.ReviewFindingActionable,
+			Group: domain.FindingGroup{
+				Title:         "Example finding",
+				Summary:       "Something worth fixing.",
+				Messages:      []string{"Something worth fixing."},
+				ReviewerCount: 1,
+				Sources:       []int{0},
+			},
+		},
+	}
+	run.AggregatedFindings = []domain.AggregatedFinding{
+		{Text: "Something worth fixing.", Reviewers: []int{0}},
+	}
+	run.Stats = domain.ReviewStats{TotalReviewers: 1, SuccessfulReviewers: 1}
+	return run
+}
+
+func persistRun(t *testing.T, dataDir string, run *domain.ReviewRun) {
+	t.Helper()
+	schema, err := store.ToReviewRunSchema(*run, store.RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.NewFilesystemRunStore(dataDir).SaveRun(schema); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type deskActTestEnv struct {
+	fixture       dispatchGitFixture
+	dataDir       string
+	configDir     string
+	key           store.PullRequestKeyV1
+	discovery     *dispatchFixtureDiscovery
+	postReviewLog string
+}
+
+func setupDeskActTest(t *testing.T, prNumber int, run *domain.ReviewRun, author string, ownPRPolicy string, postingEnabled bool) deskActTestEnv {
+	t.Helper()
+
+	fixture := newDispatchGitFixture(t, prNumber)
+
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfigFull(t, configDir, "me", []string{fixture.repoRoot}, postingEnabled, ownPRPolicy)
+
+	key := dispatchPullRequestKey(fixture.host, prNumber)
+	domainKey := key.ToDomain()
+	run.Target = domain.ReviewTarget{
+		RepositoryRoot: fixture.repoRoot,
+		WorktreeRoot:   fixture.repoRoot,
+		Revision: domain.RevisionEvidence{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "main",
+			HeadObjectID:     fixture.prHeadSHA,
+			BaseObjectID:     fixture.baseSHA,
+		},
+		PullRequest: &domainKey,
+	}
+	persistRun(t, dataDir, run)
+
+	now := time.Now()
+	snapshot := dispatchSnapshotWithAuthor(key, author, fixture.prHeadSHA, fixture.baseSHA, now)
+	discovery := &dispatchFixtureDiscovery{
+		searchResult: []domain.PullRequestKey{key.ToDomain()},
+		enrichResponses: []domain.PullRequestSnapshot{
+			snapshot,
+			dispatchSnapshotWithAuthor(key, author, fixture.prHeadSHA, fixture.baseSHA, now.Add(time.Minute)),
+		},
+	}
+
+	postReviewLog := filepath.Join(t.TempDir(), "pr-review.log")
+
+	return deskActTestEnv{
+		fixture:       fixture,
+		dataDir:       dataDir,
+		configDir:     configDir,
+		key:           key,
+		discovery:     discovery,
+		postReviewLog: postReviewLog,
+	}
+}
+
+func readPostReviewLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func loadEvents(t *testing.T, dataDir string, key store.PullRequestKeyV1) []store.ReviewEventV1 {
+	t.Helper()
+	events, corrupt, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(corrupt) != 0 {
+		t.Fatalf("unexpected corrupt events: %v", corrupt)
+	}
+	return events
+}
+
+func TestRunDeskAct_PostsApprovalForCleanReview(t *testing.T) {
+	env := setupDeskActTest(t, 21, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err != nil {
+		t.Fatalf("runDeskAct failed: %v", err)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if !strings.Contains(posted, "--approve") {
+		t.Fatalf("expected an --approve invocation, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeActionApprovalPosted {
+		t.Fatalf("expected exactly one action_approval_posted event, got %+v", events)
+	}
+
+	cfg, err := workspace.Load(env.configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := desk.LoadStored(env.dataDir, *cfg, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	item, ok := findDeskItem(inbox, env.key)
+	if !ok || item.DeskState != domain.DeskStateResolved {
+		t.Fatalf("expected the item to read as resolved after approval, got %+v (found=%v)", item, ok)
+	}
+}
+
+func TestRunDeskAct_PostsRequestChangesForFindingsReview(t *testing.T) {
+	env := setupDeskActTest(t, 22, fakeFindingsReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActRequestChanges, true, env.discovery)
+	if err != nil {
+		t.Fatalf("runDeskAct failed: %v", err)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if !strings.Contains(posted, "--request-changes") {
+		t.Fatalf("expected a --request-changes invocation, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeActionRequestChangesPosted {
+		t.Fatalf("expected exactly one action_request_changes_posted event, got %+v", events)
+	}
+}
+
+func TestRunDeskAct_PostsCommentForFindingsReview(t *testing.T) {
+	env := setupDeskActTest(t, 23, fakeFindingsReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActComment, true, env.discovery)
+	if err != nil {
+		t.Fatalf("runDeskAct failed: %v", err)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if !strings.Contains(posted, "--comment") {
+		t.Fatalf("expected a --comment invocation, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeActionCommentPosted {
+		t.Fatalf("expected exactly one action_comment_posted event, got %+v", events)
+	}
+}
+
+func TestRunDeskAct_RejectsWhenPostingDisabled(t *testing.T) {
+	env := setupDeskActTest(t, 24, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", false)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when posting is disabled")
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation, got %q", posted)
+	}
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no events to be recorded, got %+v", events)
+	}
+}
+
+func TestRunDeskAct_FailsClosedOnIdentityMismatch(t *testing.T) {
+	env := setupDeskActTest(t, 25, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "someone-entirely-different",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "someone-else",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error on identity mismatch")
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation, got %q", posted)
+	}
+}
+
+func TestRunDeskAct_SelfAuthoredPRForcesComment(t *testing.T) {
+	env := setupDeskActTest(t, 26, fakeReviewRun(t, domain.ReviewTarget{}), "me", "comment-only", true)
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.prHeadSHA,
+		prAuthor:      "me",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err != nil {
+		t.Fatalf("runDeskAct failed: %v", err)
+	}
+
+	posted := readPostReviewLog(t, env.postReviewLog)
+	if !strings.Contains(posted, "--comment") || strings.Contains(posted, "--approve") {
+		t.Fatalf("expected a self-authored PR to be downgraded to --comment, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeActionCommentPosted {
+		t.Fatalf("expected exactly one action_comment_posted event, got %+v", events)
+	}
+}
+
+func TestRunDeskAct_StaleHeadPreventsPostingAndRecordsAuditEvent(t *testing.T) {
+	env := setupDeskActTest(t, 27, fakeReviewRun(t, domain.ReviewTarget{}), "someone-else", "disabled", true)
+	now := time.Now()
+	env.discovery.enrichResponses = []domain.PullRequestSnapshot{
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.prHeadSHA, env.fixture.baseSHA, now),
+		dispatchSnapshotWithAuthor(env.key, "someone-else", env.fixture.staleSHA, env.fixture.baseSHA, now.Add(time.Minute)),
+	}
+	withFakeGH(t, fakeGHResponses{
+		user:          "me",
+		repoURL:       env.fixture.remoteURL,
+		repoSSHURL:    env.fixture.remoteURL,
+		baseRefName:   "main",
+		watchHeadSHA:  env.fixture.staleSHA,
+		prAuthor:      "someone-else",
+		ciBucket:      "pass",
+		postReviewLog: env.postReviewLog,
+	})
+
+	err := runDeskAct(context.Background(), env.key, deskActApprove, true, env.discovery)
+	if err == nil {
+		t.Fatal("expected an error when the head moved since the review")
+	}
+
+	if posted := readPostReviewLog(t, env.postReviewLog); posted != "" {
+		t.Fatalf("expected no GitHub mutation for a stale head, got %q", posted)
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 1 || events[0].Type != store.EventTypeReviewStale {
+		t.Fatalf("expected exactly one review_stale audit event, got %+v", events)
+	}
+	if events[0].PriorHeadObjectID != env.fixture.prHeadSHA {
+		t.Fatalf("expected prior_head_object_id = %q, got %q", env.fixture.prHeadSHA, events[0].PriorHeadObjectID)
+	}
+}

--- a/cmd/acr/desk_config.go
+++ b/cmd/acr/desk_config.go
@@ -38,7 +38,7 @@ func newDeskConfigInitCmd() *cobra.Command {
 				return err
 			}
 
-			defaultUser := github.GetCurrentUser(context.Background())
+			defaultUser := github.GetCurrentUser(context.Background(), "")
 			path, err := workspace.Init(configDir, defaultUser)
 			if err != nil {
 				return err
@@ -132,7 +132,7 @@ func newDeskConfigValidateCmd() *cobra.Command {
 			var errs []string
 			errs = append(errs, cfg.Validate()...)
 
-			if identityErr := workspace.CheckIdentity(context.Background(), *cfg); identityErr != nil {
+			if identityErr := workspace.CheckIdentity(context.Background(), *cfg, ""); identityErr != nil {
 				errs = append(errs, identityErr.Error())
 			}
 

--- a/cmd/acr/desk_dispatch.go
+++ b/cmd/acr/desk_dispatch.go
@@ -92,7 +92,7 @@ func runDeskDispatch(ctx context.Context, key store.PullRequestKeyV1, discovery 
 	}
 	defer func() { _ = release() }()
 
-	if identityErr := workspace.CheckIdentity(ctx, *cfg, ""); identityErr != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *cfg, key.Host); identityErr != nil {
 		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
 	}
 

--- a/cmd/acr/desk_dispatch.go
+++ b/cmd/acr/desk_dispatch.go
@@ -92,7 +92,7 @@ func runDeskDispatch(ctx context.Context, key store.PullRequestKeyV1, discovery 
 	}
 	defer func() { _ = release() }()
 
-	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *cfg, ""); identityErr != nil {
 		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
 	}
 

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -116,6 +116,16 @@ func unusedDispatchService(t *testing.T) dispatchServiceFactory {
 
 func writeWorkspaceConfig(t *testing.T, configDir, expectedUser string, repositoryRoots []string) {
 	t.Helper()
+	writeWorkspaceConfigWithPosting(t, configDir, expectedUser, repositoryRoots, false)
+}
+
+func writeWorkspaceConfigWithPosting(t *testing.T, configDir, expectedUser string, repositoryRoots []string, postingEnabled bool) {
+	t.Helper()
+	writeWorkspaceConfigFull(t, configDir, expectedUser, repositoryRoots, postingEnabled, "disabled")
+}
+
+func writeWorkspaceConfigFull(t *testing.T, configDir, expectedUser string, repositoryRoots []string, postingEnabled bool, ownPRPolicy string) {
+	t.Helper()
 	rootsYAML := "[]"
 	if len(repositoryRoots) > 0 {
 		quoted := make([]string, len(repositoryRoots))
@@ -140,12 +150,12 @@ behavior:
   concurrency: 0
   auto_review: false
   re_review: false
-  own_pr_policy: disabled
+  own_pr_policy: %s
 posting:
-  enabled: false
+  enabled: %t
 notifications:
   enabled: false
-`, expectedUser, rootsYAML)
+`, expectedUser, rootsYAML, ownPRPolicy, postingEnabled)
 
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -167,32 +177,72 @@ func joinStrings(parts []string, sep string) string {
 }
 
 type fakeGHResponses struct {
-	user        string
-	repoURL     string
-	repoSSHURL  string
-	baseRefName string
+	user          string
+	repoURL       string
+	repoSSHURL    string
+	baseRefName   string
+	watchHeadSHA  string
+	watchState    string
+	prAuthor      string
+	ciBucket      string
+	postReviewLog string
 }
 
 func withFakeGH(t *testing.T, responses fakeGHResponses) {
 	t.Helper()
 	binDir := t.TempDir()
+
+	watchState := responses.watchState
+	if watchState == "" {
+		watchState = "OPEN"
+	}
+	ciBucket := responses.ciBucket
+	if ciBucket == "" {
+		ciBucket = "pass"
+	}
+
 	script := fmt.Sprintf(`#!/bin/sh
-case "$1 $2" in
-  "api user")
+args="$*"
+case "$args" in
+  "api user --jq .login")
     echo %q
     ;;
-  "repo view")
+  "repo view --json url,sshUrl")
     echo '{"url":%q,"sshUrl":%q}'
     ;;
-  "pr view")
+  *"--json headRefOid,state,reviewRequests"*)
+    echo '{"headRefOid":%q,"state":%q,"reviewRequests":[]}'
+    ;;
+  *"--json baseRefName"*)
     echo '{"baseRefName":%q}'
     ;;
+  *"--json author --jq .author.login"*)
+    echo %q
+    ;;
+  *"pr checks "*)
+    echo '[{"name":"ci","bucket":%q}]'
+    ;;
+  *"pr review "*)
+    if [ -z %q ]; then
+      echo "fake gh: unexpected pr review invocation: $args" >&2
+      exit 1
+    fi
+    echo "$args" >> %q
+    ;;
   *)
-    echo "fake gh: unhandled invocation: $*" >&2
+    echo "fake gh: unhandled invocation: $args" >&2
     exit 1
     ;;
 esac
-`, responses.user, responses.repoURL, responses.repoSSHURL, responses.baseRefName)
+`,
+		responses.user,
+		responses.repoURL, responses.repoSSHURL,
+		responses.watchHeadSHA, watchState,
+		responses.baseRefName,
+		responses.prAuthor,
+		ciBucket,
+		responses.postReviewLog, responses.postReviewLog,
+	)
 
 	path := filepath.Join(binDir, "gh")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
@@ -362,11 +412,15 @@ func dispatchPullRequestKey(host string, prNumber int) store.PullRequestKeyV1 {
 }
 
 func dispatchSnapshot(key store.PullRequestKeyV1, head, base string, now time.Time) domain.PullRequestSnapshot {
+	return dispatchSnapshotWithAuthor(key, "someone-else", head, base, now)
+}
+
+func dispatchSnapshotWithAuthor(key store.PullRequestKeyV1, author, head, base string, now time.Time) domain.PullRequestSnapshot {
 	return domain.PullRequestSnapshot{
 		PullRequest:  key.ToDomain(),
 		URL:          fmt.Sprintf("https://%s/acme/widgets/pull/%d", key.Host, key.Number),
 		Title:        "widgets PR",
-		Author:       "someone-else",
+		Author:       author,
 		State:        domain.PullRequestStateOpen,
 		HeadObjectID: head,
 		BaseObjectID: base,

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -184,6 +184,7 @@ type fakeGHResponses struct {
 	watchHeadSHA  string
 	watchBaseSHA  string
 	watchState    string
+	watchFail     bool
 	prAuthor      string
 	ciBucket      string
 	postReviewLog string
@@ -212,6 +213,10 @@ case "$args" in
     echo '{"url":%q,"sshUrl":%q}'
     ;;
   *"--json headRefOid,baseRefOid,state,reviewRequests"*)
+    if [ %q = "true" ]; then
+      echo "fake gh: simulated watch-state lookup failure" >&2
+      exit 1
+    fi
     echo '{"headRefOid":%q,"baseRefOid":%q,"state":%q,"reviewRequests":[]}'
     ;;
   *"--json baseRefName"*)
@@ -238,6 +243,7 @@ esac
 `,
 		responses.user,
 		responses.repoURL, responses.repoSSHURL,
+		fmt.Sprintf("%t", responses.watchFail),
 		responses.watchHeadSHA, responses.watchBaseSHA, watchState,
 		responses.baseRefName,
 		responses.prAuthor,

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -357,6 +356,14 @@ func (b *syncBuffer) String() string {
 func startGitDaemon(t *testing.T, baseDir string) {
 	t.Helper()
 
+	preflight, err := net.Listen("tcp", "127.0.0.1:"+gitDaemonPort)
+	if err != nil {
+		t.Skipf("port %s is unavailable for a local git daemon in this environment: %v", gitDaemonPort, err)
+	}
+	if err := preflight.Close(); err != nil {
+		t.Fatalf("failed to release the preflight listener on port %s: %v", gitDaemonPort, err)
+	}
+
 	stderr := &syncBuffer{}
 	cmd := exec.Command("git", "daemon",
 		"--reuseaddr",
@@ -368,7 +375,7 @@ func startGitDaemon(t *testing.T, baseDir string) {
 	cmd.Stderr = stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("failed to start git daemon: %v", err)
+		t.Skipf("could not start a local git daemon in this environment: %v", err)
 	}
 	t.Cleanup(func() {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
@@ -382,13 +389,9 @@ func startGitDaemon(t *testing.T, baseDir string) {
 			_ = conn.Close()
 			return
 		}
-		if strings.Contains(stderr.String(), "Address already in use") {
-			t.Skipf("port %s unavailable for git daemon: %s", gitDaemonPort, stderr.String())
-		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Fatalf("git daemon did not become ready: %s", stderr.String())
-	t.Fatal("git daemon did not become ready")
+	t.Skipf("git daemon did not become ready in this environment: %s", stderr.String())
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -182,6 +182,7 @@ type fakeGHResponses struct {
 	repoSSHURL    string
 	baseRefName   string
 	watchHeadSHA  string
+	watchBaseSHA  string
 	watchState    string
 	prAuthor      string
 	ciBucket      string
@@ -210,8 +211,8 @@ case "$args" in
   "repo view --json url,sshUrl")
     echo '{"url":%q,"sshUrl":%q}'
     ;;
-  *"--json headRefOid,state,reviewRequests"*)
-    echo '{"headRefOid":%q,"state":%q,"reviewRequests":[]}'
+  *"--json headRefOid,baseRefOid,state,reviewRequests"*)
+    echo '{"headRefOid":%q,"baseRefOid":%q,"state":%q,"reviewRequests":[]}'
     ;;
   *"--json baseRefName"*)
     echo '{"baseRefName":%q}'
@@ -237,7 +238,7 @@ esac
 `,
 		responses.user,
 		responses.repoURL, responses.repoSSHURL,
-		responses.watchHeadSHA, watchState,
+		responses.watchHeadSHA, responses.watchBaseSHA, watchState,
 		responses.baseRefName,
 		responses.prAuthor,
 		ciBucket,

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -177,17 +177,18 @@ func joinStrings(parts []string, sep string) string {
 }
 
 type fakeGHResponses struct {
-	user          string
-	repoURL       string
-	repoSSHURL    string
-	baseRefName   string
-	watchHeadSHA  string
-	watchBaseSHA  string
-	watchState    string
-	watchFail     bool
-	prAuthor      string
-	ciBucket      string
-	postReviewLog string
+	user              string
+	repoURL           string
+	repoSSHURL        string
+	baseRefName       string
+	watchHeadSHA      string
+	watchBaseSHA      string
+	watchState        string
+	watchFail         bool
+	prAuthor          string
+	ciBucket          string
+	postReviewLog     string
+	postReviewFailFor int
 }
 
 func withFakeGH(t *testing.T, responses fakeGHResponses) {
@@ -233,6 +234,17 @@ case "$args" in
       echo "fake gh: unexpected pr review invocation: $args" >&2
       exit 1
     fi
+    count_file=%q
+    count=0
+    if [ -f "$count_file" ]; then
+      count=$(cat "$count_file")
+    fi
+    count=$((count + 1))
+    echo "$count" > "$count_file"
+    if [ "$count" -le %d ]; then
+      echo "fake gh: simulated pr review failure ($count)" >&2
+      exit 1
+    fi
     echo "$args" >> %q
     ;;
   *)
@@ -248,7 +260,7 @@ esac
 		responses.baseRefName,
 		responses.prAuthor,
 		ciBucket,
-		responses.postReviewLog, responses.postReviewLog,
+		responses.postReviewLog, responses.postReviewLog+".count", responses.postReviewFailFor, responses.postReviewLog,
 	)
 
 	path := filepath.Join(binDir, "gh")

--- a/cmd/acr/desk_dispatch_test.go
+++ b/cmd/acr/desk_dispatch_test.go
@@ -206,11 +206,14 @@ func withFakeGH(t *testing.T, responses fakeGHResponses) {
 	script := fmt.Sprintf(`#!/bin/sh
 args="$*"
 case "$args" in
-  "api user --jq .login")
+  "api user --jq .login"|"api user --jq .login --hostname "*)
     echo %q
     ;;
   "repo view --json url,sshUrl")
     echo '{"url":%q,"sshUrl":%q}'
+    ;;
+  "repo view --json url --jq .url")
+    echo %q
     ;;
   *"--json headRefOid,baseRefOid,state,reviewRequests"*)
     if [ %q = "true" ]; then
@@ -254,6 +257,7 @@ esac
 `,
 		responses.user,
 		responses.repoURL, responses.repoSSHURL,
+		responses.repoURL,
 		fmt.Sprintf("%t", responses.watchFail),
 		responses.watchHeadSHA, responses.watchBaseSHA, watchState,
 		responses.baseRefName,
@@ -377,9 +381,15 @@ func startGitDaemon(t *testing.T, baseDir string) {
 	if err := cmd.Start(); err != nil {
 		t.Skipf("could not start a local git daemon in this environment: %v", err)
 	}
+
+	exited := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
 	t.Cleanup(func() {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		_ = cmd.Wait()
+		<-exited
 	})
 
 	deadline := time.Now().Add(5 * time.Second)
@@ -389,9 +399,14 @@ func startGitDaemon(t *testing.T, baseDir string) {
 			_ = conn.Close()
 			return
 		}
+		select {
+		case <-exited:
+			t.Fatalf("git daemon exited before becoming ready: %s", stderr.String())
+		default:
+		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Skipf("git daemon did not become ready in this environment: %s", stderr.String())
+	t.Fatalf("git daemon did not become ready within the deadline: %s", stderr.String())
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -166,9 +166,13 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 }
 
 func currentlyReleased(dataDir string, key store.PullRequestKeyV1) (bool, error) {
-	eventSchemas, _, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	eventSchemas, corruptEvents, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
 	if err != nil {
 		return false, err
+	}
+	if len(corruptEvents) > 0 {
+		return false, fmt.Errorf("%d stored event(s) could not be read; run `acr desk history %s` to investigate before acting",
+			len(corruptEvents), key.String())
 	}
 	events := make([]domain.LifecycleEvent, 0, len(eventSchemas))
 	for _, schema := range eventSchemas {

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -93,7 +93,7 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 	}
 	defer func() { _ = release() }()
 
-	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *cfg, ""); identityErr != nil {
 		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
 	}
 
@@ -112,6 +112,9 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 		}
 	}
 	if eventType != store.EventTypeUserResolved {
+		if desk.ScopeExcludesKey(*cfg, key) {
+			return fmt.Errorf("%s is excluded by the current workspace scope; this action would have no effect on desk state", key.String())
+		}
 		if _, snapErr := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(key); snapErr != nil {
 			return fmt.Errorf("%s is not known to the desk; run `acr desk --once` first", key.String())
 		}

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/github"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func newDeskResolveCmd() *cobra.Command {
+	return newDeskLifecycleCmd("resolve", "Mark a pull request's current revision as resolved",
+		"Mark the pull request's current head as resolved without posting to GitHub. "+
+			"The item drops out of the actionable desk view until a new head arrives.",
+		store.EventTypeUserResolved)
+}
+
+func newDeskReleaseCmd() *cobra.Command {
+	return newDeskLifecycleCmd("release", "Stop tracking a pull request on the desk",
+		"Release a pull request from the desk workspace entirely. It will reappear only if discovery finds it again.",
+		store.EventTypeUserReleased)
+}
+
+func newDeskResumeCmd() *cobra.Command {
+	return newDeskLifecycleCmd("resume", "Resume tracking a released or snoozed pull request",
+		"Cancel a prior release or snooze so the pull request is tracked and re-reviewed normally again.",
+		store.EventTypeUserResumed)
+}
+
+func newDeskSnoozeCmd() *cobra.Command {
+	return newDeskLifecycleCmd("snooze", "Defer re-review of a pull request until resumed",
+		"Suppress automatic re-review for this pull request until `acr desk resume` is run, "+
+			"without releasing it from the desk workspace.",
+		store.EventTypeUserSnoozed)
+}
+
+func newDeskLifecycleCmd(use, short, long string, eventType store.ReviewEventTypeV1) *cobra.Command {
+	return &cobra.Command{
+		Use:   use + " <[host/]owner/repo#number>",
+		Short: short,
+		Long:  long,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := desk.ParsePullRequestRef(args[0])
+			if err != nil {
+				return err
+			}
+			return runDeskLifecycleAction(context.Background(), key, eventType, github.NewDiscovery())
+		},
+	}
+}
+
+func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eventType store.ReviewEventTypeV1, discovery github.Discovery) error {
+	configDir, err := workspace.ConfigDir()
+	if err != nil {
+		return err
+	}
+	cfg, err := workspace.Load(configDir)
+	if err != nil {
+		return err
+	}
+	if errs := cfg.Validate(); len(errs) > 0 {
+		return fmt.Errorf("workspace configuration has %d error(s): %v", len(errs), errs)
+	}
+
+	dataDir, err := store.DataDir()
+	if err != nil {
+		return err
+	}
+
+	lock, err := store.AcquireWriteLock(dataDir)
+	if err != nil {
+		if errors.Is(err, store.ErrWriterLocked) {
+			return fmt.Errorf("cannot update %s: %w", key.String(), err)
+		}
+		return err
+	}
+	released := false
+	release := func() error {
+		if released {
+			return nil
+		}
+		released = true
+		return lock.Release()
+	}
+	defer func() { _ = release() }()
+
+	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
+	}
+
+	if _, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now()); err != nil {
+		return err
+	}
+
+	storedSnapshot, snapErr := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(key)
+	if snapErr != nil {
+		return fmt.Errorf("%s is not known to the desk; run `acr desk --once` first", key.String())
+	}
+
+	now := time.Now()
+	id, err := newDeskEventID(now)
+	if err != nil {
+		return err
+	}
+	event := store.ReviewEventV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            id,
+		PullRequest:   key,
+		Type:          eventType,
+		OccurredAt:    now,
+		Actor:         cfg.Identity.ExpectedUser,
+	}
+	if eventType == store.EventTypeUserResolved {
+		event.HeadObjectID = storedSnapshot.HeadObjectID
+		event.BaseObjectID = storedSnapshot.BaseObjectID
+	}
+	if _, appendErr := store.NewFilesystemEventStore(dataDir).AppendEvent(event); appendErr != nil {
+		return appendErr
+	}
+
+	refreshed, refreshErr := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+
+	if releaseErr := release(); releaseErr != nil {
+		return releaseErr
+	}
+
+	if refreshErr != nil {
+		fmt.Printf("warning: could not refresh desk state: %v\n", refreshErr)
+		return nil
+	}
+	if resultItem, found := findDeskItem(refreshed, key); found {
+		fmt.Printf("Desk state: %s — %s\n", resultItem.DeskState, resultItem.Reason)
+	} else {
+		fmt.Printf("%s is no longer tracked on the desk.\n", key.String())
+	}
+	return nil
+}

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/github"
 	"github.com/richhaase/agentic-code-reviewer/internal/store"
 	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
@@ -101,8 +102,13 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 	}
 	liveItem, foundLive := findDeskItem(inbox, key)
 
-	if eventType == store.EventTypeUserResolved && (!foundLive || liveItem.SnapshotStale) {
-		return fmt.Errorf("%s is not currently visible on the desk with a fresh, live-observed revision; cannot resolve a possibly-stale cached snapshot", key.String())
+	if eventType == store.EventTypeUserResolved {
+		if !foundLive || liveItem.SnapshotStale {
+			return fmt.Errorf("%s is not currently visible on the desk with a fresh, live-observed revision; cannot resolve a possibly-stale cached snapshot", key.String())
+		}
+		if liveItem.DeskState == domain.DeskStateRepositoryUnavailable || liveItem.DeskState == domain.DeskStateWaitingOnOthers {
+			return fmt.Errorf("%s: resolving has no effect while the desk state is %s; nothing was recorded", key.String(), liveItem.DeskState)
+		}
 	}
 	if eventType != store.EventTypeUserResolved {
 		if _, snapErr := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(key); snapErr != nil {

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -95,13 +95,19 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
 	}
 
-	if _, err := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now()); err != nil {
-		return err
+	inbox, refreshErr := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+	if refreshErr != nil {
+		return refreshErr
 	}
+	liveItem, foundLive := findDeskItem(inbox, key)
 
-	storedSnapshot, snapErr := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(key)
-	if snapErr != nil {
-		return fmt.Errorf("%s is not known to the desk; run `acr desk --once` first", key.String())
+	if eventType == store.EventTypeUserResolved && !foundLive {
+		return fmt.Errorf("%s is not currently visible on the desk; cannot resolve a revision that hasn't been freshly observed", key.String())
+	}
+	if eventType != store.EventTypeUserResolved {
+		if _, snapErr := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(key); snapErr != nil {
+			return fmt.Errorf("%s is not known to the desk; run `acr desk --once` first", key.String())
+		}
 	}
 
 	now := time.Now()
@@ -118,24 +124,24 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 		Actor:         cfg.Identity.ExpectedUser,
 	}
 	if eventType == store.EventTypeUserResolved {
-		event.HeadObjectID = storedSnapshot.HeadObjectID
-		event.BaseObjectID = storedSnapshot.BaseObjectID
+		event.HeadObjectID = liveItem.HeadObjectID
+		event.BaseObjectID = liveItem.BaseObjectID
 	}
 	if _, appendErr := store.NewFilesystemEventStore(dataDir).AppendEvent(event); appendErr != nil {
 		return appendErr
 	}
 
-	refreshed, refreshErr := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
+	refreshedAfter, refreshErrAfter := desk.Refresh(ctx, *cfg, dataDir, discovery, time.Now())
 
 	if releaseErr := release(); releaseErr != nil {
 		return releaseErr
 	}
 
-	if refreshErr != nil {
-		fmt.Printf("warning: could not refresh desk state: %v\n", refreshErr)
+	if refreshErrAfter != nil {
+		fmt.Printf("warning: could not refresh desk state: %v\n", refreshErrAfter)
 		return nil
 	}
-	if resultItem, found := findDeskItem(refreshed, key); found {
+	if resultItem, found := findDeskItem(refreshedAfter, key); found {
 		fmt.Printf("Desk state: %s — %s\n", resultItem.DeskState, resultItem.Reason)
 	} else {
 		fmt.Printf("%s is no longer tracked on the desk.\n", key.String())

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -93,7 +93,7 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 	}
 	defer func() { _ = release() }()
 
-	if identityErr := workspace.CheckIdentity(ctx, *cfg, ""); identityErr != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *cfg, key.Host); identityErr != nil {
 		return fmt.Errorf("GitHub identity could not be verified: %w", identityErr)
 	}
 

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -116,6 +116,15 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 			return fmt.Errorf("%s is not known to the desk; run `acr desk --once` first", key.String())
 		}
 	}
+	if eventType == store.EventTypeUserSnoozed {
+		released, releasedErr := currentlyReleased(dataDir, key)
+		if releasedErr != nil {
+			return fmt.Errorf("could not load lifecycle history for %s: %w", key.String(), releasedErr)
+		}
+		if released {
+			return fmt.Errorf("%s is released; snoozing has no effect while released; run `acr desk resume` first", key.String())
+		}
+	}
 
 	now := time.Now()
 	id, err := newDeskEventID(now)
@@ -154,4 +163,18 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 		fmt.Printf("%s is no longer tracked on the desk.\n", key.String())
 	}
 	return nil
+}
+
+func currentlyReleased(dataDir string, key store.PullRequestKeyV1) (bool, error) {
+	eventSchemas, _, err := store.NewFilesystemEventStore(dataDir).ListEvents(key)
+	if err != nil {
+		return false, err
+	}
+	events := make([]domain.LifecycleEvent, 0, len(eventSchemas))
+	for _, schema := range eventSchemas {
+		if event, ok := schema.ToLifecycleEvent(); ok {
+			events = append(events, event)
+		}
+	}
+	return domain.IsReleased(events), nil
 }

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -101,8 +101,8 @@ func runDeskLifecycleAction(ctx context.Context, key store.PullRequestKeyV1, eve
 	}
 	liveItem, foundLive := findDeskItem(inbox, key)
 
-	if eventType == store.EventTypeUserResolved && !foundLive {
-		return fmt.Errorf("%s is not currently visible on the desk; cannot resolve a revision that hasn't been freshly observed", key.String())
+	if eventType == store.EventTypeUserResolved && (!foundLive || liveItem.SnapshotStale) {
+		return fmt.Errorf("%s is not currently visible on the desk with a fresh, live-observed revision; cannot resolve a possibly-stale cached snapshot", key.String())
 	}
 	if eventType != store.EventTypeUserResolved {
 		if _, snapErr := store.NewFilesystemSnapshotStore(dataDir).LoadSnapshot(key); snapErr != nil {

--- a/cmd/acr/desk_lifecycle.go
+++ b/cmd/acr/desk_lifecycle.go
@@ -24,7 +24,8 @@ func newDeskResolveCmd() *cobra.Command {
 
 func newDeskReleaseCmd() *cobra.Command {
 	return newDeskLifecycleCmd("release", "Stop tracking a pull request on the desk",
-		"Release a pull request from the desk workspace entirely. It will reappear only if discovery finds it again.",
+		"Release a pull request from the desk workspace entirely. It stays suppressed even if discovery finds it again; "+
+			"run `acr desk resume` to bring it back onto the desk.",
 		store.EventTypeUserReleased)
 }
 

--- a/cmd/acr/desk_lifecycle_test.go
+++ b/cmd/acr/desk_lifecycle_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -126,6 +128,25 @@ func TestRunDeskLifecycleAction_SnoozeRejectsAlreadyReleasedItem(t *testing.T) {
 
 	if _, ok := loadStoredItem(t, env); ok {
 		t.Fatal("expected the PR to remain untracked; a rejected snooze must not resume tracking")
+	}
+}
+
+func TestRunDeskLifecycleAction_SnoozeFailsClosedOnCorruptLifecycleHistory(t *testing.T) {
+	env := setupDeskLifecycleTest(t, 342)
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	eventsDir := filepath.Join(env.dataDir, "prs", env.key.Host, env.key.Owner, env.key.Repository, "342", "events")
+	if err := os.MkdirAll(eventsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corruptPath := filepath.Join(eventsDir, "20260101T000000.000000000Z-corrupt.json")
+	if err := os.WriteFile(corruptPath, []byte("not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserSnoozed, env.discovery)
+	if err == nil {
+		t.Fatal("expected snooze to fail closed when stored lifecycle history has an unreadable record")
 	}
 }
 

--- a/cmd/acr/desk_lifecycle_test.go
+++ b/cmd/acr/desk_lifecycle_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/desk"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/workspace"
+)
+
+func setupDeskLifecycleTest(t *testing.T, prNumber int) deskActTestEnv {
+	t.Helper()
+
+	fixture := newDispatchGitFixture(t, prNumber)
+
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfigFull(t, configDir, "me", []string{fixture.repoRoot}, false, "disabled")
+
+	key := dispatchPullRequestKey(fixture.host, prNumber)
+	now := time.Now()
+	discovery := &dispatchFixtureDiscovery{
+		searchResult: []domain.PullRequestKey{key.ToDomain()},
+		enrichResponses: []domain.PullRequestSnapshot{
+			dispatchSnapshotWithAuthor(key, "someone-else", fixture.prHeadSHA, fixture.baseSHA, now),
+		},
+	}
+
+	return deskActTestEnv{
+		fixture:   fixture,
+		dataDir:   dataDir,
+		configDir: configDir,
+		key:       key,
+		discovery: discovery,
+	}
+}
+
+func loadStoredItem(t *testing.T, env deskActTestEnv) (desk.Item, bool) {
+	t.Helper()
+	cfg, err := workspace.Load(env.configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := desk.LoadStored(env.dataDir, *cfg, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return findDeskItem(inbox, env.key)
+}
+
+func TestRunDeskLifecycleAction_ResolveMarksItemResolved(t *testing.T) {
+	env := setupDeskLifecycleTest(t, 31)
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	if err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserResolved, env.discovery); err != nil {
+		t.Fatalf("runDeskLifecycleAction failed: %v", err)
+	}
+
+	item, ok := loadStoredItem(t, env)
+	if !ok || item.DeskState != domain.DeskStateResolved {
+		t.Fatalf("expected the item to read as resolved, got %+v (found=%v)", item, ok)
+	}
+}
+
+func TestRunDeskLifecycleAction_ReleaseUntracksItem(t *testing.T) {
+	env := setupDeskLifecycleTest(t, 32)
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	if err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserReleased, env.discovery); err != nil {
+		t.Fatalf("runDeskLifecycleAction failed: %v", err)
+	}
+
+	if _, ok := loadStoredItem(t, env); ok {
+		t.Fatal("expected a released PR to no longer be tracked")
+	}
+}
+
+func TestRunDeskLifecycleAction_ResumeAfterReleaseRetracksItem(t *testing.T) {
+	env := setupDeskLifecycleTest(t, 33)
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	if err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserReleased, env.discovery); err != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+	if _, ok := loadStoredItem(t, env); ok {
+		t.Fatal("expected the PR to be untracked after release")
+	}
+
+	if err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserResumed, env.discovery); err != nil {
+		t.Fatalf("resume failed: %v", err)
+	}
+
+	item, ok := loadStoredItem(t, env)
+	if !ok {
+		t.Fatal("expected the PR to be tracked again after resume")
+	}
+	if item.DeskState == domain.DeskStateResolved {
+		t.Fatalf("did not expect a resumed PR to read as resolved, got %+v", item)
+	}
+}
+
+func TestRunDeskLifecycleAction_SnoozeSuppressesRereviewInFavorOfStale(t *testing.T) {
+	env := setupDeskLifecycleTest(t, 34)
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	run := fakeReviewRun(t, domain.ReviewTarget{})
+	domainKey := env.key.ToDomain()
+	run.Target = domain.ReviewTarget{
+		RepositoryRoot: env.fixture.repoRoot,
+		WorktreeRoot:   env.fixture.repoRoot,
+		Revision: domain.RevisionEvidence{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "main",
+			HeadObjectID:     env.fixture.baseSHA,
+			BaseObjectID:     env.fixture.baseSHA,
+		},
+		PullRequest: &domainKey,
+	}
+	persistRun(t, env.dataDir, run)
+
+	if err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserSnoozed, env.discovery); err != nil {
+		t.Fatalf("runDeskLifecycleAction failed: %v", err)
+	}
+
+	item, ok := loadStoredItem(t, env)
+	if !ok {
+		t.Fatal("expected the PR to still be tracked after snoozing")
+	}
+	if item.DeskState != domain.DeskStateStale {
+		t.Fatalf("expected a snoozed PR with a new head to read as stale (not needs_rereview), got %+v", item)
+	}
+}

--- a/cmd/acr/desk_lifecycle_test.go
+++ b/cmd/acr/desk_lifecycle_test.go
@@ -135,3 +135,34 @@ func TestRunDeskLifecycleAction_SnoozeSuppressesRereviewInFavorOfStale(t *testin
 		t.Fatalf("expected a snoozed PR with a new head to read as stale (not needs_rereview), got %+v", item)
 	}
 }
+
+func TestRunDeskLifecycleAction_ResolveRejectsStateResolutionCannotAffect(t *testing.T) {
+	fixture := newDispatchGitFixture(t, 35)
+
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfigFull(t, configDir, "me", []string{fixture.repoRoot}, false, "disabled")
+
+	key := dispatchPullRequestKey(fixture.host, 35)
+	now := time.Now()
+	discovery := &dispatchFixtureDiscovery{
+		searchResult: []domain.PullRequestKey{key.ToDomain()},
+		enrichResponses: []domain.PullRequestSnapshot{
+			dispatchSnapshotWithAuthor(key, "me", fixture.prHeadSHA, fixture.baseSHA, now),
+		},
+	}
+	env := deskActTestEnv{fixture: fixture, dataDir: dataDir, configDir: configDir, key: key, discovery: discovery}
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserResolved, env.discovery)
+	if err == nil {
+		t.Fatal("expected resolve to be rejected for an own PR waiting on others, since the event would have no effect")
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	if len(events) != 0 {
+		t.Fatalf("expected no event to be recorded, got %+v", events)
+	}
+}

--- a/cmd/acr/desk_lifecycle_test.go
+++ b/cmd/acr/desk_lifecycle_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +41,29 @@ func setupDeskLifecycleTest(t *testing.T, prNumber int) deskActTestEnv {
 		configDir: configDir,
 		key:       key,
 		discovery: discovery,
+	}
+}
+
+func writeWorkspaceConfigWithExclude(t *testing.T, configDir, expectedUser string, repositoryRoots, exclude []string) {
+	t.Helper()
+	writeWorkspaceConfigFull(t, configDir, expectedUser, repositoryRoots, false, "disabled")
+
+	path := workspace.ConfigPath(configDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	quoted := make([]string, len(exclude))
+	for i, pattern := range exclude {
+		quoted[i] = fmt.Sprintf("%q", pattern)
+	}
+	excludeYAML := "[" + strings.Join(quoted, ", ") + "]"
+	updated := strings.Replace(string(data), "exclude: []", "exclude: "+excludeYAML, 1)
+	if updated == string(data) {
+		t.Fatal("expected to find a single 'exclude: []' line to replace in the generated config")
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -128,6 +152,48 @@ func TestRunDeskLifecycleAction_SnoozeRejectsAlreadyReleasedItem(t *testing.T) {
 
 	if _, ok := loadStoredItem(t, env); ok {
 		t.Fatal("expected the PR to remain untracked; a rejected snooze must not resume tracking")
+	}
+}
+
+func TestRunDeskLifecycleAction_RejectsNonResolveActionExcludedFromWorkspaceScope(t *testing.T) {
+	fixture := newDispatchGitFixture(t, 343)
+
+	dataDir := t.TempDir()
+	t.Setenv("ACR_DATA_DIR", dataDir)
+	configDir := t.TempDir()
+	t.Setenv(workspace.ConfigDirEnvVar, configDir)
+	writeWorkspaceConfigFull(t, configDir, "me", []string{fixture.repoRoot}, false, "disabled")
+
+	key := dispatchPullRequestKey(fixture.host, 343)
+	now := time.Now()
+	discovery := &dispatchFixtureDiscovery{
+		searchResult: []domain.PullRequestKey{key.ToDomain()},
+		enrichResponses: []domain.PullRequestSnapshot{
+			dispatchSnapshotWithAuthor(key, "someone-else", fixture.prHeadSHA, fixture.baseSHA, now),
+		},
+	}
+	env := deskActTestEnv{fixture: fixture, dataDir: dataDir, configDir: configDir, key: key, discovery: discovery}
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	if err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserReleased, env.discovery); err != nil {
+		t.Fatalf("release failed while item was still in scope: %v", err)
+	}
+
+	writeWorkspaceConfigWithExclude(t, configDir, "me", []string{fixture.repoRoot}, []string{"acme/widgets"})
+
+	err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserResumed, env.discovery)
+	if err == nil {
+		t.Fatal("expected resume to be rejected once the item is excluded by workspace scope")
+	}
+	if !strings.Contains(err.Error(), "excluded") {
+		t.Fatalf("expected the error to explain scope exclusion, got %q", err.Error())
+	}
+
+	events := loadEvents(t, env.dataDir, env.key)
+	for _, event := range events {
+		if event.Type == store.EventTypeUserResumed {
+			t.Fatal("expected no resume event to be recorded once the item is excluded by workspace scope")
+		}
 	}
 }
 

--- a/cmd/acr/desk_lifecycle_test.go
+++ b/cmd/acr/desk_lifecycle_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,6 +102,30 @@ func TestRunDeskLifecycleAction_ResumeAfterReleaseRetracksItem(t *testing.T) {
 	}
 	if item.DeskState == domain.DeskStateResolved {
 		t.Fatalf("did not expect a resumed PR to read as resolved, got %+v", item)
+	}
+}
+
+func TestRunDeskLifecycleAction_SnoozeRejectsAlreadyReleasedItem(t *testing.T) {
+	env := setupDeskLifecycleTest(t, 341)
+	withFakeGH(t, fakeGHResponses{user: "me"})
+
+	if err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserReleased, env.discovery); err != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+	if _, ok := loadStoredItem(t, env); ok {
+		t.Fatal("expected the PR to be untracked after release")
+	}
+
+	err := runDeskLifecycleAction(context.Background(), env.key, store.EventTypeUserSnoozed, env.discovery)
+	if err == nil {
+		t.Fatal("expected snoozing an already released item to be rejected")
+	}
+	if !strings.Contains(err.Error(), "released") {
+		t.Fatalf("expected the error to explain the item is released, got %q", err.Error())
+	}
+
+	if _, ok := loadStoredItem(t, env); ok {
+		t.Fatal("expected the PR to remain untracked; a rejected snooze must not resume tracking")
 	}
 }
 

--- a/cmd/acr/desk_once.go
+++ b/cmd/acr/desk_once.go
@@ -44,7 +44,7 @@ func runDeskOnce(jsonOutput bool) error {
 	}
 
 	ctx := context.Background()
-	if identityErr := workspace.CheckIdentity(ctx, *cfg); identityErr != nil {
+	if identityErr := workspace.CheckIdentity(ctx, *cfg, ""); identityErr != nil {
 		if releaseErr := lock.Release(); releaseErr != nil {
 			return fmt.Errorf("%w (also failed to release desk lock: %v)", identityErr, releaseErr)
 		}

--- a/cmd/acr/outcome.go
+++ b/cmd/acr/outcome.go
@@ -11,6 +11,9 @@ const (
 	OutcomeLGTMDeclined
 	OutcomeLGTMSkipped
 	OutcomeStaleHead
+	OutcomeReviewComment
+	OutcomeReviewRequestChanges
+	OutcomeReviewSkipped
 )
 
 type CycleOutcome struct {

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -17,6 +17,8 @@ import (
 
 const maxDisplayedCIChecks = 5
 
+var errRevisionMovedSinceReview = errors.New("pull request revision moved since the review")
+
 type prContext struct {
 	number       string
 	isSelfReview bool
@@ -260,14 +262,21 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 		}
 	}
 
-	if headMovedSinceReview(ctx, opts, pr.number, logger) {
-		opts.record(OutcomeStaleHead)
-		return nil
-	}
-
 	if err := retrySubmission(ctx, func() error {
+		if headMovedSinceReview(ctx, opts, pr.number, logger) {
+			return errRevisionMovedSinceReview
+		}
+		if opts.PreSubmitCheck != nil {
+			if checkErr := opts.PreSubmitCheck(); checkErr != nil {
+				return checkErr
+			}
+		}
 		return github.SubmitPRReview(ctx, opts.RepositoryRoot, pr.number, body, requestChanges)
 	}, opts.Outcome != nil, logger); err != nil {
+		if errors.Is(err, errRevisionMovedSinceReview) {
+			opts.record(OutcomeStaleHead)
+			return nil
+		}
 		logger.Logf(terminal.StyleError, "Failed: %v", err)
 		return err
 	}
@@ -350,14 +359,21 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		}
 	}
 
-	if headMovedSinceReview(ctx, opts, pr.number, logger) {
-		opts.record(OutcomeStaleHead)
-		return nil
-	}
-
 	if err := retrySubmission(ctx, func() error {
+		if headMovedSinceReview(ctx, opts, pr.number, logger) {
+			return errRevisionMovedSinceReview
+		}
+		if opts.PreSubmitCheck != nil {
+			if checkErr := opts.PreSubmitCheck(); checkErr != nil {
+				return checkErr
+			}
+		}
 		return executeLGTMAction(ctx, opts.RepositoryRoot, action, pr.number, body, logger)
 	}, opts.Outcome != nil, logger); err != nil {
+		if errors.Is(err, errRevisionMovedSinceReview) {
+			opts.record(OutcomeStaleHead)
+			return nil
+		}
 		return err
 	}
 	if action == actionApprove {

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -202,7 +202,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 
 	requestChanges := !pr.isSelfReview && !opts.ForcePostComment
 
-	if !opts.AutoYes {
+	if !opts.AutoYes && !opts.SkipReviewTypePrompt {
 
 		if !terminal.IsStdinTTY() {
 			logger.Log("Non-interactive mode without --yes flag; skipping PR review.", terminal.StyleDim)
@@ -311,7 +311,7 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		action = actionComment
 	}
 
-	if !opts.AutoYes {
+	if !opts.AutoYes && !opts.SkipReviewTypePrompt {
 		if !terminal.IsStdinTTY() {
 			logger.Log("Non-interactive mode without --yes flag; skipping LGTM.", terminal.StyleDim)
 			opts.record(OutcomeLGTMSkipped)

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -263,13 +263,13 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 	}
 
 	if err := retrySubmission(ctx, func() error {
-		if headMovedSinceReview(ctx, opts, pr.number, logger) {
-			return errRevisionMovedSinceReview
-		}
 		if opts.PreSubmitCheck != nil {
 			if checkErr := opts.PreSubmitCheck(); checkErr != nil {
 				return checkErr
 			}
+		}
+		if headMovedSinceReview(ctx, opts, pr.number, logger) {
+			return errRevisionMovedSinceReview
 		}
 		return github.SubmitPRReview(ctx, opts.RepositoryRoot, pr.number, body, requestChanges)
 	}, opts.Outcome != nil, logger); err != nil {
@@ -360,13 +360,13 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 	}
 
 	if err := retrySubmission(ctx, func() error {
-		if headMovedSinceReview(ctx, opts, pr.number, logger) {
-			return errRevisionMovedSinceReview
-		}
 		if opts.PreSubmitCheck != nil {
 			if checkErr := opts.PreSubmitCheck(); checkErr != nil {
 				return checkErr
 			}
+		}
+		if headMovedSinceReview(ctx, opts, pr.number, logger) {
+			return errRevisionMovedSinceReview
 		}
 		return executeLGTMAction(ctx, opts.RepositoryRoot, action, pr.number, body, logger)
 	}, opts.Outcome != nil, logger); err != nil {

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -156,12 +156,18 @@ func handleFindings(ctx context.Context, opts ReviewOpts, grouped domain.Grouped
 		}
 		if canceled {
 			logger.Log("Skipped posting findings.", terminal.StyleDim)
+			opts.record(OutcomeReviewSkipped)
 			return domain.ExitFindings
 		}
 		selectedFindings = filterFindingsByIndices(grouped.Findings, indices)
 
 		if len(selectedFindings) == 0 {
 			logger.Log("No findings selected to post.", terminal.StyleDim)
+
+			if opts.SuppressZeroSelectionFallback {
+				opts.record(OutcomeReviewSkipped)
+				return domain.ExitFindings
+			}
 
 			lgtmBody := runner.RenderDismissedLGTMMarkdown(grouped.Findings, stats, version)
 			pr := getPRContext(ctx, opts)
@@ -427,15 +433,24 @@ func headMovedSinceReview(ctx context.Context, opts ReviewOpts, prNumber string,
 	if opts.ExpectedHeadSHA == "" {
 		return false
 	}
+	strict := opts.ExpectedBaseSHA != ""
 	st, err := github.GetPRWatchState(ctx, opts.RepositoryRoot, prNumber)
 	if err != nil || st.HeadSHA == "" {
+		if strict {
+			logger.Logf(terminal.StyleWarning, "could not verify the current PR revision; treating as stale.")
+			return true
+		}
 		return false
 	}
-	if strings.EqualFold(st.HeadSHA, opts.ExpectedHeadSHA) {
-		return false
+	if !strings.EqualFold(st.HeadSHA, opts.ExpectedHeadSHA) {
+		logger.Logf(terminal.StyleWarning, "PR head moved since the review; skipping post (the new head will be re-reviewed).")
+		return true
 	}
-	logger.Logf(terminal.StyleWarning, "PR head moved since the review; skipping post (the new head will be re-reviewed).")
-	return true
+	if strict && !strings.EqualFold(st.BaseSHA, opts.ExpectedBaseSHA) {
+		logger.Logf(terminal.StyleWarning, "PR base moved since the review; skipping post (the revision will be re-reviewed).")
+		return true
+	}
+	return false
 }
 
 func logCIChecks(logger *terminal.Logger, checks []string) {
@@ -468,6 +483,7 @@ func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmActi
 		fmt.Print(formatPrompt("Post as comment instead?", "[C]omment (default) / [S]kip:"))
 		switch readUserInput() {
 		case "", "c", "y", "yes":
+			opts.Outcome.CIDowngraded = true
 			return actionComment, nil
 		default:
 			logger.Log("Skipped posting LGTM.", terminal.StyleDim)
@@ -506,6 +522,9 @@ func checkCIAndMaybeDowngrade(ctx context.Context, prNum string, action lgtmActi
 
 	switch response {
 	case "", "c", "y", "yes":
+		if opts.Outcome != nil {
+			opts.Outcome.CIDowngraded = true
+		}
 		return actionComment, nil
 	default:
 		logger.Log("Skipped posting LGTM.", terminal.StyleDim)

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -459,6 +459,10 @@ func headMovedSinceReview(ctx context.Context, opts ReviewOpts, prNumber string,
 		}
 		return false
 	}
+	if st.Closed() || st.Merged() {
+		logger.Logf(terminal.StyleWarning, "PR closed or merged since the review; skipping post.")
+		return true
+	}
 	if !strings.EqualFold(st.HeadSHA, opts.ExpectedHeadSHA) {
 		logger.Logf(terminal.StyleWarning, "PR head moved since the review; skipping post (the new head will be re-reviewed).")
 		return true

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -423,7 +423,7 @@ const submissionAttempts = 3
 
 func retrySubmission(ctx context.Context, submit func() error, watchMode bool, logger *terminal.Logger) error {
 	err := submit()
-	if err == nil || !watchMode {
+	if err == nil || !watchMode || errors.Is(err, errRevisionMovedSinceReview) {
 		return err
 	}
 	for attempt := 2; attempt <= submissionAttempts; attempt++ {
@@ -438,8 +438,8 @@ func retrySubmission(ctx context.Context, submit func() error, watchMode bool, l
 			return err
 		case <-timer.C:
 		}
-		if err = submit(); err == nil {
-			return nil
+		if err = submit(); err == nil || errors.Is(err, errRevisionMovedSinceReview) {
+			return err
 		}
 	}
 	return err

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -33,7 +33,7 @@ func getPRContext(ctx context.Context, opts ReviewOpts) prContext {
 	if opts.PRNumber != "" {
 		return prContext{
 			number:       opts.PRNumber,
-			isSelfReview: github.IsSelfReview(ctx, opts.RepositoryRoot, opts.PRNumber),
+			isSelfReview: resolveSelfReview(ctx, opts, opts.PRNumber),
 		}
 	}
 
@@ -43,8 +43,15 @@ func getPRContext(ctx context.Context, opts ReviewOpts) prContext {
 	}
 	return prContext{
 		number:       foundPR,
-		isSelfReview: github.IsSelfReview(ctx, opts.RepositoryRoot, foundPR),
+		isSelfReview: resolveSelfReview(ctx, opts, foundPR),
 	}
+}
+
+func resolveSelfReview(ctx context.Context, opts ReviewOpts, prNumber string) bool {
+	if opts.KnownSelfReview != nil {
+		return *opts.KnownSelfReview
+	}
+	return github.IsSelfReview(ctx, opts.RepositoryRoot, prNumber)
 }
 
 func checkPRAvailable(pr prContext, opts ReviewOpts, logger *terminal.Logger) (bool, error) {

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -272,7 +272,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 			return errRevisionMovedSinceReview
 		}
 		return github.SubmitPRReview(ctx, opts.RepositoryRoot, pr.number, body, requestChanges)
-	}, opts.Outcome != nil, logger); err != nil {
+	}, opts.AllowSubmissionRetry, logger); err != nil {
 		if errors.Is(err, errRevisionMovedSinceReview) {
 			opts.record(OutcomeStaleHead)
 			return nil
@@ -369,7 +369,7 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 			return errRevisionMovedSinceReview
 		}
 		return executeLGTMAction(ctx, opts.RepositoryRoot, action, pr.number, body, logger)
-	}, opts.Outcome != nil, logger); err != nil {
+	}, opts.AllowSubmissionRetry, logger); err != nil {
 		if errors.Is(err, errRevisionMovedSinceReview) {
 			opts.record(OutcomeStaleHead)
 			return nil

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -206,6 +206,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 
 		if !terminal.IsStdinTTY() {
 			logger.Log("Non-interactive mode without --yes flag; skipping PR review.", terminal.StyleDim)
+			opts.record(OutcomeReviewSkipped)
 			return nil
 		}
 
@@ -227,6 +228,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 			switch response {
 			case "s", "n", "no":
 				logger.Log("Skipped posting review.", terminal.StyleDim)
+				opts.record(OutcomeReviewSkipped)
 				return nil
 			default:
 				requestChanges = false
@@ -237,6 +239,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 				requestChanges = false
 			case "s", "n", "no":
 				logger.Log("Skipped posting review.", terminal.StyleDim)
+				opts.record(OutcomeReviewSkipped)
 				return nil
 			default:
 				requestChanges = true
@@ -266,6 +269,11 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, opts
 	reviewType := "request changes"
 	if !requestChanges {
 		reviewType = "comment"
+	}
+	if requestChanges {
+		opts.record(OutcomeReviewRequestChanges)
+	} else {
+		opts.record(OutcomeReviewComment)
 	}
 	logger.Logf(terminal.StyleSuccess, "Posted %s review to PR #%s.", reviewType, pr.number)
 	return nil

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -374,6 +374,7 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 			opts.record(OutcomeStaleHead)
 			return nil
 		}
+		logger.Logf(terminal.StyleError, "Failed: %v", err)
 		return err
 	}
 	if action == actionApprove {

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -22,7 +22,8 @@ type ReviewOpts struct {
 	ConfigSource    config.SourceIdentity
 	Trigger         domain.ReviewTrigger
 
-	ForcePostComment bool
-	ExpectedHeadSHA  string
-	Outcome          *CycleOutcome
+	ForcePostComment     bool
+	SkipReviewTypePrompt bool
+	ExpectedHeadSHA      string
+	Outcome              *CycleOutcome
 }

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -22,8 +22,10 @@ type ReviewOpts struct {
 	ConfigSource    config.SourceIdentity
 	Trigger         domain.ReviewTrigger
 
-	ForcePostComment     bool
-	SkipReviewTypePrompt bool
-	ExpectedHeadSHA      string
-	Outcome              *CycleOutcome
+	ForcePostComment              bool
+	SkipReviewTypePrompt          bool
+	SuppressZeroSelectionFallback bool
+	ExpectedHeadSHA               string
+	ExpectedBaseSHA               string
+	Outcome                       *CycleOutcome
 }

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -27,5 +27,6 @@ type ReviewOpts struct {
 	SuppressZeroSelectionFallback bool
 	ExpectedHeadSHA               string
 	ExpectedBaseSHA               string
+	PreSubmitCheck                func() error
 	Outcome                       *CycleOutcome
 }

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -29,4 +29,5 @@ type ReviewOpts struct {
 	ExpectedBaseSHA               string
 	PreSubmitCheck                func() error
 	Outcome                       *CycleOutcome
+	AllowSubmissionRetry          bool
 }

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -30,4 +30,5 @@ type ReviewOpts struct {
 	PreSubmitCheck                func() error
 	Outcome                       *CycleOutcome
 	AllowSubmissionRetry          bool
+	KnownSelfReview               *bool
 }

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -164,7 +164,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		MaxDuration:  cfgResult.resolved.WatchMaxDuration,
 	}
 
-	currentUser := github.GetCurrentUser(ctx, repoRoot)
+	currentUser := github.GetCurrentUser(ctx, github.GetRepositoryHost(ctx, repoRoot))
 	if currentUser == "" {
 		logger.Log("Could not determine the authenticated gh user; re-review request triggers are disabled.", terminal.StyleWarning)
 	}

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -254,20 +254,21 @@ func resolveInitialTrustedReviewConfiguration(
 
 func buildWatchReviewOpts(cfgResult configResult, wt worktreeResult, watchPR string, mode watch.PostMode, reviewedHead string, outcome *CycleOutcome) ReviewOpts {
 	return ReviewOpts{
-		ResolvedConfig:   cfgResult.resolved,
-		Verbose:          verbose,
-		AutoYes:          mode != watch.PostModeInteractive,
-		PRNumber:         watchPR,
-		DetectedPR:       watchPR,
-		UseRefFile:       refFile,
-		ExcludePatterns:  cfgResult.excludePatterns,
-		RepositoryRoot:   wt.repositoryRoot,
-		WorkDir:          wt.workDir,
-		ForcePostComment: mode == watch.PostModeComment,
-		ExpectedHeadSHA:  reviewedHead,
-		Outcome:          outcome,
-		ConfigSource:     cfgResult.source,
-		Trigger:          domain.ReviewTriggerWatch,
+		ResolvedConfig:       cfgResult.resolved,
+		Verbose:              verbose,
+		AutoYes:              mode != watch.PostModeInteractive,
+		PRNumber:             watchPR,
+		DetectedPR:           watchPR,
+		UseRefFile:           refFile,
+		ExcludePatterns:      cfgResult.excludePatterns,
+		RepositoryRoot:       wt.repositoryRoot,
+		WorkDir:              wt.workDir,
+		ForcePostComment:     mode == watch.PostModeComment,
+		ExpectedHeadSHA:      reviewedHead,
+		Outcome:              outcome,
+		AllowSubmissionRetry: true,
+		ConfigSource:         cfgResult.source,
+		Trigger:              domain.ReviewTriggerWatch,
 	}
 }
 

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -164,7 +164,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		MaxDuration:  cfgResult.resolved.WatchMaxDuration,
 	}
 
-	currentUser := github.GetCurrentUser(ctx)
+	currentUser := github.GetCurrentUser(ctx, repoRoot)
 	if currentUser == "" {
 		logger.Log("Could not determine the authenticated gh user; re-review request triggers are disabled.", terminal.StyleWarning)
 	}

--- a/cmd/acr/watch_cmd_test.go
+++ b/cmd/acr/watch_cmd_test.go
@@ -345,6 +345,9 @@ func TestBuildWatchReviewOptsProducesRequestScopedToWatchTrigger(t *testing.T) {
 	if opts.ConfigSource != cfgResult.source {
 		t.Fatalf("opts.ConfigSource = %#v, want %#v", opts.ConfigSource, cfgResult.source)
 	}
+	if !opts.AllowSubmissionRetry {
+		t.Fatal("watch must allow submission retries; a fresh cycle makes retrying a non-idempotent post safe")
+	}
 
 	sink := &noopReviewEventSink{}
 	request, err := newReviewRequest(opts, cfgResult.resolved.Base, sink)

--- a/internal/desk/inbox.go
+++ b/internal/desk/inbox.go
@@ -77,7 +77,7 @@ func Refresh(ctx context.Context, cfg workspace.Config, dataDir string, discover
 	for _, key := range tracked {
 		trackedKey := key.ToDomain()
 		if !discoveryIncomplete && !containsKeyIdentity(discovered, trackedKey) {
-			if scopeExcludesKey(cfg, key) {
+			if ScopeExcludesKey(cfg, key) {
 				continue
 			}
 			hasHistory, historyErr := trackedKeyHasHistory(dataDir, key)
@@ -95,7 +95,7 @@ func Refresh(ctx context.Context, cfg workspace.Config, dataDir string, discover
 	for _, key := range keys {
 		schemaKey := store.ToPullRequestKeySchema(key)
 
-		if scopeExcludesKey(cfg, schemaKey) {
+		if ScopeExcludesKey(cfg, schemaKey) {
 			continue
 		}
 		if events, _, eventsErr := loadDomainEvents(dataDir, schemaKey); eventsErr == nil && domain.IsReleased(events) {
@@ -152,7 +152,7 @@ func LoadStored(dataDir string, cfg workspace.Config, now time.Time) (Inbox, err
 	inbox.Warnings = append(inbox.Warnings, resolution.RootWarnings...)
 
 	for _, schemaKey := range tracked {
-		if scopeExcludesKey(cfg, schemaKey) {
+		if ScopeExcludesKey(cfg, schemaKey) {
 			continue
 		}
 
@@ -196,7 +196,7 @@ func loadDomainEvents(dataDir string, key store.PullRequestKeyV1) ([]domain.Life
 	return events, corrupt, nil
 }
 
-func scopeExcludesKey(cfg workspace.Config, key store.PullRequestKeyV1) bool {
+func ScopeExcludesKey(cfg workspace.Config, key store.PullRequestKeyV1) bool {
 	identity := repos.Identity{
 		Host:  strings.ToLower(key.Host),
 		Owner: strings.ToLower(key.Owner),

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -446,8 +446,9 @@ func CheckGHAvailable() error {
 	return nil
 }
 
-func GetCurrentUser(ctx context.Context) string {
+func GetCurrentUser(ctx context.Context, repositoryRoot string) string {
 	cmd := exec.CommandContext(ctx, "gh", "api", "user", "--jq", ".login")
+	cmd.Dir = repositoryRoot
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -466,7 +467,7 @@ func GetPRAuthor(ctx context.Context, repositoryRoot, prNumber string) string {
 }
 
 func IsSelfReview(ctx context.Context, repositoryRoot, prNumber string) bool {
-	currentUser := GetCurrentUser(ctx)
+	currentUser := GetCurrentUser(ctx, repositoryRoot)
 	prAuthor := GetPRAuthor(ctx, repositoryRoot, prNumber)
 	return checkSelfReview(currentUser, prAuthor)
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -446,14 +446,31 @@ func CheckGHAvailable() error {
 	return nil
 }
 
-func GetCurrentUser(ctx context.Context, repositoryRoot string) string {
-	cmd := exec.CommandContext(ctx, "gh", "api", "user", "--jq", ".login")
-	cmd.Dir = repositoryRoot
+func GetCurrentUser(ctx context.Context, host string) string {
+	args := []string{"api", "user", "--jq", ".login"}
+	if host != "" {
+		args = append(args, "--hostname", host)
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func GetRepositoryHost(ctx context.Context, repositoryRoot string) string {
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "url", "--jq", ".url")
+	cmd.Dir = repositoryRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	host, _, _, ok := ParseRemoteURL(strings.TrimSpace(string(out)))
+	if !ok {
+		return ""
+	}
+	return host
 }
 
 func GetPRAuthor(ctx context.Context, repositoryRoot, prNumber string) string {
@@ -467,7 +484,7 @@ func GetPRAuthor(ctx context.Context, repositoryRoot, prNumber string) string {
 }
 
 func IsSelfReview(ctx context.Context, repositoryRoot, prNumber string) bool {
-	currentUser := GetCurrentUser(ctx, repositoryRoot)
+	currentUser := GetCurrentUser(ctx, GetRepositoryHost(ctx, repositoryRoot))
 	prAuthor := GetPRAuthor(ctx, repositoryRoot, prNumber)
 	return checkSelfReview(currentUser, prAuthor)
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -371,6 +371,7 @@ func ParseCIChecks(data []byte) CIStatus {
 
 type PRWatchState struct {
 	HeadSHA        string
+	BaseSHA        string
 	State          string
 	ReviewRequests []string
 	TeamRequests   []string
@@ -393,7 +394,7 @@ func (s PRWatchState) ReviewRequestedFrom(login string) bool {
 }
 
 func GetPRWatchState(ctx context.Context, repositoryRoot, prNumber string) (PRWatchState, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "headRefOid,state,reviewRequests")
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "headRefOid,baseRefOid,state,reviewRequests")
 	cmd.Dir = repositoryRoot
 	out, err := cmd.Output()
 	if err != nil {
@@ -405,6 +406,7 @@ func GetPRWatchState(ctx context.Context, repositoryRoot, prNumber string) (PRWa
 func ParsePRWatchState(data []byte) (PRWatchState, error) {
 	var resp struct {
 		HeadRefOid     string `json:"headRefOid"`
+		BaseRefOid     string `json:"baseRefOid"`
 		State          string `json:"state"`
 		ReviewRequests []struct {
 			Login string `json:"login"`
@@ -417,6 +419,7 @@ func ParsePRWatchState(data []byte) (PRWatchState, error) {
 
 	state := PRWatchState{
 		HeadSHA: resp.HeadRefOid,
+		BaseSHA: resp.BaseRefOid,
 		State:   resp.State,
 	}
 	for _, r := range resp.ReviewRequests {

--- a/internal/github/repo_scope_test.go
+++ b/internal/github/repo_scope_test.go
@@ -197,13 +197,41 @@ func TestGetPRAuthor_ScopesToRepositoryRoot(t *testing.T) {
 	}
 }
 
-func TestGetCurrentUser_ScopesToRepositoryRoot(t *testing.T) {
-	repoRoot := t.TempDir()
+func TestGetCurrentUser_PassesHostnameFlagWhenHostKnown(t *testing.T) {
 	scriptDir := setupMockGH(t, "octocat")
 
-	user := GetCurrentUser(context.Background(), repoRoot)
+	user := GetCurrentUser(context.Background(), "ghe.example.com")
 	if user != "octocat" {
 		t.Errorf("expected octocat, got %q", user)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || !strings.Contains(args[0], "--hostname ghe.example.com") {
+		t.Errorf("expected gh invoked with --hostname ghe.example.com, got %v", args)
+	}
+}
+
+func TestGetCurrentUser_OmitsHostnameFlagWhenHostUnknown(t *testing.T) {
+	scriptDir := setupMockGH(t, "octocat")
+
+	user := GetCurrentUser(context.Background(), "")
+	if user != "octocat" {
+		t.Errorf("expected octocat, got %q", user)
+	}
+
+	args := readCapturedArgs(t, scriptDir)
+	if len(args) != 1 || strings.Contains(args[0], "--hostname") {
+		t.Errorf("expected gh invoked without --hostname, got %v", args)
+	}
+}
+
+func TestGetRepositoryHost_ScopesToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGH(t, "https://ghe.example.com/acme/widgets")
+
+	host := GetRepositoryHost(context.Background(), repoRoot)
+	if host != "ghe.example.com" {
+		t.Errorf("expected ghe.example.com, got %q", host)
 	}
 
 	cwds := readCapturedCwd(t, scriptDir)
@@ -212,11 +240,12 @@ func TestGetCurrentUser_ScopesToRepositoryRoot(t *testing.T) {
 	}
 }
 
-func TestIsSelfReview_BothGHCallsScopeToRepositoryRoot(t *testing.T) {
+func TestIsSelfReview_ResolvesHostAndScopesEveryGHCallCorrectly(t *testing.T) {
 	repoRoot := t.TempDir()
 	scriptDir := setupMockGHRoutedByArgs(t, map[string]string{
-		"api user": "octocat",
-		"pr view":  "octocat",
+		"repo view": "https://ghe.example.com/acme/widgets",
+		"api user":  "octocat",
+		"pr view":   "octocat",
 	})
 
 	if !IsSelfReview(context.Background(), repoRoot, "7") {
@@ -225,15 +254,19 @@ func TestIsSelfReview_BothGHCallsScopeToRepositoryRoot(t *testing.T) {
 
 	cwds := readCapturedCwd(t, scriptDir)
 	args := readCapturedArgs(t, scriptDir)
-	if len(cwds) != 2 || len(args) != 2 {
-		t.Fatalf("expected 2 gh invocations (current user + pr author), got cwds=%v args=%v", cwds, args)
+	if len(cwds) != 3 || len(args) != 3 {
+		t.Fatalf("expected 3 gh invocations (repo host + current user + pr author), got cwds=%v args=%v", cwds, args)
 	}
 
 	for i, a := range args {
 		switch {
-		case strings.HasPrefix(a, "api user"):
+		case strings.HasPrefix(a, "repo view"):
 			if cwds[i] != resolvedDir(t, repoRoot) {
-				t.Errorf("expected GetCurrentUser to run in %s, got %s", resolvedDir(t, repoRoot), cwds[i])
+				t.Errorf("expected repo host resolution to run in %s, got %s", resolvedDir(t, repoRoot), cwds[i])
+			}
+		case strings.HasPrefix(a, "api user"):
+			if !strings.Contains(a, "--hostname ghe.example.com") {
+				t.Errorf("expected GetCurrentUser to pass --hostname ghe.example.com, got %q", a)
 			}
 		case strings.HasPrefix(a, "pr view"):
 			if cwds[i] != resolvedDir(t, repoRoot) {

--- a/internal/github/repo_scope_test.go
+++ b/internal/github/repo_scope_test.go
@@ -197,6 +197,21 @@ func TestGetPRAuthor_ScopesToRepositoryRoot(t *testing.T) {
 	}
 }
 
+func TestGetCurrentUser_ScopesToRepositoryRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptDir := setupMockGH(t, "octocat")
+
+	user := GetCurrentUser(context.Background(), repoRoot)
+	if user != "octocat" {
+		t.Errorf("expected octocat, got %q", user)
+	}
+
+	cwds := readCapturedCwd(t, scriptDir)
+	if len(cwds) != 1 || cwds[0] != resolvedDir(t, repoRoot) {
+		t.Errorf("expected gh invoked in %s, got %v", resolvedDir(t, repoRoot), cwds)
+	}
+}
+
 func TestIsSelfReview_BothGHCallsScopeToRepositoryRoot(t *testing.T) {
 	repoRoot := t.TempDir()
 	scriptDir := setupMockGHRoutedByArgs(t, map[string]string{
@@ -217,8 +232,8 @@ func TestIsSelfReview_BothGHCallsScopeToRepositoryRoot(t *testing.T) {
 	for i, a := range args {
 		switch {
 		case strings.HasPrefix(a, "api user"):
-			if cwds[i] == resolvedDir(t, repoRoot) {
-				t.Errorf("expected GetCurrentUser (host-scoped, not repo-scoped) to NOT run in %s", repoRoot)
+			if cwds[i] != resolvedDir(t, repoRoot) {
+				t.Errorf("expected GetCurrentUser to run in %s, got %s", resolvedDir(t, repoRoot), cwds[i])
 			}
 		case strings.HasPrefix(a, "pr view"):
 			if cwds[i] != resolvedDir(t, repoRoot) {

--- a/internal/workspace/policy.go
+++ b/internal/workspace/policy.go
@@ -72,8 +72,8 @@ func (c Config) RequirePosting() error {
 	return nil
 }
 
-func CheckIdentity(ctx context.Context, c Config, repositoryRoot string) error {
-	return matchIdentity(github.GetCurrentUser(ctx, repositoryRoot), c.Identity.ExpectedUser)
+func CheckIdentity(ctx context.Context, c Config, host string) error {
+	return matchIdentity(github.GetCurrentUser(ctx, host), c.Identity.ExpectedUser)
 }
 
 func matchIdentity(actual, expected string) error {

--- a/internal/workspace/policy.go
+++ b/internal/workspace/policy.go
@@ -72,8 +72,8 @@ func (c Config) RequirePosting() error {
 	return nil
 }
 
-func CheckIdentity(ctx context.Context, c Config) error {
-	return matchIdentity(github.GetCurrentUser(ctx), c.Identity.ExpectedUser)
+func CheckIdentity(ctx context.Context, c Config, repositoryRoot string) error {
+	return matchIdentity(github.GetCurrentUser(ctx, repositoryRoot), c.Identity.ExpectedUser)
 }
 
 func matchIdentity(actual, expected string) error {


### PR DESCRIPTION
## Summary

- Adds `acr desk act <[host/]owner/repo#number> --approve|--comment|--request-changes [--yes]`, the guarded GitHub-mutating action flow from #206. It loads the stored decision-ready `domain.ReviewRun` for the item's current head and reuses the **existing** finding-selector and posting machinery (`handleTypedReviewRun` → `handleFindings`/`handleLGTM` → `confirmAndSubmitReview`/`confirmAndSubmitLGTM` → `github.ApprovePR`/`SubmitPRReview`) rather than duplicating it — the plain `acr` CLI's self-review comment-only downgrade and stale-head guard (`headMovedSinceReview`, already used by `watch`) come along for free.
- Adds `acr desk resolve|release|resume|snooze <ref>` as local lifecycle actions on top of the (previously entirely unused) lifecycle event vocabulary from earlier phases.
- Small, backward-compatible extension to `cmd/acr/outcome.go`/`pr_submit.go`: three new `OutcomeKind` values (`OutcomeReviewComment`/`OutcomeReviewRequestChanges`/`OutcomeReviewSkipped`) recorded at the same points `confirmAndSubmitReview` already decides comment vs. request-changes vs. skip, giving `desk act` a reliable signal for what actually happened without touching its control flow — mirrors the granularity `confirmAndSubmitLGTM` already had.

## Acceptance criteria (#206)

- [x] **A moved head prevents posting and leaves an auditable stale result** — `headMovedSinceReview`'s existing live head check aborts posting; `desk act` then appends a `review_stale` event (with `prior_head_object_id`) visible via `acr desk history`.
- [x] **Posting-disabled workspaces cannot mutate GitHub** — `cfg.RequirePosting()` (previously unused scaffolding) fails closed before the write lock is even acquired.
- [x] **Identity mismatch fails closed immediately before mutation** — `workspace.CheckIdentity` runs before any repository/run work.
- [x] **Self-authored PRs cannot be approved or receive request-changes from ACR** — the existing `github.IsSelfReview`-driven downgrade in `confirmAndSubmitReview`/`confirmAndSubmitLGTM` forces comment-only; verified in an integration test that a self-authored `--approve` posts `--comment` instead.
- [x] **Confirmation and selected-finding behavior are covered by integration tests** — see below.

## Design notes / scope decisions

- Successful actions record exactly one `action_{comment,request_changes,approval}_posted` event. That alone is sufficient for `domain.Classify`'s existing `latestResolutionEvent` check to mark the item resolved on the next refresh — no new domain concept needed, and per-finding `finding_selected`/`finding_dismissed` bookkeeping is deferred (real value there is Phase 9's reconciliation work, not this slice).
- "rerun" needs no new code — it's already `acr desk dispatch <ref>` from #205.
- "open in GitHub" isn't a new command — the PR URL is already shown in `acr desk --once`/`history` output.
- `--approve` is only valid when the stored run concluded clean; `--request-changes` only when it has findings; `--comment` works either way — mirroring the product rule the existing `handleLGTM`/`handleFindings` split already encodes.

## Test plan

- [x] `make check` (build, lint, vet, staticcheck, full unit test suite)
- [x] CI-simulated: `HOME=$(mktemp -d) GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null make check`
- [x] `go test ./... -race` clean
- [x] New `cmd/acr/desk_act_test.go` (extends the `desk_dispatch_test.go` fake-`gh` harness with `pr view --json headRefOid,...`/`author`/`pr checks`/`pr review` cases): approve on a clean review, request-changes and comment on a findings review, posting-disabled fails closed, identity-mismatch fails closed, self-authored PR downgrades to comment, stale head skips posting and records the audit event.
- [x] New `cmd/acr/desk_lifecycle_test.go`: resolve marks the item resolved, release fully untracks it, resume re-tracks a released item, snooze reads as stale instead of needs-rereview.

Closes #206.