### PR TITLE
Extract reusable watcher lifecycle

### DIFF
--- a/cmd/acr/watch.go
+++ b/cmd/acr/watch.go
@@ -184,11 +184,8 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	logger.Logf(terminal.StyleInfo, "Watching PR %s (mode=%s, poll=%s, settle=%s, max-reviews=%d, max-duration=%s)",
 		formatPRRef(watchPR), mode, wcfg.PollInterval, wcfg.SettleTime, wcfg.MaxReviews, wcfg.MaxDuration)
 
-	deps := watch.Deps{
+	polling := watch.Polling{
 		Clock: watch.RealClock{},
-		Logf: func(format string, args ...any) {
-			logger.Logf(terminal.StyleInfo, format, args...)
-		},
 		State: func(ctx context.Context) (watch.PRState, error) {
 			st, err := github.GetPRWatchState(ctx, repoRoot, watchPR)
 			if err != nil {
@@ -206,6 +203,19 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 				Discussion:      mapWatchDiscussion(discussion),
 			}, nil
 		},
+	}
+	reviewExecution := watch.ReviewExecution{
+		RunCycle: func(
+			ctx context.Context,
+			_ int,
+			_ string,
+			discussion []watch.Discussion,
+			discussionRevision string,
+		) (watch.Cycle, error) {
+			return runWatchCycle(ctx, cmd, watchPR, repositoryHost, mode, discussion, discussionRevision, logger)
+		},
+	}
+	actions := watch.ActionPolicies{
 		CIGreen: func(ctx context.Context) (bool, error) {
 			status := github.CheckCIStatus(ctx, repoRoot, watchPR)
 			if status.Error != "" {
@@ -216,14 +226,10 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		Approve: func(ctx context.Context, body string) error {
 			return github.ApprovePR(ctx, repoRoot, watchPR, body)
 		},
-		RunCycle: func(
-			ctx context.Context,
-			_ int,
-			_ string,
-			discussion []watch.Discussion,
-			discussionRevision string,
-		) (watch.Cycle, error) {
-			return runWatchCycle(ctx, cmd, watchPR, repositoryHost, mode, discussion, discussionRevision, logger)
+	}
+	presentation := watch.Presentation{
+		Logf: func(format string, args ...any) {
+			logger.Logf(terminal.StyleInfo, format, args...)
 		},
 	}
 	routerAgent := cfgResult.resolved.PRFeedbackAgent
@@ -241,17 +247,24 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		logger.Logf(terminal.StyleError, "Failed to initialize discussion router: %v", err)
 		return exitCode(domain.ExitError)
 	}
-	deps.RouteDiscussion = func(ctx context.Context, discussion []watch.Discussion) (watch.RoutingDecision, error) {
+	actions.RouteDiscussion = func(ctx context.Context, discussion []watch.Discussion) (watch.RoutingDecision, error) {
 		routeCtx, cancel := context.WithTimeout(ctx, cfgResult.resolved.SummarizerTimeout)
 		defer cancel()
 		return router.Route(routeCtx, discussion)
 	}
 	if terminal.IsStdinTTY() && watchInputSupported() {
-		deps.Wait = newWatchInputAdapter(os.Stdin).Wait
+		polling.Wait = newWatchInputAdapter(os.Stdin).Wait
 		logger.Log("Press r while waiting to request an immediate review.", terminal.StyleDim)
 	}
 
-	reason := watch.Run(ctx, wcfg, deps)
+	lifecycle := watch.NewLifecycle(
+		wcfg,
+		polling,
+		reviewExecution,
+		actions,
+		presentation,
+	)
+	reason := lifecycle.Run(ctx)
 	logger.Logf(terminal.StyleInfo, "Watch finished: %s", reason)
 
 	switch reason {

--- a/internal/watch/lifecycle.go
+++ b/internal/watch/lifecycle.go
@@ -1,0 +1,60 @@
+package watch
+
+import (
+	"context"
+	"time"
+)
+
+type Polling struct {
+	State func(ctx context.Context) (PRState, error)
+	Wait  func(ctx context.Context, duration time.Duration) (WaitResult, error)
+	Clock Clock
+}
+
+type ReviewExecution struct {
+	RunCycle func(ctx context.Context, reviewNum int, trigger string, discussion []Discussion, discussionRevision string) (Cycle, error)
+}
+
+type ActionPolicies struct {
+	RouteDiscussion func(ctx context.Context, discussion []Discussion) (RoutingDecision, error)
+	CIGreen         func(ctx context.Context) (bool, error)
+	Approve         func(ctx context.Context, body string) error
+}
+
+type Presentation struct {
+	Emit func(event Event)
+	Logf func(format string, args ...any)
+}
+
+type Lifecycle struct {
+	cfg  Config
+	deps Deps
+}
+
+func NewLifecycle(
+	cfg Config,
+	polling Polling,
+	review ReviewExecution,
+	actions ActionPolicies,
+	presentation Presentation,
+) *Lifecycle {
+	return newLifecycleFromDeps(cfg, Deps{
+		State:           polling.State,
+		Wait:            polling.Wait,
+		Clock:           polling.Clock,
+		RunCycle:        review.RunCycle,
+		RouteDiscussion: actions.RouteDiscussion,
+		CIGreen:         actions.CIGreen,
+		Approve:         actions.Approve,
+		Emit:            presentation.Emit,
+		Logf:            presentation.Logf,
+	})
+}
+
+func newLifecycleFromDeps(cfg Config, deps Deps) *Lifecycle {
+	return &Lifecycle{cfg: cfg, deps: deps}
+}
+
+func (l *Lifecycle) Run(ctx context.Context) ExitReason {
+	return run(ctx, l.cfg, l.deps)
+}

--- a/internal/watch/lifecycle.go
+++ b/internal/watch/lifecycle.go
@@ -19,6 +19,7 @@ type ActionPolicies struct {
 	RouteDiscussion func(ctx context.Context, discussion []Discussion) (RoutingDecision, error)
 	CIGreen         func(ctx context.Context) (bool, error)
 	Approve         func(ctx context.Context, body string) error
+	Control         func(ctx context.Context, state PRState) (ControlDecision, error)
 }
 
 type Presentation struct {
@@ -46,6 +47,7 @@ func NewLifecycle(
 		RouteDiscussion: actions.RouteDiscussion,
 		CIGreen:         actions.CIGreen,
 		Approve:         actions.Approve,
+		Control:         actions.Control,
 		Emit:            presentation.Emit,
 		Logf:            presentation.Logf,
 	})

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -417,3 +417,55 @@ func TestLifecycleControlStopsDuringStatePollingFailures(t *testing.T) {
 		})
 	}
 }
+
+func TestLifecycleControlPreventsDeferredApproval(t *testing.T) {
+	tests := []struct {
+		name       string
+		control    ControlState
+		wantReason ExitReason
+	}{
+		{name: "snoozed", control: ControlSnoozed, wantReason: ReasonMerged},
+		{name: "released", control: ControlReleased, wantReason: ReasonReleased},
+		{name: "opted out", control: ControlOptedOut, wantReason: ReasonOptedOut},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := newHarness(t)
+			h.states = []PRState{
+				open("aaa"),
+				open("aaa"),
+				open("aaa"),
+				{HeadSHA: "aaa", Merged: true},
+			}
+			h.cycles = []Cycle{{Result: CycleLGTMCommentCIPending, LGTMBody: "LGTM"}}
+			h.ci = []bool{true}
+			deps := h.deps()
+			controlCalls := 0
+			control := func(context.Context, PRState) (ControlDecision, error) {
+				controlCalls++
+				if controlCalls < 3 {
+					return ControlDecision{State: ControlActive}, nil
+				}
+				return ControlDecision{State: test.control}, nil
+			}
+			lifecycle := NewLifecycle(
+				defaultConfig(PostModeApprove),
+				Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+				ReviewExecution{RunCycle: deps.RunCycle},
+				ActionPolicies{CIGreen: deps.CIGreen, Approve: deps.Approve, Control: control},
+				Presentation{Emit: deps.Emit, Logf: deps.Logf},
+			)
+
+			if reason := lifecycle.Run(context.Background()); reason != test.wantReason {
+				t.Fatalf("reason = %v, want %v", reason, test.wantReason)
+			}
+			if len(h.approvedWith) != 0 {
+				t.Fatalf("approvals = %v, want none", h.approvedWith)
+			}
+			if controlCalls != 3 {
+				t.Fatalf("control calls = %d, want final pre-approval check", controlCalls)
+			}
+		})
+	}
+}

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -1,0 +1,125 @@
+package watch
+
+import (
+	"context"
+	"testing"
+)
+
+type lifecycleFixture struct {
+	name         string
+	states       []PRState
+	cycles       []Cycle
+	wantReason   ExitReason
+	wantTriggers []string
+}
+
+func TestReusableLifecycleTransitionFixtures(t *testing.T) {
+	fixtures := []lifecycleFixture{
+		{
+			name:         "terminal initial review",
+			states:       []PRState{open("aaa")},
+			cycles:       []Cycle{{Result: CycleLGTMApproved}},
+			wantReason:   ReasonLGTM,
+			wantTriggers: []string{"initial review"},
+		},
+		{
+			name: "settled replacement head",
+			states: []PRState{
+				open("aaa"),
+				open("bbb"),
+				open("bbb"),
+			},
+			cycles: []Cycle{
+				{Result: CycleFindings},
+				{Result: CycleLGTMComment},
+			},
+			wantReason:   ReasonLGTM,
+			wantTriggers: []string{"initial review", "commits settled"},
+		},
+		{
+			name: "stale result returns to eligibility",
+			states: []PRState{
+				open("aaa"),
+				open("bbb"),
+				open("bbb"),
+			},
+			cycles: []Cycle{
+				{Result: CycleStaleHead},
+				{Result: CycleLGTMComment},
+			},
+			wantReason:   ReasonLGTM,
+			wantTriggers: []string{"initial review", "commits settled"},
+		},
+		{
+			name:         "merged pull request is not admitted",
+			states:       []PRState{{HeadSHA: "aaa", Merged: true}},
+			wantReason:   ReasonMerged,
+			wantTriggers: nil,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			h := newHarness(t)
+			h.states = fixture.states
+			h.cycles = fixture.cycles
+			deps := h.deps()
+			lifecycle := NewLifecycle(
+				defaultConfig(PostModeApprove),
+				Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+				ReviewExecution{RunCycle: deps.RunCycle},
+				ActionPolicies{
+					RouteDiscussion: deps.RouteDiscussion,
+					CIGreen:         deps.CIGreen,
+					Approve:         deps.Approve,
+				},
+				Presentation{Emit: deps.Emit, Logf: deps.Logf},
+			)
+
+			if reason := lifecycle.Run(context.Background()); reason != fixture.wantReason {
+				t.Fatalf("reason = %v, want %v", reason, fixture.wantReason)
+			}
+			if len(h.triggers) != len(fixture.wantTriggers) {
+				t.Fatalf("triggers = %v, want %v", h.triggers, fixture.wantTriggers)
+			}
+			for i := range fixture.wantTriggers {
+				if h.triggers[i] != fixture.wantTriggers[i] {
+					t.Fatalf("triggers = %v, want %v", h.triggers, fixture.wantTriggers)
+				}
+			}
+		})
+	}
+}
+
+func TestLifecyclePresentationDoesNotControlTransitions(t *testing.T) {
+	build := func(presentation Presentation) (*Lifecycle, *harness) {
+		h := newHarness(t)
+		h.states = []PRState{open("aaa")}
+		h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+		deps := h.deps()
+		return NewLifecycle(
+			defaultConfig(PostModeApprove),
+			Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+			ReviewExecution{RunCycle: deps.RunCycle},
+			ActionPolicies{CIGreen: deps.CIGreen, Approve: deps.Approve},
+			presentation,
+		), h
+	}
+
+	silent, silentHarness := build(Presentation{})
+	visible, visibleHarness := build(Presentation{
+		Emit: func(Event) {},
+		Logf: func(string, ...any) {},
+	})
+
+	if reason := silent.Run(context.Background()); reason != ReasonLGTM {
+		t.Fatalf("silent reason = %v, want %v", reason, ReasonLGTM)
+	}
+	if reason := visible.Run(context.Background()); reason != ReasonLGTM {
+		t.Fatalf("visible reason = %v, want %v", reason, ReasonLGTM)
+	}
+	if len(silentHarness.triggers) != 1 || len(visibleHarness.triggers) != 1 ||
+		silentHarness.triggers[0] != visibleHarness.triggers[0] {
+		t.Fatalf("silent triggers = %v, visible triggers = %v", silentHarness.triggers, visibleHarness.triggers)
+	}
+}

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -338,4 +338,7 @@ func TestLifecycleResumeAtDeadlineDoesNotAdmitReview(t *testing.T) {
 	if len(h.triggers) != 0 {
 		t.Fatalf("triggers = %v, want none", h.triggers)
 	}
+	if h.stateCalls != 1 {
+		t.Fatalf("state calls = %d, want only the initial state fetch", h.stateCalls)
+	}
 }

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -3,12 +3,14 @@ package watch
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 type lifecycleFixture struct {
 	name         string
 	states       []PRState
 	cycles       []Cycle
+	controls     []ControlDecision
 	wantReason   ExitReason
 	wantTriggers []string
 }
