### PR TITLE
Add interactive watcher retrigger

### DIFF
--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -204,7 +204,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 			return runWatchCycle(ctx, cmd, watchPR, mode, logger)
 		},
 	}
-	if terminal.IsStdinTTY() {
+	if terminal.IsStdinTTY() && watchInputSupported() {
 		deps.Wait = newWatchInputAdapter(os.Stdin).Wait
 		logger.Log("Press r while waiting to request an immediate review.", terminal.StyleDim)
 	}

--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -30,6 +30,7 @@ keep watching the PR and re-review when a re-review is requested or new
 commits settle, until a terminal LGTM is posted or a safety bound is reached.
 
 The watched PR is selected with --pr or detected from the current branch.
+While an attached watcher is waiting, press r to request an immediate review.
 
 Post modes:
   interactive  Prompt for every submission decision (default; requires a TTY)
@@ -202,6 +203,10 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		RunCycle: func(ctx context.Context, _ int, _ string) (watch.Cycle, error) {
 			return runWatchCycle(ctx, cmd, watchPR, mode, logger)
 		},
+	}
+	if terminal.IsStdinTTY() {
+		deps.Wait = newWatchInputAdapter(os.Stdin).Wait
+		logger.Log("Press r while waiting to request an immediate review.", terminal.StyleDim)
 	}
 
 	reason := watch.Run(ctx, wcfg, deps)

--- a/cmd/acr/watch_input.go
+++ b/cmd/acr/watch_input.go
@@ -18,14 +18,22 @@ const manualRequestCoalesceWindow = 30 * time.Millisecond
 var errWatchInputNotForeground = errors.New("watcher does not own the foreground terminal")
 
 type watchInputAdapter struct {
-	input    io.Reader
-	activate func() (func() error, error)
-	suspend  func() error
+	input     io.Reader
+	activate  func() (func() error, error)
+	suspend   func() error
+	newReader func(io.Reader) (cancelreader.CancelReader, error)
 }
 
 type watchInputRead struct {
 	key byte
 	err error
+}
+
+type watchInputSession struct {
+	reader cancelreader.CancelReader
+	reads  <-chan watchInputRead
+	stop   chan<- struct{}
+	done   <-chan struct{}
 }
 
 func newWatchInputAdapter(input *os.File) *watchInputAdapter {
@@ -52,20 +60,14 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 		}
 	}()
 
-	reader, err := cancelreader.NewReader(a.input)
+	session, err := a.startSession()
 	if err != nil {
 		return watch.WaitResult{}, fmt.Errorf("prepare manual input: %w", err)
 	}
-	defer reader.Close()
-
-	reads := make(chan watchInputRead, 1)
-	done := make(chan struct{})
-	stop := make(chan struct{})
-	go readWatchInput(reader, reads, stop, done)
 	defer func() {
-		close(stop)
-		reader.Cancel()
-		<-done
+		if session != nil {
+			session.close()
+		}
 	}()
 
 	timer := time.NewTimer(duration)
@@ -77,7 +79,7 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 			return watch.WaitResult{}, ctx.Err()
 		case <-timer.C:
 			return watch.WaitResult{}, nil
-		case read := <-reads:
+		case read := <-sessionReads(session):
 			if read.err != nil {
 				return watch.WaitResult{}, fmt.Errorf("read manual input: %w", read.err)
 			}
@@ -88,22 +90,78 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 				if a.suspend == nil {
 					continue
 				}
-				if err := restore(); err != nil {
-					return watch.WaitResult{}, fmt.Errorf("restore terminal input before suspend: %w", err)
-				}
-				restore = func() error { return nil }
-				if err := a.suspend(); err != nil {
-					return watch.WaitResult{}, fmt.Errorf("suspend watcher: %w", err)
-				}
-				restore, err = a.activate()
-				if err != nil {
-					return watch.WaitResult{}, fmt.Errorf("restore manual input after resume: %w", err)
+				if err := a.suspendAndResume(&session, &restore); err != nil {
+					return watch.WaitResult{}, err
 				}
 			case 'r', 'R':
-				return a.coalesce(ctx, reads)
+				return a.coalesce(ctx, &session, &restore)
 			}
 		}
 	}
