### PR TITLE
Fix manual retrigger input handoff

### DIFF
--- a/cmd/acr/watch_input.go
+++ b/cmd/acr/watch_input.go
@@ -55,19 +55,24 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 		return watch.WaitResult{}, fmt.Errorf("enable manual input: %w", err)
 	}
 
-	session, err := a.startSession()
-	if err != nil {
-		return watch.WaitResult{}, fmt.Errorf("prepare manual input: %w", err)
-	}
+	var session *watchInputSession
 	handedOff := false
 	defer func() {
 		if handedOff {
 			return
 		}
-		if err := releaseWatchInput(session, restore); err != nil && resultErr == nil {
+		if err := releaseWatchInput(session, restore); err != nil {
+			if resultErr != nil {
+				resultErr = fmt.Errorf("%v; restore terminal input: %w", resultErr, err)
+				return
+			}
 			resultErr = fmt.Errorf("restore terminal input: %w", err)
 		}
 	}()
+	session, err = a.startSession()
+	if err != nil {
+		return watch.WaitResult{}, fmt.Errorf("prepare manual input: %w", err)
+	}
 
 	timer := time.NewTimer(duration)
 	defer timer.Stop()
@@ -96,6 +101,9 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 				result, err := a.coalesce(ctx, &session, &restore, 1)
 				if err != nil {
 					return watch.WaitResult{}, err
+				}
+				if result.Interrupted {
+					return result, nil
 				}
 				result.Finalize = a.handoff(&session, &restore)
 				handedOff = true
@@ -235,14 +243,14 @@ func (a *watchInputAdapter) coalesce(
 func (a *watchInputAdapter) handoff(
 	session **watchInputSession,
 	restore *func() error,
-) func(context.Context) (watch.WaitResult, error) {
+) func(context.Context, <-chan struct{}) (watch.WaitResult, error) {
 	finalized := false
-	return func(ctx context.Context) (watch.WaitResult, error) {
+	return func(ctx context.Context, stateReady <-chan struct{}) (watch.WaitResult, error) {
 		if finalized {
 			return watch.WaitResult{}, nil
 		}
 		finalized = true
-		result, collectErr := a.coalesce(ctx, session, restore, 0)
+		result, collectErr := a.coalesceThroughState(ctx, session, restore, stateReady)
 		releaseErr := releaseWatchInput(*session, *restore)
 		*session = nil
 		*restore = nil
@@ -256,6 +264,67 @@ func (a *watchInputAdapter) handoff(
 			return result, fmt.Errorf("restore terminal input: %w", releaseErr)
 		}
 		return result, nil
+	}
+}
+
+func (a *watchInputAdapter) coalesceThroughState(
+	ctx context.Context,
+	session **watchInputSession,
+	restore *func() error,
+	stateReady <-chan struct{},
+) (watch.WaitResult, error) {
+	var timer *time.Timer
+	var quiet <-chan time.Time
+	if stateReady == nil {
+		timer = time.NewTimer(manualRequestCoalesceWindow)
+		quiet = timer.C
+		stateReady = nil
+	}
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
+	count := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return watch.WaitResult{}, ctx.Err()
+		case <-stateReady:
+			stateReady = nil
+			timer = time.NewTimer(manualRequestCoalesceWindow)
+			quiet = timer.C
+		case <-quiet:
+			return watch.WaitResult{ManualRequests: count}, nil
+		case read := <-sessionReads(*session):
+			if read.err != nil {
+				return watch.WaitResult{}, fmt.Errorf("read manual input: %w", read.err)
+			}
+			switch read.key {
+			case 3:
+				return watch.WaitResult{Interrupted: true}, nil
+			case 26:
+				if a.suspend != nil {
+					if err := a.suspendAndResume(session, restore); err != nil {
+						return watch.WaitResult{}, err
+					}
+				}
+			case 'r', 'R':
+				count++
+				if timer == nil {
+					continue
+				}
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(manualRequestCoalesceWindow)
+				quiet = timer.C
+			}
+		}
 	}
 }
 

--- a/cmd/acr/watch_input.go
+++ b/cmd/acr/watch_input.go
@@ -54,19 +54,18 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 		}
 		return watch.WaitResult{}, fmt.Errorf("enable manual input: %w", err)
 	}