@@ -56,6 +58,62 @@ func TestReusableLifecycleTransitionFixtures(t *testing.T) {
 			wantReason:   ReasonMerged,
 			wantTriggers: nil,
 		},
+		{
+			name:         "released pull request is not admitted",
+			states:       []PRState{open("aaa")},
+			controls:     []ControlDecision{{State: ControlReleased}},
+			wantReason:   ReasonReleased,
+			wantTriggers: nil,
+		},
+		{
+			name:         "opted out pull request is not admitted",
+			states:       []PRState{open("aaa")},
+			controls:     []ControlDecision{{State: ControlOptedOut}},
+			wantReason:   ReasonOptedOut,
+			wantTriggers: nil,
+		},
+		{
+			name: "explicit resume admits snoozed pull request",
+			states: []PRState{
+				open("aaa"),
+				open("aaa"),
+			},
+			cycles: []Cycle{{Result: CycleLGTMApproved}},
+			controls: []ControlDecision{
+				{State: ControlSnoozed},
+				{State: ControlActive},
+			},
+			wantReason:   ReasonLGTM,
+			wantTriggers: []string{"initial review"},
+		},
+		{
+			name: "snooze expiry resumes eligibility",
+			states: []PRState{
+				open("aaa"),
+				open("aaa"),
+				open("aaa"),
+			},
+			cycles: []Cycle{{Result: CycleLGTMApproved}},
+			controls: []ControlDecision{
+				{State: ControlSnoozed, ResumeAt: time.Unix(1_700_000_000, 0).Add(2 * time.Minute)},
+			},
+			wantReason:   ReasonLGTM,
+			wantTriggers: []string{"initial review"},
+		},
+		{
+			name: "release stops an active lifecycle",
+			states: []PRState{
+				open("aaa"),
+				open("aaa"),
+			},
+			cycles: []Cycle{{Result: CycleFindings}},
+			controls: []ControlDecision{
+				{State: ControlActive},
+				{State: ControlReleased},
+			},
+			wantReason:   ReasonReleased,
+			wantTriggers: []string{"initial review"},
+		},
 	}
 
 	for _, fixture := range fixtures {
@@ -64,6 +122,17 @@ func TestReusableLifecycleTransitionFixtures(t *testing.T) {
 			h.states = fixture.states
 			h.cycles = fixture.cycles
 			deps := h.deps()
+			controlI := 0
+			control := func(context.Context, PRState) (ControlDecision, error) {
+				if controlI < len(fixture.controls)-1 {
+					controlI++
+					return fixture.controls[controlI-1], nil
+				}
+				return fixture.controls[len(fixture.controls)-1], nil
+			}
+			if len(fixture.controls) == 0 {
+				control = nil
+			}
 			lifecycle := NewLifecycle(
 				defaultConfig(PostModeApprove),
 				Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
@@ -72,6 +141,7 @@ func TestReusableLifecycleTransitionFixtures(t *testing.T) {
 					RouteDiscussion: deps.RouteDiscussion,
 					CIGreen:         deps.CIGreen,
 					Approve:         deps.Approve,
+					Control:         control,
 				},
 				Presentation{Emit: deps.Emit, Logf: deps.Logf},
 			)

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -342,3 +342,57 @@ func TestLifecycleResumeAtDeadlineDoesNotAdmitReview(t *testing.T) {
 		t.Fatalf("state calls = %d, want only the initial state fetch", h.stateCalls)
 	}
 }
+
+func TestLifecycleControlStopsDuringStatePollingFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		control    ControlState
+		wantReason ExitReason
+	}{
+		{name: "released", control: ControlReleased, wantReason: ReasonReleased},
+		{name: "opted out", control: ControlOptedOut, wantReason: ReasonOptedOut},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := newHarness(t)
+			h.cycles = []Cycle{{Result: CycleFindings}}
+			deps := h.deps()
+			stateCalls := 0
+			deps.State = func(context.Context) (PRState, error) {
+				stateCalls++
+				if stateCalls == 1 {
+					return open("aaa"), nil
+				}
+				return PRState{}, errors.New("transient gh failure")
+			}
+			controlCalls := 0
+			var controlledStates []PRState
+			control := func(_ context.Context, state PRState) (ControlDecision, error) {
+				controlledStates = append(controlledStates, state)
+				controlCalls++
+				if controlCalls == 1 {
+					return ControlDecision{State: ControlActive}, nil
+				}
+				return ControlDecision{State: test.control}, nil
+			}
+			lifecycle := NewLifecycle(
+				defaultConfig(PostModeComment),
+				Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+				ReviewExecution{RunCycle: deps.RunCycle},
+				ActionPolicies{CIGreen: deps.CIGreen, Approve: deps.Approve, Control: control},
+				Presentation{Emit: deps.Emit, Logf: deps.Logf},
+			)
+
+			if reason := lifecycle.Run(context.Background()); reason != test.wantReason {
+				t.Fatalf("reason = %v, want %v", reason, test.wantReason)
+			}
+			if stateCalls != 2 {
+				t.Fatalf("state calls = %d, want initial success and one failure", stateCalls)
+			}
+			if len(controlledStates) != 2 || controlledStates[1].HeadSHA != "aaa" {
+				t.Fatalf("controlled states = %#v, want last successful state", controlledStates)
+			}
+		})
+	}
+}

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -115,6 +115,27 @@ func TestReusableLifecycleTransitionFixtures(t *testing.T) {
 			wantReason:   ReasonReleased,
 			wantTriggers: []string{"initial review"},
 		},