+}
+
+func (a *watchInputAdapter) startSession() (*watchInputSession, error) {
+	newReader := a.newReader
+	if newReader == nil {
+		newReader = cancelreader.NewReader
+	}
+	reader, err := newReader(a.input)
+	if err != nil {
+		return nil, err
+	}
+	reads := make(chan watchInputRead, 1)
+	done := make(chan struct{})
+	stop := make(chan struct{})
+	go readWatchInput(reader, reads, stop, done)
+	return &watchInputSession{reader: reader, reads: reads, stop: stop, done: done}, nil
+}
+
+func (s *watchInputSession) close() {
+	close(s.stop)
+	if s.reader.Cancel() {
+		<-s.done
+	}
+	s.reader.Close()
+}
+
+func sessionReads(session *watchInputSession) <-chan watchInputRead {
+	if session == nil {
+		return nil
+	}
+	return session.reads
+}
+
+func (a *watchInputAdapter) suspendAndResume(session **watchInputSession, restore *func() error) error {
+	(*session).close()
+	*session = nil
+	if err := (*restore)(); err != nil {
+		return fmt.Errorf("restore terminal input before suspend: %w", err)
+	}
+	*restore = func() error { return nil }
+	if err := a.suspend(); err != nil {
+		return fmt.Errorf("suspend watcher: %w", err)
+	}
+	nextRestore, err := a.activate()
+	if errors.Is(err, errWatchInputNotForeground) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("restore manual input after resume: %w", err)
+	}
+	nextSession, err := a.startSession()
+	if err != nil {
+		if restoreErr := nextRestore(); restoreErr != nil {
+			return fmt.Errorf(
+				"restore terminal after input reader failure: %v; prepare input reader: %w",
+				restoreErr,
+				err,
+			)
+		}
+		return fmt.Errorf("restore manual input reader after resume: %w", err)
+	}
+	*restore = nextRestore
+	*session = nextSession
+	return nil
 }
 
 func waitWithoutWatchInput(ctx context.Context, duration time.Duration) (watch.WaitResult, error) {
@@ -117,7 +175,11 @@ func waitWithoutWatchInput(ctx context.Context, duration time.Duration) (watch.W
 	}
 }
 
-func (a *watchInputAdapter) coalesce(ctx context.Context, reads <-chan watchInputRead) (watch.WaitResult, error) {
+func (a *watchInputAdapter) coalesce(
+	ctx context.Context,
+	session **watchInputSession,
+	restore *func() error,
+) (watch.WaitResult, error) {
 	count := 1
 	timer := time.NewTimer(manualRequestCoalesceWindow)
 	defer timer.Stop()
@@ -128,13 +190,19 @@ func (a *watchInputAdapter) coalesce(ctx context.Context, reads <-chan watchInpu
 			return watch.WaitResult{}, ctx.Err()
 		case <-timer.C:
 			return watch.WaitResult{ManualRequests: count}, nil
-		case read := <-reads:
+		case read := <-sessionReads(*session):
 			if read.err != nil {
 				return watch.WaitResult{}, fmt.Errorf("read manual input: %w", read.err)
 			}
 			switch read.key {
 			case 3:
 				return watch.WaitResult{Interrupted: true}, nil
+			case 26:
+				if a.suspend != nil {
+					if err := a.suspendAndResume(session, restore); err != nil {
+						return watch.WaitResult{}, err
+					}
+				}
 			case 'r', 'R':
 				count++
 				if !timer.Stop() {

--- a/cmd/acr/watch_input.go
+++ b/cmd/acr/watch_input.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/muesli/cancelreader"
+	"golang.org/x/term"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/watch"
+)
+
+const manualRequestCoalesceWindow = 30 * time.Millisecond
+
+type watchInputAdapter struct {
+	input    io.Reader
+	activate func() (func() error, error)
+}
+
+type watchInputRead struct {
+	key byte
+	err error
+}
+
+func newWatchInputAdapter(input *os.File) *watchInputAdapter {
+	return &watchInputAdapter{
+		input: input,
+		activate: func() (func() error, error) {
+			fd := int(input.Fd())
+			state, err := term.MakeRaw(fd)
+			if err != nil {
+				return nil, err
+			}
+			return func() error {
+				return term.Restore(fd, state)
+			}, nil
+		},
+	}
+}
+
+func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (result watch.WaitResult, resultErr error) {
+	restore, err := a.activate()
+	if err != nil {
+		return watch.WaitResult{}, fmt.Errorf("enable manual input: %w", err)
+	}
+	defer func() {
+		if err := restore(); err != nil && resultErr == nil {
+			resultErr = fmt.Errorf("restore terminal input: %w", err)
+		}
+	}()
+
+	reader, err := cancelreader.NewReader(a.input)
+	if err != nil {
+		return watch.WaitResult{}, fmt.Errorf("prepare manual input: %w", err)
+	}
+	defer reader.Close()
+
+	reads := make(chan watchInputRead, 1)
+	done := make(chan struct{})
+	stop := make(chan struct{})
+	go readWatchInput(reader, reads, stop, done)
+	defer func() {
+		close(stop)
+		reader.Cancel()
+		<-done
+	}()
+
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return watch.WaitResult{}, ctx.Err()
+		case <-timer.C:
+			return watch.WaitResult{}, nil
+		case read := <-reads:
+			if read.err != nil {
+				return watch.WaitResult{}, fmt.Errorf("read manual input: %w", read.err)
+			}
+			switch read.key {
+			case 3:
+				return watch.WaitResult{Interrupted: true}, nil
+			case 'r', 'R':
+				return a.coalesce(ctx, reads)
+			}
+		}
+	}
+}
+
+func (a *watchInputAdapter) coalesce(ctx context.Context, reads <-chan watchInputRead) (watch.WaitResult, error) {
+	count := 1
+	timer := time.NewTimer(manualRequestCoalesceWindow)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return watch.WaitResult{}, ctx.Err()
+		case <-timer.C:
+			return watch.WaitResult{ManualRequests: count}, nil
+		case read := <-reads:
+			if read.err != nil {
+				return watch.WaitResult{}, fmt.Errorf("read manual input: %w", read.err)
+			}
+			switch read.key {
+			case 3:
+				return watch.WaitResult{Interrupted: true}, nil
+			case 'r', 'R':
+				count++
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(manualRequestCoalesceWindow)
+			}
+		}
+	}
+}
+
+func readWatchInput(reader io.Reader, reads chan<- watchInputRead, stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+	var buffer [1]byte
+	for {
+		n, err := reader.Read(buffer[:])
+		if err != nil {
+			if err != cancelreader.ErrCanceled {
+				select {
+				case reads <- watchInputRead{err: err}:
+				case <-stop:
+				}
+			}
+			return
+		}
+		if n == 1 {
+			for _, key := range buffer {
+				select {
+				case reads <- watchInputRead{key: key}:
+				case <-stop:
+					return
+				}
+			}
+		}
+	}
+}