-	defer func() {
-		if err := restore(); err != nil && resultErr == nil {
-			resultErr = fmt.Errorf("restore terminal input: %w", err)
-		}
-	}()
 
 	session, err := a.startSession()
 	if err != nil {
 		return watch.WaitResult{}, fmt.Errorf("prepare manual input: %w", err)
 	}
+	handedOff := false
 	defer func() {
-		if session != nil {
-			session.close()
+		if handedOff {
+			return
+		}
+		if err := releaseWatchInput(session, restore); err != nil && resultErr == nil {
+			resultErr = fmt.Errorf("restore terminal input: %w", err)
 		}
 	}()
 
@@ -94,7 +93,13 @@ func (a *watchInputAdapter) Wait(ctx context.Context, duration time.Duration) (r
 					return watch.WaitResult{}, err
 				}
 			case 'r', 'R':
-				return a.coalesce(ctx, &session, &restore)
+				result, err := a.coalesce(ctx, &session, &restore, 1)
+				if err != nil {
+					return watch.WaitResult{}, err
+				}
+				result.Finalize = a.handoff(&session, &restore)
+				handedOff = true
+				return result, nil
 			}
 		}
 	}
@@ -122,6 +127,16 @@ func (s *watchInputSession) close() {
 		<-s.done
 	}
 	s.reader.Close()
+}
+
+func releaseWatchInput(session *watchInputSession, restore func() error) error {
+	if session != nil {
+		session.close()
+	}
+	if restore == nil {
+		return nil
+	}
+	return restore()
 }
 
 func sessionReads(session *watchInputSession) <-chan watchInputRead {
@@ -179,8 +194,8 @@ func (a *watchInputAdapter) coalesce(
 	ctx context.Context,
 	session **watchInputSession,
 	restore *func() error,
+	count int,
 ) (watch.WaitResult, error) {
-	count := 1
 	timer := time.NewTimer(manualRequestCoalesceWindow)
 	defer timer.Stop()
 
@@ -214,6 +229,33 @@ func (a *watchInputAdapter) coalesce(
 				timer.Reset(manualRequestCoalesceWindow)
 			}
 		}
+	}
+}
+
+func (a *watchInputAdapter) handoff(
+	session **watchInputSession,
+	restore *func() error,
+) func(context.Context) (watch.WaitResult, error) {
+	finalized := false
+	return func(ctx context.Context) (watch.WaitResult, error) {
+		if finalized {
+			return watch.WaitResult{}, nil
+		}
+		finalized = true
+		result, collectErr := a.coalesce(ctx, session, restore, 0)
+		releaseErr := releaseWatchInput(*session, *restore)
+		*session = nil
+		*restore = nil
+		if collectErr != nil {
+			if releaseErr != nil {
+				return result, fmt.Errorf("%v; restore terminal input: %w", collectErr, releaseErr)
+			}
+			return result, collectErr
+		}
+		if releaseErr != nil {
+			return result, fmt.Errorf("restore terminal input: %w", releaseErr)
+		}
+		return result, nil
 	}
 }
 

--- a/cmd/acr/watch_input_darwin.go
+++ b/cmd/acr/watch_input_darwin.go
@@ -34,7 +34,10 @@ func activateWatchInput(input *os.File) (func() error, error) {
 		return nil, err
 	}
 	return func() error {
-		return term.Restore(fd, rawState)
+		if err := term.Restore(fd, rawState); err != nil {
+			return err
+		}
+		return unix.IoctlSetTermios(fd, unix.TIOCSETAF, state)
 	}, nil
 }
 