+		{
+			name: "review request rearmed during snooze",
+			states: []PRState{
+				requested("aaa"),
+				open("aaa"),
+				requested("aaa"),
+				requested("aaa"),
+			},
+			cycles: []Cycle{
+				{Result: CycleFindings},
+				{Result: CycleLGTMApproved},
+			},
+			controls: []ControlDecision{
+				{State: ControlActive},
+				{State: ControlSnoozed},
+				{State: ControlSnoozed},
+				{State: ControlActive},
+			},
+			wantReason:   ReasonLGTM,
+			wantTriggers: []string{"initial review", "re-review requested"},
+		},
 	}
 
 	for _, fixture := range fixtures {

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -191,5 +192,150 @@ func TestLifecyclePresentationDoesNotControlTransitions(t *testing.T) {
 	if len(silentHarness.triggers) != 1 || len(visibleHarness.triggers) != 1 ||
 		silentHarness.triggers[0] != visibleHarness.triggers[0] {
 		t.Fatalf("silent triggers = %v, visible triggers = %v", silentHarness.triggers, visibleHarness.triggers)
+	}
+}
+
+func TestLifecycleAdmissionUsesLatestSuccessfulState(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa"), open("bbb")}
+	h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+	deps := h.deps()
+	var controlledHeads []string
+	controlCalls := 0
+	control := func(_ context.Context, state PRState) (ControlDecision, error) {
+		controlledHeads = append(controlledHeads, state.HeadSHA)
+		controlCalls++
+		if controlCalls == 1 {
+			return ControlDecision{State: ControlSnoozed}, nil
+		}
+		return ControlDecision{State: ControlActive}, nil
+	}
+	lifecycle := NewLifecycle(
+		defaultConfig(PostModeApprove),
+		Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+		ReviewExecution{RunCycle: deps.RunCycle},
+		ActionPolicies{CIGreen: deps.CIGreen, Approve: deps.Approve, Control: control},
+		Presentation{Emit: deps.Emit, Logf: deps.Logf},
+	)
+
+	if reason := lifecycle.Run(context.Background()); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want %v", reason, ReasonLGTM)
+	}
+	if len(controlledHeads) != 2 || controlledHeads[1] != "bbb" {
+		t.Fatalf("controlled heads = %v, want [aaa bbb]", controlledHeads)
+	}
+}
+
+func TestLifecycleAdmissionPreservesStateAfterFailedRefresh(t *testing.T) {
+	h := newHarness(t)
+	h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+	deps := h.deps()
+	stateCalls := 0
+	deps.State = func(context.Context) (PRState, error) {
+		stateCalls++
+		if stateCalls == 1 {
+			return open("aaa"), nil
+		}
+		return open("bbb"), errors.New("transient gh failure")
+	}
+	var controlledHeads []string
+	controlCalls := 0
+	control := func(_ context.Context, state PRState) (ControlDecision, error) {
+		controlledHeads = append(controlledHeads, state.HeadSHA)
+		controlCalls++
+		if controlCalls == 1 {
+			return ControlDecision{State: ControlSnoozed}, nil
+		}
+		return ControlDecision{State: ControlActive}, nil
+	}
+	lifecycle := NewLifecycle(
+		defaultConfig(PostModeApprove),
+		Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+		ReviewExecution{RunCycle: deps.RunCycle},
+		ActionPolicies{CIGreen: deps.CIGreen, Approve: deps.Approve, Control: control},
+		Presentation{Emit: deps.Emit, Logf: deps.Logf},
+	)
+
+	if reason := lifecycle.Run(context.Background()); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want %v", reason, ReasonLGTM)
+	}
+	if len(controlledHeads) != 2 || controlledHeads[1] != "aaa" {
+		t.Fatalf("controlled heads = %v, want [aaa aaa]", controlledHeads)
+	}
+}
+
+func TestLifecycleSnoozeExpiryRetainsPollIntervalAfterStateError(t *testing.T) {
+	h := newHarness(t)
+	h.cycles = []Cycle{{Result: CycleFindings}}
+	deps := h.deps()
+	stateCalls := 0
+	deps.State = func(context.Context) (PRState, error) {
+		stateCalls++
+		switch stateCalls {
+		case 1, 2:
+			return open("aaa"), nil
+		case 3:
+			return PRState{}, errors.New("transient gh failure")
+		default:
+			return PRState{HeadSHA: "aaa", Merged: true}, nil
+		}
+	}
+	var waits []time.Duration
+	deps.Wait = func(_ context.Context, duration time.Duration) (WaitResult, error) {
+		waits = append(waits, duration)
+		h.clock.now = h.clock.now.Add(duration)
+		return WaitResult{}, nil
+	}
+	controlCalls := 0
+	control := func(context.Context, PRState) (ControlDecision, error) {
+		controlCalls++
+		if controlCalls == 1 {
+			return ControlDecision{State: ControlActive}, nil
+		}
+		return ControlDecision{State: ControlSnoozed, ResumeAt: h.clock.Now().Add(time.Minute)}, nil
+	}
+	lifecycle := NewLifecycle(
+		defaultConfig(PostModeComment),
+		Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+		ReviewExecution{RunCycle: deps.RunCycle},
+		ActionPolicies{CIGreen: deps.CIGreen, Approve: deps.Approve, Control: control},
+		Presentation{Emit: deps.Emit, Logf: deps.Logf},
+	)
+
+	if reason := lifecycle.Run(context.Background()); reason != ReasonMerged {
+		t.Fatalf("reason = %v, want %v", reason, ReasonMerged)
+	}
+	if len(waits) != 3 || waits[2] != time.Minute {
+		t.Fatalf("waits = %v, want three one-minute waits", waits)
+	}
+}
+
+func TestLifecycleResumeAtDeadlineDoesNotAdmitReview(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	h.cycles = []Cycle{{Result: CycleLGTMApproved}}
+	deps := h.deps()
+	cfg := defaultConfig(PostModeApprove)
+	cfg.MaxDuration = time.Minute
+	resumeAt := h.clock.Now().Add(cfg.MaxDuration)
+	lifecycle := NewLifecycle(
+		cfg,
+		Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+		ReviewExecution{RunCycle: deps.RunCycle},
+		ActionPolicies{
+			CIGreen: deps.CIGreen,
+			Approve: deps.Approve,
+			Control: func(context.Context, PRState) (ControlDecision, error) {
+				return ControlDecision{State: ControlSnoozed, ResumeAt: resumeAt}, nil
+			},
+		},
+		Presentation{Emit: deps.Emit, Logf: deps.Logf},
+	)
+
+	if reason := lifecycle.Run(context.Background()); reason != ReasonMaxDuration {
+		t.Fatalf("reason = %v, want %v", reason, ReasonMaxDuration)
+	}
+	if len(h.triggers) != 0 {
+		t.Fatalf("triggers = %v, want none", h.triggers)
 	}
 }