--- a/cmd/acr/watch_input.go
+++ b/cmd/acr/watch_input.go
@@ -2,22 +2,25 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"time"
 
 	"github.com/muesli/cancelreader"
-	"golang.org/x/term"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
 
 const manualRequestCoalesceWindow = 30 * time.Millisecond
 
+var errWatchInputNotForeground = errors.New("watcher does not own the foreground terminal")
+
 type watchInputAdapter struct {
 	input    io.Reader
 	activate func() (func() error, error)
+	suspend  func() error
 }
 
 type watchInputRead struct {
@@ -29,21 +32,18 @@ func newWatchInputAdapter(input *os.File) *watchInputAdapter {
 	return &watchInputAdapter{
 		input: input,
 		activate: func() (func() error, error) {
-			fd := int(input.Fd())
-			state, err := term.MakeRaw(fd)
-			if err != nil {
-				return nil, err
-			}
-			return func() error {
-				return term.Restore(fd, state)
-			}, nil
+			return activateWatchInput(input)
 		},
+		suspend: suspendWatchInput,
 	}
 }
 
 func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (result watch.WaitResult, resultErr error) {
 	restore, err := a.activate()
 	if err != nil {
+		if errors.Is(err, errWatchInputNotForeground) {
+			return waitWithoutWatchInput(ctx, duration)
+		}
 		return watch.WaitResult{}, fmt.Errorf("enable manual input: %w", err)
 	}
 	defer func() {
@@ -84,10 +84,36 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 			switch read.key {
 			case 3:
 				return watch.WaitResult{Interrupted: true}, nil
+			case 26:
+				if a.suspend == nil {
+					continue
+				}
+				if err := restore(); err != nil {
+					return watch.WaitResult{}, fmt.Errorf("restore terminal input before suspend: %w", err)
+				}
+				restore = func() error { return nil }
+				if err := a.suspend(); err != nil {
+					return watch.WaitResult{}, fmt.Errorf("suspend watcher: %w", err)
+				}
+				restore, err = a.activate()
+				if err != nil {
+					return watch.WaitResult{}, fmt.Errorf("restore manual input after resume: %w", err)
+				}
 			case 'r', 'R':
 				return a.coalesce(ctx, reads)
 			}
 		}
+	}
+}
+
+func waitWithoutWatchInput(ctx context.Context, duration time.Duration) (watch.WaitResult, error) {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return watch.WaitResult{}, ctx.Err()
+	case <-timer.C:
+		return watch.WaitResult{}, nil
 	}
 }
 

--- a/cmd/acr/watch_input_darwin.go
+++ b/cmd/acr/watch_input_darwin.go
@@ -9,6 +9,10 @@ import (
 	"golang.org/x/term"
 )
 
+func watchInputSupported() bool {
+	return true
+}
+
 func activateWatchInput(input *os.File) (func() error, error) {
 	fd := int(input.Fd())
 	foregroundGroup, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
@@ -35,5 +39,5 @@ func activateWatchInput(input *os.File) (func() error, error) {
 }
 
 func suspendWatchInput() error {
-	return syscall.Kill(os.Getpid(), syscall.SIGTSTP)
+	return syscall.Kill(-unix.Getpgrp(), syscall.SIGTSTP)
 }

--- a/cmd/acr/watch_input_darwin.go
+++ b/cmd/acr/watch_input_darwin.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+func activateWatchInput(input *os.File) (func() error, error) {
+	fd := int(input.Fd())
+	foregroundGroup, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+	if err != nil {
+		return nil, fmt.Errorf("read foreground process group: %w", err)
+	}
+	if foregroundGroup != unix.Getpgrp() {
+		return nil, errWatchInputNotForeground
+	}
+	state, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.IoctlSetTermios(fd, unix.TIOCSETAF, state); err != nil {
+		return nil, fmt.Errorf("discard pending terminal input: %w", err)
+	}
+	rawState, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		return term.Restore(fd, rawState)
+	}, nil
+}
+
+func suspendWatchInput() error {
+	return syscall.Kill(os.Getpid(), syscall.SIGTSTP)
+}

--- a/cmd/acr/watch_input_linux.go
+++ b/cmd/acr/watch_input_linux.go
@@ -9,6 +9,10 @@ import (
 	"golang.org/x/term"
 )
 