--- a/cmd/acr/watch_input_linux.go
+++ b/cmd/acr/watch_input_linux.go
@@ -34,7 +34,10 @@ func activateWatchInput(input *os.File) (func() error, error) {
 		return nil, err
 	}
 	return func() error {
-		return term.Restore(fd, rawState)
+		if err := term.Restore(fd, rawState); err != nil {
+			return err
+		}
+		return unix.IoctlSetTermios(fd, unix.TCSETSF, state)
 	}, nil
 }
 

--- a/cmd/acr/watch_input_test.go
+++ b/cmd/acr/watch_input_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/muesli/cancelreader"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
 
 func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
@@ -34,13 +36,13 @@ func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
 		},
 	}
 	type waitOutcome struct {
-		result int
+		result watch.WaitResult
 		err    error
 	}
 	outcome := make(chan waitOutcome, 1)
 	go func() {
 		result, err := adapter.Wait(context.Background(), time.Hour)
-		outcome <- waitOutcome{result: result.ManualRequests, err: err}
+		outcome <- waitOutcome{result: result, err: err}
 	}()
 
 	<-activated
@@ -51,8 +53,23 @@ func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
 	if got.err != nil {
 		t.Fatal(got.err)
 	}
-	if got.result != 3 {
-		t.Fatalf("manual requests = %d, want 3", got.result)
+	if got.result.ManualRequests != 3 {
+		t.Fatalf("manual requests = %d, want 3", got.result.ManualRequests)
+	}
+	select {
+	case <-released:
+		t.Fatal("manual input released before the pre-review handoff")
+	default:
+	}
+	if _, err := writer.Write([]byte("r")); err != nil {
+		t.Fatal(err)
+	}
+	additional, err := got.result.Finalize(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if additional.ManualRequests != 1 {
+		t.Fatalf("additional manual requests = %d, want 1", additional.ManualRequests)
 	}
 	<-released
 
@@ -220,13 +237,13 @@ func TestWatchInputAdapterSuspendsDuringCoalescing(t *testing.T) {
 		},
 	}
 	type waitOutcome struct {
-		result int
+		result watch.WaitResult
 		err    error
 	}
 	outcome := make(chan waitOutcome, 1)
 	go func() {
 		result, err := adapter.Wait(context.Background(), time.Hour)
-		outcome <- waitOutcome{result: result.ManualRequests, err: err}
+		outcome <- waitOutcome{result: result, err: err}
 	}()
 
 	<-activated
@@ -239,8 +256,11 @@ func TestWatchInputAdapterSuspendsDuringCoalescing(t *testing.T) {
 	if got.err != nil {
 		t.Fatal(got.err)
 	}
-	if got.result != 1 {
-		t.Fatalf("manual requests = %d, want 1", got.result)
+	if got.result.ManualRequests != 1 {
+		t.Fatalf("manual requests = %d, want 1", got.result.ManualRequests)
+	}
+	if _, err := got.result.Finalize(context.Background()); err != nil {
+		t.Fatal(err)
 	}
 	<-released
 }
@@ -343,6 +363,42 @@ func TestWatchInputAdapterReportsTerminalRestoreFailure(t *testing.T) {
 
 	_, err = adapter.Wait(context.Background(), time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "restore terminal input: restore failed") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWatchInputAdapterReportsHandoffRestoreFailure(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{})
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			close(activated)
+			return func() error { return errors.New("restore failed") }, nil
+		},
+	}
+	outcome := make(chan watch.WaitResult, 1)
+	go func() {
+		result, _ := adapter.Wait(context.Background(), time.Hour)
+		outcome <- result
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte("r")); err != nil {
+		t.Fatal(err)
+	}
+	result := <-outcome
+	if result.Finalize == nil {
+		t.Fatal("manual input handoff is missing")
+	}
+	if _, err := result.Finalize(context.Background()); err == nil || !strings.Contains(err.Error(), "restore terminal input: restore failed") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/cmd/acr/watch_input_test.go
+++ b/cmd/acr/watch_input_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
 
+type waitOutcome struct {
+	result watch.WaitResult
+	err    error
+}
+
 func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
 	reader, writer, err := os.Pipe()
 	if err != nil {
@@ -34,10 +39,6 @@ func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
 				return nil
 			}, nil
 		},