--- a/internal/watch/lifecycle_test.go
+++ b/internal/watch/lifecycle_test.go
@@ -469,3 +469,62 @@ func TestLifecycleControlPreventsDeferredApproval(t *testing.T) {
 		})
 	}
 }
+
+func TestLifecycleControlPreventsRoutedReview(t *testing.T) {
+	tests := []struct {
+		name       string
+		control    ControlState
+		wantReason ExitReason
+	}{
+		{name: "snoozed", control: ControlSnoozed, wantReason: ReasonMerged},
+		{name: "released", control: ControlReleased, wantReason: ReasonReleased},
+		{name: "opted out", control: ControlOptedOut, wantReason: ReasonOptedOut},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			item := discussion("issue_comment", 1, "v1", "reviewer", "Please reconsider.")
+			h := newHarness(t)
+			h.states = []PRState{
+				open("aaa"),
+				discussed("aaa", item),
+				{HeadSHA: "aaa", Merged: true},
+			}
+			h.cycles = []Cycle{{Result: CycleFindings}}
+			h.routes = []RoutingDecision{RoutingReviewRequired}
+			deps := h.deps()
+			controlCalls := 0
+			control := func(context.Context, PRState) (ControlDecision, error) {
+				controlCalls++
+				if controlCalls < 3 {
+					return ControlDecision{State: ControlActive}, nil
+				}
+				return ControlDecision{State: test.control}, nil
+			}
+			cfg := defaultConfig(PostModeComment)
+			cfg.SettleTime = 0
+			lifecycle := NewLifecycle(
+				cfg,
+				Polling{State: deps.State, Wait: deps.Wait, Clock: deps.Clock},
+				ReviewExecution{RunCycle: deps.RunCycle},
+				ActionPolicies{
+					RouteDiscussion: deps.RouteDiscussion,
+					CIGreen:         deps.CIGreen,
+					Approve:         deps.Approve,
+					Control:         control,
+				},
+				Presentation{Emit: deps.Emit, Logf: deps.Logf},
+			)
+
+			if reason := lifecycle.Run(context.Background()); reason != test.wantReason {
+				t.Fatalf("reason = %v, want %v", reason, test.wantReason)
+			}
+			if len(h.triggers) != 1 {
+				t.Fatalf("triggers = %v, want only initial review", h.triggers)
+			}
+			if len(h.routed) != 1 || controlCalls != 3 {
+				t.Fatalf("routing calls = %d, control calls = %d", len(h.routed), controlCalls)
+			}
+		})
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -363,6 +363,10 @@ func (l *loop) routeDiscussion(ctx context.Context, items []Discussion) (Routing
 }
 
 func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