+func watchInputSupported() bool {
+	return true
+}
+
 func activateWatchInput(input *os.File) (func() error, error) {
 	fd := int(input.Fd())
 	foregroundGroup, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
@@ -35,5 +39,5 @@ func activateWatchInput(input *os.File) (func() error, error) {
 }
 
 func suspendWatchInput() error {
-	return syscall.Kill(os.Getpid(), syscall.SIGTSTP)
+	return syscall.Kill(-unix.Getpgrp(), syscall.SIGTSTP)
 }

--- a/cmd/acr/watch_input_linux.go
+++ b/cmd/acr/watch_input_linux.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+func activateWatchInput(input *os.File) (func() error, error) {
+	fd := int(input.Fd())
+	foregroundGroup, err := unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+	if err != nil {
+		return nil, fmt.Errorf("read foreground process group: %w", err)
+	}
+	if foregroundGroup != unix.Getpgrp() {
+		return nil, errWatchInputNotForeground
+	}
+	state, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.IoctlSetTermios(fd, unix.TCSETSF, state); err != nil {
+		return nil, fmt.Errorf("discard pending terminal input: %w", err)
+	}
+	rawState, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		return term.Restore(fd, rawState)
+	}, nil
+}
+
+func suspendWatchInput() error {
+	return syscall.Kill(os.Getpid(), syscall.SIGTSTP)
+}

--- a/cmd/acr/watch_input_other.go
+++ b/cmd/acr/watch_input_other.go
@@ -1,0 +1,17 @@
+//go:build !darwin && !linux && !windows
+
+package main
+
+import "os"
+
+func watchInputSupported() bool {
+	return false
+}
+
+func activateWatchInput(_ *os.File) (func() error, error) {
+	return nil, errWatchInputNotForeground
+}
+
+func suspendWatchInput() error {
+	return nil
+}

--- a/cmd/acr/watch_input_test.go
+++ b/cmd/acr/watch_input_test.go
@@ -137,6 +137,77 @@ func TestWatchInputAdapterTreatsControlCAsInterrupt(t *testing.T) {
 	}
 }
 
+func TestWatchInputAdapterRestoresAroundSuspend(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{}, 2)
+	released := make(chan struct{}, 2)
+	suspended := make(chan struct{}, 1)
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			activated <- struct{}{}
+			return func() error {
+				released <- struct{}{}
+				return nil
+			}, nil
+		},
+		suspend: func() error {
+			select {
+			case <-released:
+			default:
+				t.Fatal("terminal input was not restored before suspension")
+			}
+			suspended <- struct{}{}
+			return nil
+		},
+	}
+	outcome := make(chan bool, 1)
+	go func() {
+		result, _ := adapter.Wait(context.Background(), time.Hour)
+		outcome <- result.Interrupted
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte{26}); err != nil {
+		t.Fatal(err)
+	}
+	<-suspended
+	<-activated
+	if _, err := writer.Write([]byte{3}); err != nil {
+		t.Fatal(err)
+	}
+	if !<-outcome {
+		t.Fatal("control-C did not interrupt the resumed wait")
+	}
+	<-released
+}
+
+func TestWatchInputAdapterFallsBackWhenBackgrounded(t *testing.T) {
+	adapter := &watchInputAdapter{
+		activate: func() (func() error, error) {
+			return nil, errWatchInputNotForeground
+		},
+	}
+	start := time.Now()
+	result, err := adapter.Wait(context.Background(), time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ManualRequests != 0 || result.Interrupted {
+		t.Fatalf("result = %#v", result)
+	}
+	if time.Since(start) < time.Millisecond {
+		t.Fatal("background fallback did not wait")
+	}
+}
+
 func TestWatchInputAdapterReportsTerminalRestoreFailure(t *testing.T) {
 	reader, writer, err := os.Pipe()
 	if err != nil {

--- a/cmd/acr/watch_input_test.go
+++ b/cmd/acr/watch_input_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{}, 1)
+	released := make(chan struct{}, 1)
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			activated <- struct{}{}
+			return func() error {
+				released <- struct{}{}
+				return nil
+			}, nil
+		},
+	}
+	type waitOutcome struct {
+		result int
+		err    error
+	}
+	outcome := make(chan waitOutcome, 1)
+	go func() {
+		result, err := adapter.Wait(context.Background(), time.Hour)
+		outcome <- waitOutcome{result: result.ManualRequests, err: err}
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte("rrr")); err != nil {
+		t.Fatal(err)
+	}
+	got := <-outcome
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if got.result != 3 {
+		t.Fatalf("manual requests = %d, want 3", got.result)
+	}
+	<-released
+
+	nextRead := make(chan byte, 1)
+	go func() {
+		buffer := make([]byte, 1)
+		if _, err := reader.Read(buffer); err == nil {
+			nextRead <- buffer[0]
+		}
+	}()
+	if _, err := writer.Write([]byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case key := <-nextRead:
+		if key != 'x' {
+			t.Fatalf("key = %q, want x", key)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("manual input reader retained ownership after Wait returned")
+	}
+}
+
+func TestWatchInputAdapterReleasesInputAfterScheduledWait(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	released := false
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			return func() error {
+				released = true
+				return nil
+			}, nil
+		},
+	}
+
+	result, err := adapter.Wait(context.Background(), time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ManualRequests != 0 {
+		t.Fatalf("manual requests = %d", result.ManualRequests)
+	}
+	if !released {
+		t.Fatal("input was not released after scheduled wait")
+	}
+}
+
+func TestWatchInputAdapterTreatsControlCAsInterrupt(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{})
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			close(activated)
+			return func() error { return nil }, nil
+		},
+	}
+	outcome := make(chan bool, 1)
+	go func() {
+		result, _ := adapter.Wait(context.Background(), time.Hour)
+		outcome <- result.Interrupted
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte{3}); err != nil {
+		t.Fatal(err)
+	}
+	if !<-outcome {
+		t.Fatal("control-C did not interrupt the wait")
+	}
+}
+
+func TestWatchInputAdapterReportsTerminalRestoreFailure(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			return func() error { return errors.New("restore failed") }, nil
+		},
+	}
+
+	_, err = adapter.Wait(context.Background(), time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "restore terminal input: restore failed") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/cmd/acr/watch_input_test.go
+++ b/cmd/acr/watch_input_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/muesli/cancelreader"
 )
 
 func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