-	}
-	type waitOutcome struct {
-		result watch.WaitResult
-		err    error
 	}
 	outcome := make(chan waitOutcome, 1)
 	go func() {
@@ -61,10 +62,18 @@ func TestWatchInputAdapterReadsAndCoalescesManualRequests(t *testing.T) {
 		t.Fatal("manual input released before the pre-review handoff")
 	default:
 	}
+	stateReady := make(chan struct{})
+	finalized := make(chan waitOutcome, 1)
+	go func() {
+		result, err := got.result.Finalize(context.Background(), stateReady)
+		finalized <- waitOutcome{result: result, err: err}
+	}()
 	if _, err := writer.Write([]byte("r")); err != nil {
 		t.Fatal(err)
 	}
-	additional, err := got.result.Finalize(context.Background())
+	close(stateReady)
+	final := <-finalized
+	additional, err := final.result, final.err
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +268,9 @@ func TestWatchInputAdapterSuspendsDuringCoalescing(t *testing.T) {
 	if got.result.ManualRequests != 1 {
 		t.Fatalf("manual requests = %d, want 1", got.result.ManualRequests)
 	}
-	if _, err := got.result.Finalize(context.Background()); err != nil {
+	stateReady := make(chan struct{})
+	close(stateReady)
+	if _, err := got.result.Finalize(context.Background(), stateReady); err != nil {
 		t.Fatal(err)
 	}
 	<-released
@@ -398,8 +409,151 @@ func TestWatchInputAdapterReportsHandoffRestoreFailure(t *testing.T) {
 	if result.Finalize == nil {
 		t.Fatal("manual input handoff is missing")
 	}
-	if _, err := result.Finalize(context.Background()); err == nil || !strings.Contains(err.Error(), "restore terminal input: restore failed") {
+	stateReady := make(chan struct{})
+	close(stateReady)
+	if _, err := result.Finalize(context.Background(), stateReady); err == nil || !strings.Contains(err.Error(), "restore terminal input: restore failed") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWatchInputAdapterRestoresWhenReaderSetupFails(t *testing.T) {
+	released := false
+	adapter := &watchInputAdapter{
+		input: strings.NewReader(""),
+		activate: func() (func() error, error) {
+			return func() error {
+				released = true
+				return nil
+			}, nil
+		},
+		newReader: func(io.Reader) (cancelreader.CancelReader, error) {
+			return nil, errors.New("reader failed")
+		},
+	}
+
+	_, err := adapter.Wait(context.Background(), time.Hour)
+	if err == nil || !strings.Contains(err.Error(), "prepare manual input: reader failed") {
+		t.Fatalf("error = %v", err)
+	}
+	if !released {
+		t.Fatal("terminal input was not restored after reader setup failed")
+	}
+}
+
+func TestWatchInputAdapterReleasesInterruptedCoalescing(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{})
+	released := make(chan struct{})
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			close(activated)
+			return func() error {
+				close(released)
+				return nil
+			}, nil
+		},
+	}
+	outcome := make(chan waitOutcome, 1)
+	go func() {
+		result, err := adapter.Wait(context.Background(), time.Hour)
+		outcome <- waitOutcome{result: result, err: err}
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte{'r', 3}); err != nil {
+		t.Fatal(err)
+	}
+	got := <-outcome
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if !got.result.Interrupted {
+		t.Fatal("control-C during coalescing did not interrupt the wait")
+	}
+	if got.result.Finalize != nil {
+		t.Fatal("interrupted coalescing retained a finalizer")
+	}
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("terminal input was not restored after interrupted coalescing")
+	}
+}
+
+func TestWatchInputAdapterHandlesControlsDuringStateFetch(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	activated := make(chan struct{}, 2)
+	released := make(chan struct{}, 2)
+	suspended := make(chan struct{}, 1)
+	adapter := &watchInputAdapter{
+		input: reader,
+		activate: func() (func() error, error) {
+			activated <- struct{}{}
+			return func() error {
+				released <- struct{}{}
+				return nil
+			}, nil
+		},
+		suspend: func() error {
+			<-released
+			suspended <- struct{}{}
+			return nil
+		},
+	}
+	outcome := make(chan waitOutcome, 1)
+	go func() {
+		result, err := adapter.Wait(context.Background(), time.Hour)
+		outcome <- waitOutcome{result: result, err: err}
+	}()
+
+	<-activated
+	if _, err := writer.Write([]byte("r")); err != nil {
+		t.Fatal(err)
+	}
+	waited := <-outcome
+	if waited.err != nil {
+		t.Fatal(waited.err)
+	}
+	stateReady := make(chan struct{})
+	finalized := make(chan waitOutcome, 1)
+	go func() {
+		result, err := waited.result.Finalize(context.Background(), stateReady)
+		finalized <- waitOutcome{result: result, err: err}
+	}()
+	if _, err := writer.Write([]byte{26}); err != nil {
+		t.Fatal(err)
+	}
+	<-suspended
+	<-activated
+	if _, err := writer.Write([]byte{3}); err != nil {
+		t.Fatal(err)
+	}
+	got := <-finalized
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if !got.result.Interrupted {
+		t.Fatal("control-C during state fetch did not interrupt the handoff")
+	}
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("terminal input was not restored after state-fetch interruption")
 	}
 }
 