+	return newLifecycleFromDeps(cfg, deps).Run(ctx)
+}
+
+func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 	l := &loop{cfg: cfg, deps: deps, requestArmed: true}
 	clock := deps.Clock
 	l.deadline = clock.Now().Add(cfg.MaxDuration)

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -98,6 +98,7 @@ type Deps struct {
 	RouteDiscussion func(ctx context.Context, discussion []Discussion) (RoutingDecision, error)
 	CIGreen         func(ctx context.Context) (bool, error)
 	Approve         func(ctx context.Context, body string) error
+	Control         func(ctx context.Context, state PRState) (ControlDecision, error)
 	Wait            func(ctx context.Context, duration time.Duration) (WaitResult, error)
 	Emit            func(event Event)
 	Clock           Clock
@@ -121,6 +122,7 @@ const (
 	EventDiscussionDetected     EventType = "discussion_detected"
 	EventDiscussionRouted       EventType = "discussion_routed"
 	EventDiscussionWaiting      EventType = "discussion_waiting"
+	EventControlChanged         EventType = "control_changed"
 )
 
 type Event struct {
@@ -130,6 +132,22 @@ type Event struct {
 	ReviewNumber    int
 	Reason          string
 	Decision        RoutingDecision
+	Control         ControlState
+	ResumeAt        time.Time
+}
+
+type ControlState string
+
+const (
+	ControlActive   ControlState = "active"
+	ControlSnoozed  ControlState = "snoozed"
+	ControlReleased ControlState = "released"
+	ControlOptedOut ControlState = "opted_out"
+)
+
+type ControlDecision struct {
+	State    ControlState
+	ResumeAt time.Time
 }
 
 type Config struct {
@@ -151,6 +169,8 @@ const (
 	ReasonMaxReviews
 	ReasonMaxDuration
 	ReasonInterrupted
+	ReasonReleased
+	ReasonOptedOut
 	ReasonError
 )
 
@@ -170,6 +190,10 @@ func (r ExitReason) String() string {
 		return "maximum duration reached"
 	case ReasonInterrupted:
 		return "interrupted"
+	case ReasonReleased:
+		return "released"
+	case ReasonOptedOut:
+		return "opted out"
 	default:
 		return "error"
 	}
@@ -198,6 +222,7 @@ type loop struct {
 	pendingDiscussion  []Discussion
 	discussionDeadline time.Time
 	waitingDiscussion  string
+	control            ControlDecision
 }
 
 func (l *loop) logf(format string, args ...any) {
@@ -362,6 +387,105 @@ func (l *loop) routeDiscussion(ctx context.Context, items []Discussion) (Routing
 	return l.deps.RouteDiscussion(ctx, items)
 }
 
+func (l *loop) controlDecision(ctx context.Context, state PRState) (ControlDecision, ExitReason, bool) {
+	decision := ControlDecision{State: ControlActive}
+	if l.deps.Control != nil {
+		var err error
+		decision, err = l.deps.Control(ctx, state)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ControlDecision{}, ReasonInterrupted, true
+			}
+			l.logf("Failed to determine lifecycle control state: %v", err)
+			return ControlDecision{}, ReasonError, true
+		}
+	}
+	if decision.State == "" {
+		decision.State = ControlActive
+	}
+	if decision.State == ControlSnoozed && !decision.ResumeAt.IsZero() &&
+		!l.deps.Clock.Now().Before(decision.ResumeAt) {
+		decision = ControlDecision{State: ControlActive}
+	}
+	if decision != l.control {
+		l.control = decision
+		l.emit(Event{Type: EventControlChanged, Control: decision.State, ResumeAt: decision.ResumeAt})
+	}
+	switch decision.State {
+	case ControlActive, ControlSnoozed:
+		return decision, 0, false
+	case ControlReleased:
+		l.logf("PR lifecycle released; stopping watch.")
+		return decision, ReasonReleased, true
+	case ControlOptedOut:
+		l.logf("PR lifecycle opted out; stopping watch.")
+		return decision, ReasonOptedOut, true
+	default:
+		l.logf("Invalid lifecycle control state %q.", decision.State)
+		return decision, ReasonError, true
+	}
+}
+
+func (l *loop) awaitAdmission(ctx context.Context, state PRState) (PRState, ExitReason, bool) {
+	pollErrors := 0
+	for {
+		decision, reason, done := l.controlDecision(ctx, state)
+		if done {
+			return PRState{}, reason, true
+		}
+		if decision.State == ControlActive {
+			return state, 0, false
+		}
+		now := l.deps.Clock.Now()
+		if !now.Before(l.deadline) {
+			l.logf("Reached maximum duration (%s) while lifecycle was snoozed; stopping.", l.cfg.MaxDuration)
+			return PRState{}, ReasonMaxDuration, true
+		}
+		sleep := l.cfg.PollInterval
+		if !decision.ResumeAt.IsZero() {
+			if untilResume := decision.ResumeAt.Sub(now); untilResume < sleep {
+				sleep = untilResume
+			}
+		}
+		if remaining := l.deadline.Sub(now); remaining < sleep {
+			sleep = remaining
+		}
+		waitResult, err := l.wait(ctx, sleep)
+		if reason, done := l.handleWaitError(err); done {
+			return PRState{}, reason, true
+		}
+		if waitResult.Interrupted {
+			return PRState{}, ReasonInterrupted, true
+		}
+		state, err, waitResult, waitErr := l.stateAfterWait(ctx, waitResult)
+		if reason, done := l.handleWaitError(waitErr); done {
+			return PRState{}, reason, true
+		}
+		if waitResult.Interrupted {
+			return PRState{}, ReasonInterrupted, true
+		}
+		if waitResult.ManualRequests > 0 {
+			l.receiveManualRequests(waitResult.ManualRequests)
+			l.rejectManualRequests("lifecycle is snoozed")
+		}
+		if err != nil {
+			if ctx.Err() != nil {
+				return PRState{}, ReasonInterrupted, true
+			}
+			pollErrors++
+			l.logf("Failed to fetch PR state while lifecycle was snoozed (%d/%d): %v", pollErrors, maxConsecutivePollErrors, err)
+			if pollErrors >= maxConsecutivePollErrors {
+				return PRState{}, ReasonError, true
+			}
+			continue
+		}
+		pollErrors = 0
+		if reason, done := l.checkOpen(state); done {
+			return PRState{}, reason, true
+		}
+	}
+}
+
 func Run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 	return newLifecycleFromDeps(cfg, deps).Run(ctx)
 }
@@ -381,6 +505,10 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		return ReasonError
 	}
 	if reason, done := l.checkOpen(st); done {
+		return reason
+	}
+	st, reason, done := l.awaitAdmission(ctx, st)
+	if done {
 		return reason
 	}
 	l.initializeDiscussion(st.Discussion)