@@ -189,6 +192,97 @@ func TestWatchInputAdapterRestoresAroundSuspend(t *testing.T) {
 	<-released
 }
 
+func TestWatchInputAdapterSuspendsDuringCoalescing(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{}, 2)
+	released := make(chan struct{}, 2)
+	suspended := make(chan struct{}, 1)
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			activated <- struct{}{}
+			return func() error {
+				released <- struct{}{}
+				return nil
+			}, nil
+		},
+		suspend: func() error {
+			<-released
+			suspended <- struct{}{}
+			return nil
+		},
+	}
+	type waitOutcome struct {
+		result int
+		err    error
+	}
+	outcome := make(chan waitOutcome, 1)
+	go func() {
+		result, err := adapter.Wait(context.Background(), time.Hour)
+		outcome <- waitOutcome{result: result.ManualRequests, err: err}
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte{'r', 26}); err != nil {
+		t.Fatal(err)
+	}
+	<-suspended
+	<-activated
+	got := <-outcome
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if got.result != 1 {
+		t.Fatalf("manual requests = %d, want 1", got.result)
+	}
+	<-released
+}
+
+func TestWatchInputAdapterFallsBackWhenResumedInBackground(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{})
+	activation := 0
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			activation++
+			if activation > 1 {
+				return nil, errWatchInputNotForeground
+			}
+			close(activated)
+			return func() error { return nil }, nil
+		},
+		suspend: func() error { return nil },
+	}
+	outcome := make(chan error, 1)
+	go func() {
+		_, err := adapter.Wait(context.Background(), 10*time.Millisecond)
+		outcome <- err
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte{26}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-outcome; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWatchInputAdapterFallsBackWhenBackgrounded(t *testing.T) {
 	adapter := &watchInputAdapter{
 		activate: func() (func() error, error) {
@@ -205,6 +299,29 @@ func TestWatchInputAdapterFallsBackWhenBackgrounded(t *testing.T) {
 	}
 	if time.Since(start) < time.Millisecond {
 		t.Fatal("background fallback did not wait")
+	}
+}
+
+func TestWatchInputAdapterDoesNotWaitWhenCancellationFails(t *testing.T) {
+	reader := &failedCancellationReader{closed: make(chan struct{})}
+	adapter := &watchInputAdapter{
+		input: io.Reader(reader),
+		activate: func() (func() error, error) {
+			return func() error { return nil }, nil
+		},
+		newReader: func(io.Reader) (cancelreader.CancelReader, error) {
+			return reader, nil
+		},
+	}
+
+	_, err := adapter.Wait(context.Background(), time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-reader.closed:
+	case <-time.After(time.Second):
+		t.Fatal("uncancelable reader was not closed")
 	}
 }
 
@@ -228,4 +345,22 @@ func TestWatchInputAdapterReportsTerminalRestoreFailure(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "restore terminal input: restore failed") {
 		t.Fatalf("error = %v", err)
 	}
+}
+
+type failedCancellationReader struct {
+	closed chan struct{}
+}
+
+func (r *failedCancellationReader) Read([]byte) (int, error) {
+	<-r.closed
+	return 0, io.EOF
+}
+
+func (r *failedCancellationReader) Cancel() bool {
+	return false
+}
+
+func (r *failedCancellationReader) Close() error {
+	close(r.closed)
+	return nil
 }

--- a/cmd/acr/watch_input_windows.go
+++ b/cmd/acr/watch_input_windows.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/term"
+)
+
+func activateWatchInput(input *os.File) (func() error, error) {
+	fd := int(input.Fd())
+	if err := windows.FlushConsoleInputBuffer(windows.Handle(input.Fd())); err != nil {
+		return nil, err
+	}
+	state, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		return term.Restore(fd, state)
+	}, nil
+}
+
+func suspendWatchInput() error {
+	return nil
+}