--- a/cmd/acr/watch_input_windows.go
+++ b/cmd/acr/watch_input_windows.go
@@ -21,7 +21,10 @@ func activateWatchInput(input *os.File) (func() error, error) {
 		return nil, err
 	}
 	return func() error {
-		return term.Restore(fd, state)
+		if err := term.Restore(fd, state); err != nil {
+			return err
+		}
+		return windows.FlushConsoleInputBuffer(windows.Handle(input.Fd()))
 	}, nil
 }
 

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -313,6 +313,9 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			if reason, done := l.handleWaitError(err); done {
 				return reason
 			}
+			if waitResult.Interrupted {
+				return ReasonInterrupted
+			}
 			l.receiveManualRequests(waitResult.ManualRequests)
 			l.rejectManualRequests(ReasonMaxDuration.String())
 			l.logf("Reached maximum duration (%s) without a terminal LGTM; stopping.", cfg.MaxDuration)

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -66,7 +66,7 @@ type Deps struct {
 type WaitResult struct {
 	ManualRequests int
 	Interrupted    bool
-	Finalize       func(context.Context) (WaitResult, error)
+	Finalize       func(context.Context, <-chan struct{}) (WaitResult, error)
 }
 
 type EventType string
@@ -167,15 +167,49 @@ func (l *loop) wait(ctx context.Context, duration time.Duration) (WaitResult, er
 	return WaitResult{}, l.deps.Clock.Sleep(ctx, duration)
 }
 
-func (l *loop) finalizeWait(ctx context.Context, result WaitResult) (WaitResult, error) {
+func (l *loop) finalizeWait(
+	ctx context.Context,
+	result WaitResult,
+	stateReady <-chan struct{},
+) (WaitResult, error) {
 	if result.Finalize == nil {
 		return result, nil
 	}
-	additional, err := result.Finalize(ctx)
+	additional, err := result.Finalize(ctx, stateReady)
 	result.Finalize = nil
 	result.ManualRequests += additional.ManualRequests
 	result.Interrupted = result.Interrupted || additional.Interrupted
 	return result, err
+}
+
+type stateOutcome struct {
+	state PRState
+	err   error
+}
+
+func (l *loop) stateAfterWait(
+	ctx context.Context,
+	result WaitResult,
+) (PRState, error, WaitResult, error) {
+	if result.Finalize == nil {
+		state, err := l.deps.State(ctx)
+		return state, err, result, nil
+	}
+	stateCtx, cancelState := context.WithCancel(ctx)
+	defer cancelState()
+	stateReady := make(chan struct{})
+	outcome := make(chan stateOutcome, 1)
+	go func() {
+		state, err := l.deps.State(stateCtx)
+		outcome <- stateOutcome{state: state, err: err}
+		close(stateReady)
+	}()
+	finalized, finalizeErr := l.finalizeWait(ctx, result, stateReady)
+	if finalizeErr != nil || finalized.Interrupted {
+		cancelState()
+	}
+	stateResult := <-outcome
+	return stateResult.state, stateResult.err, finalized, finalizeErr
 }
 
 func (l *loop) handleWaitError(err error) (ExitReason, bool) {
@@ -273,7 +307,9 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 		if !clock.Now().Before(deadline) {
 			var err error
-			waitResult, err = l.finalizeWait(ctx, waitResult)
+			stateReady := make(chan struct{})
+			close(stateReady)
+			waitResult, err = l.finalizeWait(ctx, waitResult, stateReady)
 			if reason, done := l.handleWaitError(err); done {
 				return reason
 			}
@@ -283,8 +319,7 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			return ReasonMaxDuration
 		}
 
-		st, err := deps.State(ctx)
-		waitResult, waitErr := l.finalizeWait(ctx, waitResult)
+		st, err, waitResult, waitErr := l.stateAfterWait(ctx, waitResult)
 		if reason, done := l.handleWaitError(waitErr); done {
 			return reason
 		}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -66,6 +66,7 @@ type Deps struct {
 type WaitResult struct {
 	ManualRequests int
 	Interrupted    bool
+	Finalize       func(context.Context) (WaitResult, error)
 }
 
 type EventType string
@@ -166,6 +167,29 @@ func (l *loop) wait(ctx context.Context, duration time.Duration) (WaitResult, er
 	return WaitResult{}, l.deps.Clock.Sleep(ctx, duration)
 }
 
+func (l *loop) finalizeWait(ctx context.Context, result WaitResult) (WaitResult, error) {
+	if result.Finalize == nil {
+		return result, nil
+	}
+	additional, err := result.Finalize(ctx)
+	result.Finalize = nil
+	result.ManualRequests += additional.ManualRequests
+	result.Interrupted = result.Interrupted || additional.Interrupted
+	return result, err
+}
+
+func (l *loop) handleWaitError(err error) (ExitReason, bool) {
+	if err == nil {
+		return 0, false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ReasonInterrupted, true
+	}
+	l.emit(Event{Type: EventManualInputUnsafe, Reason: err.Error()})
+	l.logf("Manual input could not be handled safely: %v", err)
+	return ReasonError, true
+}
+
 func (l *loop) receiveManualRequests(count int) {
 	if count <= 0 {
 		return
@@ -224,6 +248,7 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 
 	pollErrors := 0
 	for {
+		waitResult := WaitResult{}
 		now := clock.Now()
 		if !now.Before(deadline) {
 			l.rejectManualRequests(ReasonMaxDuration.String())
@@ -235,29 +260,38 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			if remaining := deadline.Sub(now); remaining < sleep {
 				sleep = remaining
 			}
-			waitResult, err := l.wait(ctx, sleep)
+			var err error
+			waitResult, err = l.wait(ctx, sleep)
 			if err != nil {
-				if ctx.Err() != nil {
-					return ReasonInterrupted
+				if reason, done := l.handleWaitError(err); done {
+					return reason
 				}
-				l.emit(Event{Type: EventManualInputUnsafe, Reason: err.Error()})
-				l.logf("Manual input could not be handled safely: %v", err)
-				return ReasonError
 			}
 			if waitResult.Interrupted {
 				return ReasonInterrupted
 			}
-			l.receiveManualRequests(waitResult.ManualRequests)
 		}
 		if !clock.Now().Before(deadline) {
+			var err error
+			waitResult, err = l.finalizeWait(ctx, waitResult)
+			if reason, done := l.handleWaitError(err); done {
+				return reason
+			}
+			l.receiveManualRequests(waitResult.ManualRequests)
 			l.rejectManualRequests(ReasonMaxDuration.String())
 			l.logf("Reached maximum duration (%s) without a terminal LGTM; stopping.", cfg.MaxDuration)
 			return ReasonMaxDuration
 		}
 
-		manualTrigger := l.manualRequests > 0
-
 		st, err := deps.State(ctx)
+		waitResult, waitErr := l.finalizeWait(ctx, waitResult)
+		if reason, done := l.handleWaitError(waitErr); done {
+			return reason
+		}
+		if waitResult.Interrupted {
+			return ReasonInterrupted
+		}
+		l.receiveManualRequests(waitResult.ManualRequests)
 		if err != nil {
 			if ctx.Err() != nil {
 				return ReasonInterrupted
@@ -270,6 +304,8 @@ func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			continue
 		}
 		pollErrors = 0
+
+		manualTrigger := l.manualRequests > 0
 
 		if reason, done := l.checkOpen(st); done {
 			if manualTrigger {

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -231,6 +231,59 @@ func TestManualRequestsCoalesceBeforeReviewStarts(t *testing.T) {
 	}
 }
 
+func TestManualRequestsCoalesceThroughPreReviewHandoff(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{
+		{Result: CycleFindings},
+		{Result: CycleLGTMApproved},
+	}
+	deps := h.deps()
+	state := deps.State
+	runCycle := deps.RunCycle
+	stateCalls := 0
+	var order []string
+	deps.State = func(ctx context.Context) (PRState, error) {
+		stateCalls++
+		result, err := state(ctx)
+		if stateCalls == 2 {
+			order = append(order, "state")
+		}
+		return result, err
+	}
+	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
+		return WaitResult{
+			ManualRequests: 1,
+			Finalize: func(context.Context) (WaitResult, error) {
+				order = append(order, "finalize")
+				return WaitResult{ManualRequests: 2}, nil
+			},
+		}, nil
+	}
+	deps.RunCycle = func(ctx context.Context, reviewNum int, trigger string) (Cycle, error) {
+		if trigger == "manual request" {
+			order = append(order, "cycle")
+		}
+		return runCycle(ctx, reviewNum, trigger)
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if strings.Join(order, ",") != "state,finalize,cycle" {
+		t.Fatalf("order = %v", order)
+	}
+	var started Event
+	for _, event := range h.events {
+		if event.Type == EventManualReviewStarted {
+			started = event
+		}
+	}
+	if started.RequestCount != 3 {
+		t.Fatalf("manual review event = %#v", started)
+	}
+}
+
 func TestManualRequestRejectedWhenReviewBudgetIsExhausted(t *testing.T) {
 	h := newHarness(t)
 	h.states = []PRState{open("aaa")}
@@ -280,6 +333,31 @@ func TestManualInputSafetyFailureStopsWatcher(t *testing.T) {
 	}
 	if !hasEvent(h.events, EventManualInputUnsafe) {
 		t.Fatalf("events = %#v", h.events)
+	}
+}
+
+func TestManualInputHandoffFailureStopsWatcher(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	deps := h.deps()
+	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
+		return WaitResult{
+			ManualRequests: 1,
+			Finalize: func(context.Context) (WaitResult, error) {
+				return WaitResult{}, errors.New("terminal restore failed")
+			},
+		}, nil
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), deps); reason != ReasonError {
+		t.Fatalf("reason = %v, want ReasonError", reason)
+	}
+	if !hasEvent(h.events, EventManualInputUnsafe) {
+		t.Fatalf("events = %#v", h.events)
+	}
+	if len(h.triggers) != 1 {
+		t.Fatalf("cycles = %d, want only the initial review", len(h.triggers))
 	}
 }
 

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -254,7 +254,8 @@ func TestManualRequestsCoalesceThroughPreReviewHandoff(t *testing.T) {
 	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
 		return WaitResult{
 			ManualRequests: 1,
-			Finalize: func(context.Context) (WaitResult, error) {
+			Finalize: func(_ context.Context, stateReady <-chan struct{}) (WaitResult, error) {
+				<-stateReady
 				order = append(order, "finalize")
 				return WaitResult{ManualRequests: 2}, nil
 			},
@@ -344,7 +345,7 @@ func TestManualInputHandoffFailureStopsWatcher(t *testing.T) {
 	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
 		return WaitResult{
 			ManualRequests: 1,
-			Finalize: func(context.Context) (WaitResult, error) {
+			Finalize: func(context.Context, <-chan struct{}) (WaitResult, error) {
 				return WaitResult{}, errors.New("terminal restore failed")
 			},
 		}, nil
@@ -358,6 +359,45 @@ func TestManualInputHandoffFailureStopsWatcher(t *testing.T) {
 	}
 	if len(h.triggers) != 1 {
 		t.Fatalf("cycles = %d, want only the initial review", len(h.triggers))
+	}
+}
+
+func TestManualInputInterruptCancelsStateFetch(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	deps := h.deps()
+	state := deps.State
+	stateCalls := 0
+	stateStarted := make(chan struct{})
+	stateCanceled := make(chan struct{})
+	deps.State = func(ctx context.Context) (PRState, error) {
+		stateCalls++
+		if stateCalls == 1 {
+			return state(ctx)
+		}
+		close(stateStarted)
+		<-ctx.Done()
+		close(stateCanceled)
+		return PRState{}, ctx.Err()
+	}
+	deps.Wait = func(context.Context, time.Duration) (WaitResult, error) {
+		return WaitResult{
+			ManualRequests: 1,
+			Finalize: func(context.Context, <-chan struct{}) (WaitResult, error) {
+				<-stateStarted
+				return WaitResult{Interrupted: true}, nil
+			},
+		}, nil
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeComment), deps); reason != ReasonInterrupted {
+		t.Fatalf("reason = %v, want ReasonInterrupted", reason)
+	}
+	select {
+	case <-stateCanceled:
+	default:
+		t.Fatal("state fetch was not canceled after manual input interrupted")
 	}
 }
 

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -401,6 +401,28 @@ func TestManualInputInterruptCancelsStateFetch(t *testing.T) {
 	}
 }
 
+func TestManualInputInterruptWinsAtDeadlineFinalization(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	cfg := defaultConfig(PostModeComment)
+	deps := h.deps()
+	deps.Wait = func(_ context.Context, duration time.Duration) (WaitResult, error) {
+		h.clock.now = h.clock.now.Add(duration)
+		return WaitResult{
+			ManualRequests: 1,
+			Finalize: func(_ context.Context, stateReady <-chan struct{}) (WaitResult, error) {
+				<-stateReady
+				return WaitResult{Interrupted: true}, nil
+			},
+		}, nil
+	}
+
+	if reason := Run(context.Background(), cfg, deps); reason != ReasonInterrupted {
+		t.Fatalf("reason = %v, want ReasonInterrupted", reason)
+	}
+}
+
 func TestManualRequestSurvivesTransientStateFailureWithRetryDelay(t *testing.T) {
 	h := newHarness(t)
 	h.cycles = []Cycle{


### PR DESCRIPTION
## What changed

- keeps manual watcher input ownership active through the fresh-state capture that precedes review execution
- coalesces later human-paced `r` presses into the same manual review request
- releases and flushes terminal input immediately before review or posting can own stdin
- fails closed if the handoff or terminal restoration cannot complete safely
- adds adapter and watcher-engine regression coverage for the complete pre-review handoff

## Root cause

PR #250 ended input ownership after a 30 ms burst-coalescing window. Input entered after that window but before the requested review actually started could remain queued and reach a later interactive posting prompt, violating #249’s coalescing and terminal-ownership requirements.

## Validation

- `go test -race ./cmd/acr ./internal/watch -run 'TestWatchInputAdapter|TestManual' -count=10 -timeout=120s`
- `go test -race ./cmd/acr ./internal/watch -count=5 -timeout=180s`
- Linux, Windows, and FreeBSD command-test cross-compiles
- `make check`
- `git diff --check`

Follow-up to #250 and #249.