@@ -405,6 +533,11 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 		if l.manualRequests == 0 || pollErrors > 0 {
 			sleep := cfg.PollInterval
+			if l.control.State == ControlSnoozed && !l.control.ResumeAt.IsZero() {
+				if untilResume := l.control.ResumeAt.Sub(now); untilResume < sleep {
+					sleep = untilResume
+				}
+			}
 			if remaining := deadline.Sub(now); remaining < sleep {
 				sleep = remaining
 			}
@@ -464,6 +597,19 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 				l.rejectManualRequests(reason.String())
 			}
 			return reason
+		}
+		control, reason, done := l.controlDecision(ctx, st)
+		if done {
+			if manualTrigger {
+				l.rejectManualRequests(reason.String())
+			}
+			return reason
+		}
+		if control.State == ControlSnoozed {
+			if manualTrigger {
+				l.rejectManualRequests("lifecycle is snoozed")
+			}
+			continue
 		}
 		if l.retryPending && st.HeadSHA != l.retryHead {
 			l.retryPending = false

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -776,6 +776,19 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			l.logf("Reached maximum of %d reviews without a terminal LGTM; stopping.", cfg.MaxReviews)
 			return ReasonMaxReviews
 		}
+		control, reason, done = l.controlDecision(ctx, st)
+		if done {
+			if manualTrigger {
+				l.rejectManualRequests(reason.String())
+			}
+			return reason
+		}
+		if control.State == ControlSnoozed {
+			if manualTrigger {
+				l.rejectManualRequests("lifecycle is snoozed")
+			}
+			continue
+		}
 		if reason, done := l.cycle(ctx, st.HeadSHA, trigger, cycleDiscussion, DiscussionRevision(st.Discussion)); done {
 			return reason
 		}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -633,6 +633,9 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			}
 			return reason
 		}