--- a/cmd/acr/watch_input_windows.go
+++ b/cmd/acr/watch_input_windows.go
@@ -7,6 +7,10 @@ import (
 	"golang.org/x/term"
 )
 
+func watchInputSupported() bool {
+	return true
+}
+
 func activateWatchInput(input *os.File) (func() error, error) {
 	fd := int(input.Fd())
 	if err := windows.FlushConsoleInputBuffer(windows.Handle(input.Fd())); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/uuid v1.6.0
+	github.com/muesli/cancelreader v0.2.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/sys v0.47.0
@@ -29,7 +30,6 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.27 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -230,7 +230,7 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			l.logf("Reached maximum duration (%s) without a terminal LGTM; stopping.", cfg.MaxDuration)
 			return ReasonMaxDuration
 		}
-		if l.manualRequests == 0 {
+		if l.manualRequests == 0 || pollErrors > 0 {
 			sleep := cfg.PollInterval
 			if remaining := deadline.Sub(now); remaining < sleep {
 				sleep = remaining
@@ -290,6 +290,9 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		trigger := ""
 		if manualTrigger {
 			trigger = "manual request"
+			if st.ReviewRequested && l.requestArmed {
+				l.requestArmed = false
+			}
 		} else if st.ReviewRequested && l.requestArmed {
 			trigger = "re-review requested"
 			l.requestArmed = false

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -57,8 +57,32 @@ type Deps struct {
 	RunCycle func(ctx context.Context, reviewNum int, trigger string) (Cycle, error)
 	CIGreen  func(ctx context.Context) (bool, error)
 	Approve  func(ctx context.Context, body string) error
+	Wait     func(ctx context.Context, duration time.Duration) (WaitResult, error)
+	Emit     func(event Event)
 	Clock    Clock
 	Logf     func(format string, args ...any)
+}
+
+type WaitResult struct {
+	ManualRequests int
+	Interrupted    bool
+}
+
+type EventType string
+
+const (
+	EventManualRequestReceived  EventType = "manual_request_received"
+	EventManualRequestCoalesced EventType = "manual_request_coalesced"
+	EventManualReviewStarted    EventType = "manual_review_started"
+	EventManualRequestRejected  EventType = "manual_request_rejected"
+	EventManualInputUnsafe      EventType = "manual_input_unsafe"
+)
+
+type Event struct {
+	Type         EventType
+	RequestCount int
+	ReviewNumber int
+	Reason       string
 }
 
 type Config struct {
@@ -120,12 +144,48 @@ type loop struct {
 	cycleErrors     int
 	retryPending    bool
 	retryHead       string
+	manualRequests  int
 }
 
 func (l *loop) logf(format string, args ...any) {
 	if l.deps.Logf != nil {
 		l.deps.Logf(format, args...)
 	}
+}
+
+func (l *loop) emit(event Event) {
+	if l.deps.Emit != nil {
+		l.deps.Emit(event)
+	}
+}
+
+func (l *loop) wait(ctx context.Context, duration time.Duration) (WaitResult, error) {
+	if l.deps.Wait != nil {
+		return l.deps.Wait(ctx, duration)
+	}
+	return WaitResult{}, l.deps.Clock.Sleep(ctx, duration)
+}
+
+func (l *loop) receiveManualRequests(count int) {
+	if count <= 0 {
+		return
+	}
+	l.manualRequests += count
+	l.emit(Event{Type: EventManualRequestReceived, RequestCount: count})
+	l.logf("Manual review requested.")
+	if l.manualRequests > 1 {
+		l.emit(Event{Type: EventManualRequestCoalesced, RequestCount: l.manualRequests})
+		l.logf("Coalesced %d manual review requests into one review.", l.manualRequests)
+	}
+}
+
+func (l *loop) rejectManualRequests(reason string) {
+	if l.manualRequests == 0 {
+		return
+	}
+	l.emit(Event{Type: EventManualRequestRejected, RequestCount: l.manualRequests, Reason: reason})
+	l.logf("Manual review request rejected: %s.", reason)
+	l.manualRequests = 0
 }
 
 func shortSHA(sha string) string {
@@ -166,20 +226,36 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 	for {
 		now := clock.Now()
 		if !now.Before(deadline) {
+			l.rejectManualRequests(ReasonMaxDuration.String())
 			l.logf("Reached maximum duration (%s) without a terminal LGTM; stopping.", cfg.MaxDuration)
 			return ReasonMaxDuration
 		}
-		sleep := cfg.PollInterval
-		if remaining := deadline.Sub(now); remaining < sleep {
-			sleep = remaining
-		}
-		if err := clock.Sleep(ctx, sleep); err != nil {
-			return ReasonInterrupted
+		if l.manualRequests == 0 {
+			sleep := cfg.PollInterval
+			if remaining := deadline.Sub(now); remaining < sleep {
+				sleep = remaining
+			}
+			waitResult, err := l.wait(ctx, sleep)
+			if err != nil {
+				if ctx.Err() != nil {
+					return ReasonInterrupted
+				}
+				l.emit(Event{Type: EventManualInputUnsafe, Reason: err.Error()})
+				l.logf("Manual input could not be handled safely: %v", err)
+				return ReasonError
+			}
+			if waitResult.Interrupted {
+				return ReasonInterrupted
+			}
+			l.receiveManualRequests(waitResult.ManualRequests)
 		}
 		if !clock.Now().Before(deadline) {
+			l.rejectManualRequests(ReasonMaxDuration.String())
 			l.logf("Reached maximum duration (%s) without a terminal LGTM; stopping.", cfg.MaxDuration)
 			return ReasonMaxDuration
 		}
+
+		manualTrigger := l.manualRequests > 0
 
 		st, err := deps.State(ctx)
 		if err != nil {
@@ -196,6 +272,9 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		pollErrors = 0
 
 		if reason, done := l.checkOpen(st); done {
+			if manualTrigger {
+				l.rejectManualRequests(reason.String())
+			}
 			return reason
 		}
 		if l.retryPending && st.HeadSHA != l.retryHead {
@@ -209,7 +288,9 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 
 		trigger := ""
-		if st.ReviewRequested && l.requestArmed {
+		if manualTrigger {
+			trigger = "manual request"
+		} else if st.ReviewRequested && l.requestArmed {
 			trigger = "re-review requested"
 			l.requestArmed = false
 		}
@@ -250,6 +331,9 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 
 		if l.reviews >= cfg.MaxReviews {
+			if manualTrigger {
+				l.rejectManualRequests(ReasonMaxReviews.String())
+			}
 			if l.pendingApproval != "" {
 				l.logf("Review budget exhausted; ignoring trigger (%s) and continuing to wait for CI.", trigger)
 				continue
@@ -347,6 +431,10 @@ func (l *loop) cycle(ctx context.Context, head, trigger string) (ExitReason, boo
 	l.retryHead = ""
 	l.pendingApproval = ""
 	l.reviews++
+	if trigger == "manual request" {
+		l.emit(Event{Type: EventManualReviewStarted, RequestCount: l.manualRequests, ReviewNumber: l.reviews})
+		l.manualRequests = 0
+	}
 	l.logf("Review #%d/%d starting (%s)", l.reviews, l.cfg.MaxReviews, trigger)
 
 	cycleCtx, cancel := context.WithTimeout(ctx, l.deadline.Sub(l.deps.Clock.Now()))

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -283,7 +283,7 @@ func TestManualInputSafetyFailureStopsWatcher(t *testing.T) {
 	}
 }
 
-func TestManualRequestSurvivesTransientStateFailureWithoutAnotherWait(t *testing.T) {
+func TestManualRequestSurvivesTransientStateFailureWithRetryDelay(t *testing.T) {
 	h := newHarness(t)
 	h.cycles = []Cycle{
 		{Result: CycleFindings},
@@ -301,16 +301,53 @@ func TestManualRequestSurvivesTransientStateFailureWithoutAnotherWait(t *testing
 	}
 	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
 		waitCalls++
-		return WaitResult{ManualRequests: 1}, nil
+		if waitCalls == 1 {
+			return WaitResult{ManualRequests: 1}, nil
+		}
+		return WaitResult{}, nil
 	}
 
 	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
 		t.Fatalf("reason = %v, want ReasonLGTM", reason)
 	}
-	if waitCalls != 1 {
-		t.Fatalf("wait calls = %d, want 1", waitCalls)
+	if waitCalls != 2 {
+		t.Fatalf("wait calls = %d, want 2", waitCalls)
 	}
 	if len(h.triggers) != 2 || h.triggers[1] != "manual request" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+}
+
+func TestManualRequestConsumesConcurrentReReviewRequest(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		requested("aaa"),
+	}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleFindings},
+	}
+	cfg := defaultConfig(PostModeComment)
+	cfg.MaxDuration = 30 * time.Minute
+	waitCalls := 0
+	deps := h.deps()
+	deps.Wait = func(ctx context.Context, duration time.Duration) (WaitResult, error) {
+		waitCalls++
+		if waitCalls == 1 {
+			return WaitResult{ManualRequests: 1}, nil
+		}
+		h.clock.now = h.clock.now.Add(duration)
+		return WaitResult{}, nil
+	}
+
+	if reason := Run(context.Background(), cfg, deps); reason != ReasonMaxDuration {
+		t.Fatalf("reason = %v, want ReasonMaxDuration", reason)
+	}
+	if len(h.triggers) != 2 {
+		t.Fatalf("triggers = %v, want initial plus one manual review", h.triggers)
+	}
+	if h.triggers[1] != "manual request" {
 		t.Fatalf("triggers = %v", h.triggers)
 	}
 }

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -27,8 +27,9 @@ type harness struct {
 	t     *testing.T
 	clock *fakeClock
 
-	states []PRState
-	stateI int
+	states     []PRState
+	stateI     int
+	stateCalls int
 
 	cycles []Cycle
 	cycleI int
@@ -42,6 +43,7 @@ type harness struct {
 	triggers     []string
 	approvedWith []string
 	logs         []string
+	events       []Event
 }
 
 func newHarness(t *testing.T) *harness {
@@ -52,6 +54,7 @@ func (h *harness) deps() Deps {
 	return Deps{
 		Clock: h.clock,
 		State: func(ctx context.Context) (PRState, error) {
+			h.stateCalls++
 			if h.stateI < len(h.states)-1 {
 				h.stateI++
 				return h.states[h.stateI-1], nil
@@ -86,6 +89,9 @@ func (h *harness) deps() Deps {
 		},
 		Logf: func(format string, args ...any) {
 			h.logs = append(h.logs, fmt.Sprintf(format, args...))
+		},
+		Emit: func(event Event) {
+			h.events = append(h.events, event)
 		},
 	}
 }
@@ -163,6 +169,159 @@ func TestReReviewRequestTriggersWithoutSettleWait(t *testing.T) {
 	if elapsed := h.clock.now.Sub(start); elapsed > 5*time.Minute {
 		t.Errorf("request trigger waited %s; settle time must not apply", elapsed)
 	}
+}
+
+func TestManualRequestWakesAndReviewsFreshState(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{
+		open("aaa"),
+		open("bbb"),
+	}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved, HeadSHA: "bbb"},
+	}
+	deps := h.deps()
+	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
+		return WaitResult{ManualRequests: 1}, nil
+	}
+
+	reason := Run(context.Background(), defaultConfig(PostModeApprove), deps)
+
+	if reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "manual request" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	if h.stateCalls != 2 {
+		t.Fatalf("state captures = %d, want 2", h.stateCalls)
+	}
+	if !hasEvent(h.events, EventManualRequestReceived) || !hasEvent(h.events, EventManualReviewStarted) {
+		t.Fatalf("events = %#v", h.events)
+	}
+}
+
+func TestManualRequestsCoalesceBeforeReviewStarts(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved},
+	}
+	deps := h.deps()
+	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
+		return WaitResult{ManualRequests: 4}, nil
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 2 {
+		t.Fatalf("cycles = %d, want initial plus one manual review", len(h.triggers))
+	}
+	var coalesced Event
+	for _, event := range h.events {
+		if event.Type == EventManualRequestCoalesced {
+			coalesced = event
+		}
+	}
+	if coalesced.RequestCount != 4 {
+		t.Fatalf("coalesced event = %#v", coalesced)
+	}
+}
+
+func TestManualRequestRejectedWhenReviewBudgetIsExhausted(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "LGTM body"}}
+	h.ci = []bool{true}
+	cfg := defaultConfig(PostModeApprove)
+	cfg.MaxReviews = 1
+	waits := 0
+	deps := h.deps()
+	deps.Wait = func(ctx context.Context, duration time.Duration) (WaitResult, error) {
+		waits++
+		if waits == 1 {
+			return WaitResult{ManualRequests: 1}, nil
+		}
+		h.clock.now = h.clock.now.Add(duration)
+		return WaitResult{}, nil
+	}
+
+	if reason := Run(context.Background(), cfg, deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(h.triggers) != 1 {
+		t.Fatalf("cycles = %d, want no review beyond the initial review", len(h.triggers))
+	}
+	var rejected Event
+	for _, event := range h.events {
+		if event.Type == EventManualRequestRejected {
+			rejected = event
+		}
+	}
+	if rejected.Reason != ReasonMaxReviews.String() {
+		t.Fatalf("rejected event = %#v", rejected)
+	}
+}
+
+func TestManualInputSafetyFailureStopsWatcher(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	deps := h.deps()
+	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
+		return WaitResult{}, errors.New("terminal restore failed")
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), deps); reason != ReasonError {
+		t.Fatalf("reason = %v, want ReasonError", reason)
+	}
+	if !hasEvent(h.events, EventManualInputUnsafe) {
+		t.Fatalf("events = %#v", h.events)
+	}
+}
+
+func TestManualRequestSurvivesTransientStateFailureWithoutAnotherWait(t *testing.T) {
+	h := newHarness(t)
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved},
+	}
+	stateCalls := 0
+	waitCalls := 0
+	deps := h.deps()
+	deps.State = func(context.Context) (PRState, error) {
+		stateCalls++
+		if stateCalls == 2 {
+			return PRState{}, errors.New("transient gh failure")
+		}
+		return open("aaa"), nil
+	}
+	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
+		waitCalls++
+		return WaitResult{ManualRequests: 1}, nil
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("wait calls = %d, want 1", waitCalls)
+	}
+	if len(h.triggers) != 2 || h.triggers[1] != "manual request" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+}
+
+func hasEvent(events []Event, eventType EventType) bool {
+	for _, event := range events {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPersistentRequestIsConsumedOnce(t *testing.T) {


### PR DESCRIPTION
Closes #249

## What changed

- accepts `r` while an attached `acr watch` session is idle or sleeping
- routes manual requests through reusable watcher-engine wait and event dependencies
- coalesces repeated requests and preserves pending requests across transient state-refresh failures
- reuses the existing full-review path, including review limits, duration bounds, prior feedback, cancellation, stale-head handling, and posting safeguards
- releases terminal input before review execution or interactive posting prompts
- documents the interactive key in watch help and runtime output

This is deliberately independent of conversation discovery and routing in #248.

## Verification

- `go test -race ./cmd/acr ./internal/watch -run 'TestWatchInputAdapter|TestManual' -count=1 -timeout=60s`
- `make check`