+		if !st.ReviewRequested {
+			l.requestArmed = true
+		}
 		if control.State == ControlSnoozed {
 			if manualTrigger {
 				l.rejectManualRequests("lifecycle is snoozed")
@@ -643,10 +646,6 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			l.retryPending = false
 			l.retryHead = ""
 			l.cycleErrors = 0
-		}
-
-		if !st.ReviewRequested {
-			l.requestArmed = true
 		}
 
 		trigger := ""

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -856,6 +856,14 @@ func (l *loop) tryApprove(ctx context.Context) (ExitReason, bool) {
 		l.logf("New PR discussion arrived before approval; deferring.")
 		return 0, false
 	}
+	control, reason, done := l.controlDecision(ctx, st)
+	if done {
+		return reason, true
+	}
+	if control.State == ControlSnoozed {
+		l.logf("Lifecycle snoozed before approval; deferring.")
+		return 0, false
+	}
 	if err := l.deps.Approve(ctx, l.pendingApproval); err != nil {
 		if ctx.Err() != nil {
 			return ReasonInterrupted, true

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -433,17 +433,17 @@ func (l *loop) awaitAdmission(ctx context.Context, state PRState) (PRState, Exit
 		if done {
 			return PRState{}, reason, true
 		}
-		if decision.State == ControlActive {
-			return state, 0, false
-		}
 		now := l.deps.Clock.Now()
 		if !now.Before(l.deadline) {
 			l.logf("Reached maximum duration (%s) while lifecycle was snoozed; stopping.", l.cfg.MaxDuration)
 			return PRState{}, ReasonMaxDuration, true
 		}
+		if decision.State == ControlActive {
+			return state, 0, false
+		}
 		sleep := l.cfg.PollInterval
 		if !decision.ResumeAt.IsZero() {
-			if untilResume := decision.ResumeAt.Sub(now); untilResume < sleep {
+			if untilResume := decision.ResumeAt.Sub(now); untilResume > 0 && untilResume < sleep {
 				sleep = untilResume
 			}
 		}
@@ -457,7 +457,7 @@ func (l *loop) awaitAdmission(ctx context.Context, state PRState) (PRState, Exit
 		if waitResult.Interrupted {
 			return PRState{}, ReasonInterrupted, true
 		}
-		state, err, waitResult, waitErr := l.stateAfterWait(ctx, waitResult)
+		refreshedState, err, waitResult, waitErr := l.stateAfterWait(ctx, waitResult)
 		if reason, done := l.handleWaitError(waitErr); done {
 			return PRState{}, reason, true
 		}
@@ -479,6 +479,7 @@ func (l *loop) awaitAdmission(ctx context.Context, state PRState) (PRState, Exit
 			}
 			continue
 		}
+		state = refreshedState
 		pollErrors = 0
 		if reason, done := l.checkOpen(state); done {
 			return PRState{}, reason, true
@@ -534,7 +535,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		if l.manualRequests == 0 || pollErrors > 0 {
 			sleep := cfg.PollInterval
 			if l.control.State == ControlSnoozed && !l.control.ResumeAt.IsZero() {
-				if untilResume := l.control.ResumeAt.Sub(now); untilResume < sleep {
+				if untilResume := l.control.ResumeAt.Sub(now); untilResume > 0 && untilResume < sleep {
 					sleep = untilResume
 				}
 			}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -538,6 +538,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		return reason
 	}
 
+	lastState := st
 	pollErrors := 0
 	for {
 		waitResult := WaitResult{}
@@ -599,6 +600,16 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			}
 			pollErrors++
 			l.logf("Failed to fetch PR state (%d/%d): %v", pollErrors, maxConsecutivePollErrors, err)
+			control, reason, done := l.controlDecision(ctx, lastState)
+			if done {
+				if l.manualRequests > 0 {
+					l.rejectManualRequests(reason.String())
+				}
+				return reason
+			}
+			if control.State == ControlSnoozed && l.manualRequests > 0 {
+				l.rejectManualRequests("lifecycle is snoozed")
+			}
 			if pollErrors >= maxConsecutivePollErrors {
 				return ReasonError
 			}
@@ -614,6 +625,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			}
 			return reason
 		}
+		lastState = st
 		control, reason, done := l.controlDecision(ctx, st)
 		if done {
 			if manualTrigger {

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -457,6 +457,21 @@ func (l *loop) awaitAdmission(ctx context.Context, state PRState) (PRState, Exit
 		if waitResult.Interrupted {
 			return PRState{}, ReasonInterrupted, true
 		}
+		if !l.deps.Clock.Now().Before(l.deadline) {
+			stateReady := make(chan struct{})
+			close(stateReady)
+			waitResult, err = l.finalizeWait(ctx, waitResult, stateReady)
+			if reason, done := l.handleWaitError(err); done {
+				return PRState{}, reason, true
+			}
+			if waitResult.Interrupted {
+				return PRState{}, ReasonInterrupted, true
+			}
+			l.receiveManualRequests(waitResult.ManualRequests)
+			l.rejectManualRequests(ReasonMaxDuration.String())
+			l.logf("Reached maximum duration (%s) while lifecycle was snoozed; stopping.", l.cfg.MaxDuration)
+			return PRState{}, ReasonMaxDuration, true
+		}
 		refreshedState, err, waitResult, waitErr := l.stateAfterWait(ctx, waitResult)
 		if reason, done := l.handleWaitError(waitErr); done {
 			return PRState{}, reason, true


### PR DESCRIPTION
Closes #210

## Summary

- expose a presentation-neutral per-PR lifecycle with independent polling, review execution, action-policy, and presentation ports
- centralize active, snoozed, released, opted-out, explicit-resume, and timed-resume eligibility decisions in the shared lifecycle
- adapt `acr watch` to construct and run that lifecycle without changing its CLI or behavior
- add shared transition fixtures for admission, control decisions, settled heads, stale results, terminal states, and presentation independence

## Steward contract

- contract: `reusable-watcher-lifecycle@1`
- frozen hash: `0b702935b1b90e4ba0aad41b2c1e80ef61bd5db05b9136402056a2acfaedc8de`

## Validation

- `go test -count=1 ./internal/watch ./cmd/acr`
- `go test -race -count=1 ./internal/watch ./cmd/acr`
- `make check`