### PR TITLE
Add bounded automatic review controller

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -69,10 +69,15 @@ one.
   genuinely unavailable usage/cost data from a measured zero; validation
   rejects a record that claims `Known: false` while also carrying nonzero
   measurements, so "unknown" can never be silently reinterpreted as "zero."
-- **`LoopDecisionV1`** (issue #223) — one continue/stop/escalate decision from
-  the review convergence loop, with its reason, iteration counters, budget
-  state (`BudgetStateV1`, with the same known/unknown distinction as provider
-  usage), and the adjudication records that informed it.
+- **`LoopDecisionV1`** (issues #223 and #224) — one admission, continue, stop,
+  or escalation decision from an automatic review lifecycle, with its reason,
+  trusted authorization and policy source for admissions, lifecycle session,
+  review and duration counters, measured provider cost, and the adjudication
+  records that informed it. An explicit scope keeps automatic-execution
+  admissions separate from later semantic-convergence decisions. The
+  append-only decisions preserve exhausted
+  budgets across process restarts; only a new trusted admission starts a new
+  bounded session.
 - **`AdjudicationPolicyV1`** (issue #223) — the budget policy, stop policy,
   and evaluation guidance used by the convergence loop. `Source` is a
   `PolicySourceV1`, which mirrors `config.SourceIdentity` — the exact trust

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -375,9 +375,21 @@ func (c *Controller) currentBudget(key store.PullRequestKeyV1, admission store.L
 		budget.CostKnown = true
 		return budget, true, nil
 	}
-	records, _, err := c.economics.ListEconomics(key)
+	records, corrupt, err := c.economics.ListEconomics(key)
 	if err != nil {
 		return store.BudgetStateV1{}, false, fmt.Errorf("load automatic review economics: %w", err)
+	}
+	for _, record := range corrupt {
+		if record.RecordID == "" {
+			budget.CostKnown = false
+			budget.CostUSDUsed = 0
+			return budget, false, nil
+		}
+		if _, active := runIDs[record.RecordID]; active {
+			budget.CostKnown = false
+			budget.CostUSDUsed = 0
+			return budget, false, nil
+		}
 	}
 	byRun := make(map[string]store.ReviewEconomicsV1, len(records))
 	for _, record := range records {

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -349,6 +349,9 @@ func (c *Controller) currentBudget(key store.PullRequestKeyV1, admission store.L
 			runIDs[decision.RunID] = struct{}{}
 		}
 	}
+	if budget.CostUSDLimit == 0 {
+		return budget, true, nil
+	}
 	if len(runIDs) == 0 {
 		budget.CostKnown = true
 		return budget, true, nil

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -285,14 +285,15 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 	if err != nil {
 		return Decision{}, fmt.Errorf("create automatic review session id: %w", err)
 	}
-	now, err := c.nextDecisionTime(key)
+	startedAt := c.now().UTC()
+	decidedAt, err := c.nextDecisionTime(key)
 	if err != nil {
 		return Decision{}, err
 	}
 	budget := store.BudgetStateV1{
 		Known:           true,
 		IterationsLimit: policy.policy.Budget.MaxIterations,
-		StartedAt:       now,
+		StartedAt:       startedAt,
 		DurationLimit:   policy.policy.Budget.MaxDuration,
 		CostKnown:       true,
 		CostUSDLimit:    policy.policy.Budget.MaxCostUSD,
@@ -314,7 +315,7 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 		Decision:          store.LoopDecisionAdmit,
 		Reason:            fmt.Sprintf("%s by %s %q", reason, authorization.kind, authorization.actor),
 		Budget:            budget,
-		DecidedAt:         now,
+		DecidedAt:         decidedAt,
 	}
 	if _, err := c.decisions.SaveLoopDecision(record); err != nil {
 		return Decision{}, fmt.Errorf("record automatic review admission: %w", err)
@@ -326,6 +327,9 @@ func (c *Controller) currentBudget(key store.PullRequestKeyV1, admission store.L
 	budget := budgetFromAdmission(admission, c.now())
 	runIDs := make(map[string]struct{})
 	for _, decision := range decisions {
+		if decision.Budget.Elapsed > budget.Elapsed {
+			budget.Elapsed = decision.Budget.Elapsed
+		}
 		if decision.Decision == store.LoopDecisionContinue {
 			budget.IterationsUsed++
 			runIDs[decision.RunID] = struct{}{}

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -192,12 +192,9 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 			return Decision{}, fmt.Errorf("automatic review run %q already has a durable decision", runID)
 		}
 	}
-	economics, corruptEconomics, err := c.economics.ListEconomics(key)
+	economics, _, err := c.economics.ListEconomics(key)
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review economics: %w", err)
-	}
-	if len(corruptEconomics) != 0 {
-		return Decision{}, fmt.Errorf("automatic review economics contain %d corrupt record(s)", len(corruptEconomics))
 	}
 	for _, record := range economics {
 		if record.Economics.RunID == runID {

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -55,7 +55,13 @@ func NewTrustedPolicy(policy store.AdjudicationPolicyV1, target store.ReviewTarg
 	if policy.Budget.MaxIterations == 0 && policy.Budget.MaxDuration == 0 {
 		return TrustedPolicy{}, fmt.Errorf("automatic review policy requires a review or duration bound")
 	}
-	return TrustedPolicy{policy: policy, target: target}, nil
+	if target.PullRequest == nil {
+		return TrustedPolicy{}, fmt.Errorf("automatic review target must identify a pull request")
+	}
+	targetCopy := target
+	pullRequestCopy := *target.PullRequest
+	targetCopy.PullRequest = &pullRequestCopy
+	return TrustedPolicy{policy: policy, target: targetCopy}, nil
 }
 
 type Decision struct {
@@ -448,7 +454,10 @@ func validateTrustedTarget(key store.PullRequestKeyV1, target store.ReviewTarget
 	if !reflect.DeepEqual(target, policy.target) {
 		return fmt.Errorf("automatic review policy was not validated for the requested review target")
 	}
-	if target.PullRequest != nil && *target.PullRequest != key {
+	if target.PullRequest == nil {
+		return fmt.Errorf("automatic review target must identify the requested pull request")
+	}
+	if *target.PullRequest != key {
 		return fmt.Errorf("automatic review target %s does not match requested pull request %s", target.PullRequest.String(), key.String())
 	}
 	return nil

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -152,7 +152,7 @@ func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTarge
 	return c.admit(key, policy, authorization, "automatic review resumed by trusted decision")
 }
 
-func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, runID string) (Decision, error) {
+func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, runID string) (Decision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	release, err := c.decisions.AcquireDecisionWriteLock()
@@ -160,16 +160,19 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, runID string) (
 		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
 	}
 	defer func() { _ = release() }()
+	if err := validateTrustedTarget(key, target, policy); err != nil {
+		return Decision{}, err
+	}
 
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
 		return Decision{}, fmt.Errorf("automatic review run id is required")
 	}
-	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	allDecisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
 	}
-	decisions = automaticDecisions(decisions)
+	decisions := automaticDecisions(allDecisions)
 	if len(decisions) == 0 {
 		return Decision{}, fmt.Errorf("automatic review has not been commissioned")
 	}
@@ -184,9 +187,21 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, runID string) (
 	if len(corrupt) != 0 {
 		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", store.BudgetStateV1{}, false)
 	}
-	for _, decision := range decisions {
+	for _, decision := range allDecisions {
 		if decision.RunID == runID {
 			return Decision{}, fmt.Errorf("automatic review run %q already has a durable decision", runID)
+		}
+	}
+	economics, corruptEconomics, err := c.economics.ListEconomics(key)
+	if err != nil {
+		return Decision{}, fmt.Errorf("load automatic review economics: %w", err)
+	}
+	if len(corruptEconomics) != 0 {
+		return Decision{}, fmt.Errorf("automatic review economics contain %d corrupt record(s)", len(corruptEconomics))
+	}
+	for _, record := range economics {
+		if record.Economics.RunID == runID {
+			return Decision{}, fmt.Errorf("automatic review run %q already has durable economics", runID)
 		}
 	}
 
@@ -303,6 +318,7 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 		return Decision{}, fmt.Errorf("create automatic review decision id: %w", err)
 	}
 	source := policy.policy.Source
+	target := policy.target
 	record := store.LoopDecisionV1{
 		SchemaVersion:     store.CurrentSchemaVersion,
 		ID:                id,
@@ -311,6 +327,7 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 		AuthorizationKind: string(authorization.kind),
 		AuthorizedBy:      authorization.actor,
 		PolicySource:      &source,
+		ReviewTarget:      &target,
 		Scope:             store.LoopDecisionScopeAutomaticExecution,
 		Decision:          store.LoopDecisionAdmit,
 		Reason:            fmt.Sprintf("%s by %s %q", reason, authorization.kind, authorization.actor),

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -299,6 +299,11 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 	if strings.TrimSpace(authorization.actor) == "" {
 		return Decision{}, fmt.Errorf("automatic review authorization actor is required")
 	}
+	for _, record := range corrupt {
+		if record.Fingerprint == "" {
+			return Decision{}, fmt.Errorf("automatic review cannot resume because corrupt decision record %q cannot be durably acknowledged", filepath.Base(record.Path))
+		}
+	}
 	sessionID, err := c.newID()
 	if err != nil {
 		return Decision{}, fmt.Errorf("create automatic review session id: %w", err)
@@ -324,12 +329,10 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 	target := policy.target
 	acknowledgedCorruptRecords := make([]store.CorruptRecordAcknowledgmentV1, 0, len(corrupt))
 	for _, record := range corrupt {
-		if record.Fingerprint != "" {
-			acknowledgedCorruptRecords = append(acknowledgedCorruptRecords, store.CorruptRecordAcknowledgmentV1{
-				Name:        filepath.Base(record.Path),
-				Fingerprint: record.Fingerprint,
-			})
-		}
+		acknowledgedCorruptRecords = append(acknowledgedCorruptRecords, store.CorruptRecordAcknowledgmentV1{
+			Name:        filepath.Base(record.Path),
+			Fingerprint: record.Fingerprint,
+		})
 	}
 	record := store.LoopDecisionV1{
 		SchemaVersion:              store.CurrentSchemaVersion,

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -41,6 +42,7 @@ func newAuthorization(kind AuthorizationKind, actor string) (Authorization, erro
 
 type TrustedPolicy struct {
 	policy store.AdjudicationPolicyV1
+	target store.ReviewTargetV1
 }
 
 func NewTrustedPolicy(policy store.AdjudicationPolicyV1, target store.ReviewTargetV1) (TrustedPolicy, error) {
@@ -53,7 +55,7 @@ func NewTrustedPolicy(policy store.AdjudicationPolicyV1, target store.ReviewTarg
 	if policy.Budget.MaxIterations == 0 && policy.Budget.MaxDuration == 0 {
 		return TrustedPolicy{}, fmt.Errorf("automatic review policy requires a review or duration bound")
 	}
-	return TrustedPolicy{policy: policy}, nil
+	return TrustedPolicy{policy: policy, target: target}, nil
 }
 
 type Decision struct {
@@ -87,9 +89,17 @@ func NewController(decisions store.LoopDecisionStore, economics store.EconomicsS
 	}, nil
 }
 
-func (c *Controller) Commission(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
+func (c *Controller) Commission(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	release, err := c.decisions.AcquireDecisionWriteLock()
+	if err != nil {
+		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
+	}
+	defer func() { _ = release() }()
+	if err := validateTrustedTarget(key, target, policy); err != nil {
+		return Decision{}, err
+	}
 
 	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
@@ -106,9 +116,17 @@ func (c *Controller) Commission(key store.PullRequestKeyV1, policy TrustedPolicy
 	return c.admit(key, policy, authorization, "automatic review explicitly commissioned")
 }
 
-func (c *Controller) Resume(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
+func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	release, err := c.decisions.AcquireDecisionWriteLock()
+	if err != nil {
+		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
+	}
+	defer func() { _ = release() }()
+	if err := validateTrustedTarget(key, target, policy); err != nil {
+		return Decision{}, err
+	}
 
 	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
@@ -131,6 +149,11 @@ func (c *Controller) Resume(key store.PullRequestKeyV1, policy TrustedPolicy, au
 func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, runID string) (Decision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	release, err := c.decisions.AcquireDecisionWriteLock()
+	if err != nil {
+		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
+	}
+	defer func() { _ = release() }()
 
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
@@ -153,9 +176,9 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, runID string) (
 		return decisionFromRecord(latest, false), nil
 	}
 	if len(corrupt) != 0 {
-		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", budgetFromAdmission(session, c.now()), false)
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", store.BudgetStateV1{}, false)
 	}
-	for _, decision := range sessionDecisions {
+	for _, decision := range decisions {
 		if decision.RunID == runID {
 			return Decision{}, fmt.Errorf("automatic review run %q already has a durable decision", runID)
 		}
@@ -185,6 +208,11 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, runID string) (
 func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time.Time, economics store.ReviewEconomicsV1) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	release, err := c.decisions.AcquireDecisionWriteLock()
+	if err != nil {
+		return fmt.Errorf("lock automatic review decisions: %w", err)
+	}
+	defer func() { _ = release() }()
 
 	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
@@ -212,6 +240,11 @@ func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time
 func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (Decision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	release, err := c.decisions.AcquireDecisionWriteLock()
+	if err != nil {
+		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
+	}
+	defer func() { _ = release() }()
 
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
@@ -409,6 +442,16 @@ func automaticDecisions(decisions []store.LoopDecisionV1) []store.LoopDecisionV1
 		}
 	}
 	return result
+}
+
+func validateTrustedTarget(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy) error {
+	if !reflect.DeepEqual(target, policy.target) {
+		return fmt.Errorf("automatic review policy was not validated for the requested review target")
+	}
+	if target.PullRequest != nil && *target.PullRequest != key {
+		return fmt.Errorf("automatic review target %s does not match requested pull request %s", target.PullRequest.String(), key.String())
+	}
+	return nil
 }
 
 func randomID() (string, error) {

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -120,7 +121,7 @@ func (c *Controller) Commission(key store.PullRequestKeyV1, target store.ReviewT
 			return Decision{}, fmt.Errorf("automatic review is already commissioned; use a trusted resume after it stops")
 		}
 	}
-	return c.admit(key, policy, authorization, "automatic review explicitly commissioned")
+	return c.admit(key, policy, authorization, "automatic review explicitly commissioned", nil)
 }
 
 func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, authorization Authorization) (_ Decision, err error) {
@@ -135,19 +136,19 @@ func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTarge
 		return Decision{}, err
 	}
 
-	decisions, _, err := c.decisions.ListLoopDecisions(key)
+	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
 	}
-	decisions = automaticDecisions(decisions)
-	if len(decisions) == 0 {
-		return Decision{}, fmt.Errorf("automatic review has not been commissioned")
+	_, sessionDecisions, err := activeSession(automaticDecisions(decisions))
+	if err != nil {
+		return Decision{}, err
 	}
-	latest := decisions[len(decisions)-1]
+	latest := sessionDecisions[len(sessionDecisions)-1]
 	if latest.Decision != store.LoopDecisionStop && latest.Decision != store.LoopDecisionEscalate {
 		return Decision{}, fmt.Errorf("automatic review can only resume after a stop or escalation decision")
 	}
-	return c.admit(key, policy, authorization, "automatic review resumed by trusted decision")
+	return c.admit(key, policy, authorization, "automatic review resumed by trusted decision", corrupt)
 }
 
 func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, runID string) (_ Decision, err error) {
@@ -182,7 +183,7 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 	if latest.Decision == store.LoopDecisionStop || latest.Decision == store.LoopDecisionEscalate {
 		return decisionFromRecord(latest, false), nil
 	}
-	if hasCorruptDecisionAtOrAfter(corrupt, session.DecidedAt) {
+	if hasUnacknowledgedCorruptDecisions(corrupt, session) {
 		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", store.BudgetStateV1{}, false)
 	}
 	for _, decision := range allDecisions {
@@ -234,11 +235,15 @@ func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time
 	if err != nil {
 		return fmt.Errorf("load automatic review decisions: %w", err)
 	}
-	if len(corrupt) != 0 {
-		return fmt.Errorf("automatic review history contains %d corrupt record(s)", len(corrupt))
+	_, sessionDecisions, err := activeSession(automaticDecisions(decisions))
+	if err != nil {
+		return err
+	}
+	if hasUnacknowledgedCorruptDecisions(corrupt, sessionDecisions[0]) {
+		return fmt.Errorf("automatic review active session contains corrupt decision records")
 	}
 	found := false
-	for _, decision := range automaticDecisions(decisions) {
+	for _, decision := range sessionDecisions {
 		if decision.Decision == store.LoopDecisionContinue && decision.RunID == economics.RunID {
 			found = true
 			break
@@ -270,12 +275,12 @@ func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (_ Deci
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
 	}
-	if len(corrupt) != 0 {
-		return Decision{}, fmt.Errorf("automatic review history contains %d corrupt record(s)", len(corrupt))
-	}
 	session, sessionDecisions, err := activeSession(automaticDecisions(decisions))
 	if err != nil {
 		return Decision{}, err
+	}
+	if hasUnacknowledgedCorruptDecisions(corrupt, session) {
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", store.BudgetStateV1{}, false)
 	}
 	budget, _, err := c.currentBudget(key, session, sessionDecisions)
 	if err != nil {
@@ -284,7 +289,7 @@ func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (_ Deci
 	return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", budget, false)
 }
 
-func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization, reason string) (Decision, error) {
+func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization, reason string, corrupt []store.CorruptRecord) (Decision, error) {
 	if authorization.kind != AuthorizationUser && authorization.kind != AuthorizationWorkspace {
 		return Decision{}, fmt.Errorf("automatic review requires explicit user or trusted workspace authorization")
 	}
@@ -314,20 +319,25 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 	}
 	source := policy.policy.Source
 	target := policy.target
+	acknowledgedCorruptFiles := make([]string, 0, len(corrupt))
+	for _, record := range corrupt {
+		acknowledgedCorruptFiles = append(acknowledgedCorruptFiles, filepath.Base(record.Path))
+	}
 	record := store.LoopDecisionV1{
-		SchemaVersion:     store.CurrentSchemaVersion,
-		ID:                id,
-		PullRequest:       key,
-		SessionID:         sessionID,
-		AuthorizationKind: string(authorization.kind),
-		AuthorizedBy:      authorization.actor,
-		PolicySource:      &source,
-		ReviewTarget:      &target,
-		Scope:             store.LoopDecisionScopeAutomaticExecution,
-		Decision:          store.LoopDecisionAdmit,
-		Reason:            fmt.Sprintf("%s by %s %q", reason, authorization.kind, authorization.actor),
-		Budget:            budget,
-		DecidedAt:         decidedAt,
+		SchemaVersion:            store.CurrentSchemaVersion,
+		ID:                       id,
+		PullRequest:              key,
+		SessionID:                sessionID,
+		AuthorizationKind:        string(authorization.kind),
+		AuthorizedBy:             authorization.actor,
+		PolicySource:             &source,
+		ReviewTarget:             &target,
+		AcknowledgedCorruptFiles: acknowledgedCorruptFiles,
+		Scope:                    store.LoopDecisionScopeAutomaticExecution,
+		Decision:                 store.LoopDecisionAdmit,
+		Reason:                   fmt.Sprintf("%s by %s %q", reason, authorization.kind, authorization.actor),
+		Budget:                   budget,
+		DecidedAt:                decidedAt,
 	}
 	if _, err := c.decisions.SaveLoopDecision(record); err != nil {
 		return Decision{}, fmt.Errorf("record automatic review admission: %w", err)
@@ -449,18 +459,13 @@ func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.
 
 func (c *Controller) nextDecisionTime(key store.PullRequestKeyV1) (time.Time, error) {
 	now := c.now().UTC()
-	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	decisions, _, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("load automatic review decisions: %w", err)
 	}
 	for _, decision := range decisions {
 		if !now.After(decision.DecidedAt) {
 			now = decision.DecidedAt.Add(time.Nanosecond)
-		}
-	}
-	for _, record := range corrupt {
-		if !record.RecordedAt.IsZero() && !now.After(record.RecordedAt) {
-			now = record.RecordedAt.Add(time.Nanosecond)
 		}
 	}
 	return now, nil
@@ -503,9 +508,13 @@ func releaseDecisionLock(release func() error, err *error) {
 	}
 }
 
-func hasCorruptDecisionAtOrAfter(records []store.CorruptRecord, startedAt time.Time) bool {
+func hasUnacknowledgedCorruptDecisions(records []store.CorruptRecord, admission store.LoopDecisionV1) bool {
+	acknowledged := make(map[string]struct{}, len(admission.AcknowledgedCorruptFiles))
+	for _, name := range admission.AcknowledgedCorruptFiles {
+		acknowledged[name] = struct{}{}
+	}
 	for _, record := range records {
-		if record.RecordedAt.IsZero() || !record.RecordedAt.Before(startedAt) {
+		if _, ok := acknowledged[filepath.Base(record.Path)]; !ok {
 			return true
 		}
 	}

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -1,0 +1,420 @@
+package automatic
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+)
+
+type AuthorizationKind string
+
+const (
+	AuthorizationUser      AuthorizationKind = "user"
+	AuthorizationWorkspace AuthorizationKind = "workspace_controller"
+)
+
+type Authorization struct {
+	kind  AuthorizationKind
+	actor string
+}
+
+func UserAuthorization(actor string) (Authorization, error) {
+	return newAuthorization(AuthorizationUser, actor)
+}
+
+func WorkspaceAuthorization(controller string) (Authorization, error) {
+	return newAuthorization(AuthorizationWorkspace, controller)
+}
+
+func newAuthorization(kind AuthorizationKind, actor string) (Authorization, error) {
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		return Authorization{}, fmt.Errorf("automatic review authorization actor is required")
+	}
+	return Authorization{kind: kind, actor: actor}, nil
+}
+
+type TrustedPolicy struct {
+	policy store.AdjudicationPolicyV1
+}
+
+func NewTrustedPolicy(policy store.AdjudicationPolicyV1, target store.ReviewTargetV1) (TrustedPolicy, error) {
+	if err := policy.Validate(); err != nil {
+		return TrustedPolicy{}, fmt.Errorf("automatic review policy: %w", err)
+	}
+	if err := store.ValidatePolicySourceOutsideReview(policy.Source, target); err != nil {
+		return TrustedPolicy{}, fmt.Errorf("automatic review policy: %w", err)
+	}
+	if policy.Budget.MaxIterations == 0 && policy.Budget.MaxDuration == 0 {
+		return TrustedPolicy{}, fmt.Errorf("automatic review policy requires a review or duration bound")
+	}
+	return TrustedPolicy{policy: policy}, nil
+}
+
+type Decision struct {
+	Kind     store.LoopDecisionKindV1
+	Reason   string
+	Budget   store.BudgetStateV1
+	Allowed  bool
+	Deadline time.Time
+}
+
+type Controller struct {
+	decisions store.LoopDecisionStore
+	economics store.EconomicsStore
+	now       func() time.Time
+	newID     func() (string, error)
+	mu        sync.Mutex
+}
+
+func NewController(decisions store.LoopDecisionStore, economics store.EconomicsStore) (*Controller, error) {
+	if decisions == nil {
+		return nil, fmt.Errorf("automatic review decision store is required")
+	}
+	if economics == nil {
+		return nil, fmt.Errorf("automatic review economics store is required")
+	}
+	return &Controller{
+		decisions: decisions,
+		economics: economics,
+		now:       time.Now,
+		newID:     randomID,
+	}, nil
+}
+
+func (c *Controller) Commission(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	if err != nil {
+		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
+	}
+	if len(corrupt) != 0 {
+		return Decision{}, fmt.Errorf("automatic review history contains %d corrupt record(s)", len(corrupt))
+	}
+	for _, decision := range automaticDecisions(decisions) {
+		if decision.Decision == store.LoopDecisionAdmit {
+			return Decision{}, fmt.Errorf("automatic review is already commissioned; use a trusted resume after it stops")
+		}
+	}
+	return c.admit(key, policy, authorization, "automatic review explicitly commissioned")
+}
+
+func (c *Controller) Resume(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	if err != nil {
+		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
+	}
+	if len(corrupt) != 0 {
+		return Decision{}, fmt.Errorf("automatic review history contains %d corrupt record(s)", len(corrupt))
+	}
+	decisions = automaticDecisions(decisions)
+	if len(decisions) == 0 {
+		return Decision{}, fmt.Errorf("automatic review has not been commissioned")
+	}
+	latest := decisions[len(decisions)-1]
+	if latest.Decision != store.LoopDecisionStop && latest.Decision != store.LoopDecisionEscalate {
+		return Decision{}, fmt.Errorf("automatic review can only resume after a stop or escalation decision")
+	}
+	return c.admit(key, policy, authorization, "automatic review resumed by trusted decision")
+}
+
+func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, runID string) (Decision, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return Decision{}, fmt.Errorf("automatic review run id is required")
+	}
+	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	if err != nil {
+		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
+	}
+	decisions = automaticDecisions(decisions)
+	if len(decisions) == 0 {
+		return Decision{}, fmt.Errorf("automatic review has not been commissioned")
+	}
+	session, sessionDecisions, err := activeSession(decisions)
+	if err != nil {
+		return Decision{}, err
+	}
+	latest := sessionDecisions[len(sessionDecisions)-1]
+	if latest.Decision == store.LoopDecisionStop || latest.Decision == store.LoopDecisionEscalate {
+		return decisionFromRecord(latest, false), nil
+	}
+	if len(corrupt) != 0 {
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", budgetFromAdmission(session, c.now()), false)
+	}
+	for _, decision := range sessionDecisions {
+		if decision.RunID == runID {
+			return Decision{}, fmt.Errorf("automatic review run %q already has a durable decision", runID)
+		}
+	}
+
+	budget, usageAvailable, err := c.currentBudget(key, session, sessionDecisions)
+	if err != nil {
+		return Decision{}, err
+	}
+	if budget.IterationsLimit > 0 && budget.IterationsUsed >= budget.IterationsLimit {
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the review bound was reached", "", budget, false)
+	}
+	if budget.DurationLimit > 0 && budget.Elapsed >= budget.DurationLimit {
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the lifecycle duration bound was reached", "", budget, false)
+	}
+	if budget.CostUSDLimit > 0 && !usageAvailable {
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because configured provider usage could not be measured", "", budget, false)
+	}
+	if budget.CostUSDLimit > 0 && budget.CostUSDUsed >= budget.CostUSDLimit {
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the provider usage bound was reached", "", budget, false)
+	}
+
+	budget.IterationsUsed++
+	return c.recordDecision(key, session, store.LoopDecisionContinue, "automatic review admitted within the configured lifecycle bounds", runID, budget, true)
+}
+
+func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time.Time, economics store.ReviewEconomicsV1) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	if err != nil {
+		return fmt.Errorf("load automatic review decisions: %w", err)
+	}
+	if len(corrupt) != 0 {
+		return fmt.Errorf("automatic review history contains %d corrupt record(s)", len(corrupt))
+	}
+	found := false
+	for _, decision := range automaticDecisions(decisions) {
+		if decision.Decision == store.LoopDecisionContinue && decision.RunID == economics.RunID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("automatic review run %q was not admitted by this controller", economics.RunID)
+	}
+	if _, err := c.economics.SaveEconomics(key, recordedAt, economics); err != nil {
+		return fmt.Errorf("record automatic review economics: %w", err)
+	}
+	return nil
+}
+
+func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (Decision, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return Decision{}, fmt.Errorf("automatic review escalation reason is required")
+	}
+	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	if err != nil {
+		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
+	}
+	if len(corrupt) != 0 {
+		return Decision{}, fmt.Errorf("automatic review history contains %d corrupt record(s)", len(corrupt))
+	}
+	session, sessionDecisions, err := activeSession(automaticDecisions(decisions))
+	if err != nil {
+		return Decision{}, err
+	}
+	budget, _, err := c.currentBudget(key, session, sessionDecisions)
+	if err != nil {
+		return Decision{}, err
+	}
+	return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", budget, false)
+}
+
+func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization, reason string) (Decision, error) {
+	if authorization.kind != AuthorizationUser && authorization.kind != AuthorizationWorkspace {
+		return Decision{}, fmt.Errorf("automatic review requires explicit user or trusted workspace authorization")
+	}
+	if strings.TrimSpace(authorization.actor) == "" {
+		return Decision{}, fmt.Errorf("automatic review authorization actor is required")
+	}
+	sessionID, err := c.newID()
+	if err != nil {
+		return Decision{}, fmt.Errorf("create automatic review session id: %w", err)
+	}
+	now, err := c.nextDecisionTime(key)
+	if err != nil {
+		return Decision{}, err
+	}
+	budget := store.BudgetStateV1{
+		Known:           true,
+		IterationsLimit: policy.policy.Budget.MaxIterations,
+		StartedAt:       now,
+		DurationLimit:   policy.policy.Budget.MaxDuration,
+		CostKnown:       true,
+		CostUSDLimit:    policy.policy.Budget.MaxCostUSD,
+	}
+	id, err := c.newID()
+	if err != nil {
+		return Decision{}, fmt.Errorf("create automatic review decision id: %w", err)
+	}
+	source := policy.policy.Source
+	record := store.LoopDecisionV1{
+		SchemaVersion:     store.CurrentSchemaVersion,
+		ID:                id,
+		PullRequest:       key,
+		SessionID:         sessionID,
+		AuthorizationKind: string(authorization.kind),
+		AuthorizedBy:      authorization.actor,
+		PolicySource:      &source,
+		Scope:             store.LoopDecisionScopeAutomaticExecution,
+		Decision:          store.LoopDecisionAdmit,
+		Reason:            fmt.Sprintf("%s by %s %q", reason, authorization.kind, authorization.actor),
+		Budget:            budget,
+		DecidedAt:         now,
+	}
+	if _, err := c.decisions.SaveLoopDecision(record); err != nil {
+		return Decision{}, fmt.Errorf("record automatic review admission: %w", err)
+	}
+	return decisionFromRecord(record, false), nil
+}
+
+func (c *Controller) currentBudget(key store.PullRequestKeyV1, admission store.LoopDecisionV1, decisions []store.LoopDecisionV1) (store.BudgetStateV1, bool, error) {
+	budget := budgetFromAdmission(admission, c.now())
+	runIDs := make(map[string]struct{})
+	for _, decision := range decisions {
+		if decision.Decision == store.LoopDecisionContinue {
+			budget.IterationsUsed++
+			runIDs[decision.RunID] = struct{}{}
+		}
+	}
+	if len(runIDs) == 0 {
+		budget.CostKnown = true
+		return budget, true, nil
+	}
+	records, corrupt, err := c.economics.ListEconomics(key)
+	if err != nil {
+		return store.BudgetStateV1{}, false, fmt.Errorf("load automatic review economics: %w", err)
+	}
+	if len(corrupt) != 0 {
+		budget.CostKnown = false
+		return budget, false, nil
+	}
+	byRun := make(map[string]store.ReviewEconomicsV1, len(records))
+	for _, record := range records {
+		byRun[record.Economics.RunID] = record.Economics
+	}
+	for runID := range runIDs {
+		economics, ok := byRun[runID]
+		if !ok || len(economics.ProviderUsage) == 0 {
+			budget.CostKnown = false
+			budget.CostUSDUsed = 0
+			return budget, false, nil
+		}
+		for _, usage := range economics.ProviderUsage {
+			if !usage.Usage.Known {
+				budget.CostKnown = false
+				budget.CostUSDUsed = 0
+				return budget, false, nil
+			}
+			budget.CostUSDUsed += usage.Usage.CostUSD
+		}
+	}
+	budget.CostKnown = true
+	return budget, true, nil
+}
+
+func budgetFromAdmission(admission store.LoopDecisionV1, now time.Time) store.BudgetStateV1 {
+	budget := admission.Budget
+	budget.IterationsUsed = 0
+	budget.Elapsed = now.UTC().Sub(budget.StartedAt)
+	if budget.Elapsed < 0 {
+		budget.Elapsed = 0
+	}
+	budget.CostUSDUsed = 0
+	return budget
+}
+
+func activeSession(decisions []store.LoopDecisionV1) (store.LoopDecisionV1, []store.LoopDecisionV1, error) {
+	for i := len(decisions) - 1; i >= 0; i-- {
+		if decisions[i].Decision == store.LoopDecisionAdmit {
+			if decisions[i].SessionID == "" {
+				return store.LoopDecisionV1{}, nil, fmt.Errorf("automatic review admission has no session id")
+			}
+			return decisions[i], decisions[i:], nil
+		}
+	}
+	return store.LoopDecisionV1{}, nil, fmt.Errorf("automatic review has no durable trusted admission")
+}
+
+func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.LoopDecisionV1, kind store.LoopDecisionKindV1, reason, runID string, budget store.BudgetStateV1, allowed bool) (Decision, error) {
+	id, err := c.newID()
+	if err != nil {
+		return Decision{}, fmt.Errorf("create automatic review decision id: %w", err)
+	}
+	decidedAt, err := c.nextDecisionTime(key)
+	if err != nil {
+		return Decision{}, err
+	}
+	record := store.LoopDecisionV1{
+		SchemaVersion:  store.CurrentSchemaVersion,
+		ID:             id,
+		PullRequest:    key,
+		RunID:          runID,
+		SessionID:      admission.SessionID,
+		Scope:          store.LoopDecisionScopeAutomaticExecution,
+		Decision:       kind,
+		Reason:         reason,
+		IterationCount: budget.IterationsUsed,
+		Budget:         budget,
+		DecidedAt:      decidedAt,
+	}
+	if _, err := c.decisions.SaveLoopDecision(record); err != nil {
+		return Decision{}, fmt.Errorf("record automatic review decision: %w", err)
+	}
+	return decisionFromRecord(record, allowed), nil
+}
+
+func (c *Controller) nextDecisionTime(key store.PullRequestKeyV1) (time.Time, error) {
+	now := c.now().UTC()
+	decisions, _, err := c.decisions.ListLoopDecisions(key)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("load automatic review decisions: %w", err)
+	}
+	for _, decision := range decisions {
+		if !now.After(decision.DecidedAt) {
+			now = decision.DecidedAt.Add(time.Nanosecond)
+		}
+	}
+	return now, nil
+}
+
+func decisionFromRecord(record store.LoopDecisionV1, allowed bool) Decision {
+	decision := Decision{Kind: record.Decision, Reason: record.Reason, Budget: record.Budget, Allowed: allowed}
+	if record.Budget.DurationLimit > 0 {
+		decision.Deadline = record.Budget.StartedAt.Add(record.Budget.DurationLimit)
+	}
+	return decision
+}
+
+func automaticDecisions(decisions []store.LoopDecisionV1) []store.LoopDecisionV1 {
+	result := make([]store.LoopDecisionV1, 0, len(decisions))
+	for _, decision := range decisions {
+		if decision.Scope == store.LoopDecisionScopeAutomaticExecution {
+			result = append(result, decision)
+		}
+	}
+	return result
+}
+
+func randomID() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -356,13 +356,9 @@ func (c *Controller) currentBudget(key store.PullRequestKeyV1, admission store.L
 		budget.CostKnown = true
 		return budget, true, nil
 	}
-	records, corrupt, err := c.economics.ListEconomics(key)
+	records, _, err := c.economics.ListEconomics(key)
 	if err != nil {
 		return store.BudgetStateV1{}, false, fmt.Errorf("load automatic review economics: %w", err)
-	}
-	if len(corrupt) != 0 {
-		budget.CostKnown = false
-		return budget, false, nil
 	}
 	byRun := make(map[string]store.ReviewEconomicsV1, len(records))
 	for _, record := range records {

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -51,6 +51,9 @@ func NewTrustedPolicy(policy store.AdjudicationPolicyV1, target store.ReviewTarg
 	if err := policy.Validate(); err != nil {
 		return TrustedPolicy{}, fmt.Errorf("automatic review policy: %w", err)
 	}
+	if err := target.Validate(); err != nil {
+		return TrustedPolicy{}, fmt.Errorf("automatic review target: %w", err)
+	}
 	if err := store.ValidatePolicySourceOutsideReview(policy.Source, target); err != nil {
 		return TrustedPolicy{}, fmt.Errorf("automatic review policy: %w", err)
 	}
@@ -301,7 +304,7 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 		return Decision{}, fmt.Errorf("create automatic review session id: %w", err)
 	}
 	startedAt := c.now().UTC()
-	decidedAt, err := c.nextDecisionTime(key)
+	decidedAt, err := c.nextDecisionTime(key, startedAt)
 	if err != nil {
 		return Decision{}, err
 	}
@@ -319,25 +322,30 @@ func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, aut
 	}
 	source := policy.policy.Source
 	target := policy.target
-	acknowledgedCorruptFiles := make([]string, 0, len(corrupt))
+	acknowledgedCorruptRecords := make([]store.CorruptRecordAcknowledgmentV1, 0, len(corrupt))
 	for _, record := range corrupt {
-		acknowledgedCorruptFiles = append(acknowledgedCorruptFiles, filepath.Base(record.Path))
+		if record.Fingerprint != "" {
+			acknowledgedCorruptRecords = append(acknowledgedCorruptRecords, store.CorruptRecordAcknowledgmentV1{
+				Name:        filepath.Base(record.Path),
+				Fingerprint: record.Fingerprint,
+			})
+		}
 	}
 	record := store.LoopDecisionV1{
-		SchemaVersion:            store.CurrentSchemaVersion,
-		ID:                       id,
-		PullRequest:              key,
-		SessionID:                sessionID,
-		AuthorizationKind:        string(authorization.kind),
-		AuthorizedBy:             authorization.actor,
-		PolicySource:             &source,
-		ReviewTarget:             &target,
-		AcknowledgedCorruptFiles: acknowledgedCorruptFiles,
-		Scope:                    store.LoopDecisionScopeAutomaticExecution,
-		Decision:                 store.LoopDecisionAdmit,
-		Reason:                   fmt.Sprintf("%s by %s %q", reason, authorization.kind, authorization.actor),
-		Budget:                   budget,
-		DecidedAt:                decidedAt,
+		SchemaVersion:              store.CurrentSchemaVersion,
+		ID:                         id,
+		PullRequest:                key,
+		SessionID:                  sessionID,
+		AuthorizationKind:          string(authorization.kind),
+		AuthorizedBy:               authorization.actor,
+		PolicySource:               &source,
+		ReviewTarget:               &target,
+		AcknowledgedCorruptRecords: acknowledgedCorruptRecords,
+		Scope:                      store.LoopDecisionScopeAutomaticExecution,
+		Decision:                   store.LoopDecisionAdmit,
+		Reason:                     fmt.Sprintf("%s by %s %q", reason, authorization.kind, authorization.actor),
+		Budget:                     budget,
+		DecidedAt:                  decidedAt,
 	}
 	if _, err := c.decisions.SaveLoopDecision(record); err != nil {
 		return Decision{}, fmt.Errorf("record automatic review admission: %w", err)
@@ -434,7 +442,7 @@ func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.
 	if err != nil {
 		return Decision{}, fmt.Errorf("create automatic review decision id: %w", err)
 	}
-	decidedAt, err := c.nextDecisionTime(key)
+	decidedAt, err := c.nextDecisionTime(key, c.now().UTC())
 	if err != nil {
 		return Decision{}, err
 	}
@@ -457,8 +465,7 @@ func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.
 	return decisionFromRecord(record, allowed), nil
 }
 
-func (c *Controller) nextDecisionTime(key store.PullRequestKeyV1) (time.Time, error) {
-	now := c.now().UTC()
+func (c *Controller) nextDecisionTime(key store.PullRequestKeyV1, now time.Time) (time.Time, error) {
 	decisions, _, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("load automatic review decisions: %w", err)
@@ -509,12 +516,13 @@ func releaseDecisionLock(release func() error, err *error) {
 }
 
 func hasUnacknowledgedCorruptDecisions(records []store.CorruptRecord, admission store.LoopDecisionV1) bool {
-	acknowledged := make(map[string]struct{}, len(admission.AcknowledgedCorruptFiles))
-	for _, name := range admission.AcknowledgedCorruptFiles {
-		acknowledged[name] = struct{}{}
+	acknowledged := make(map[store.CorruptRecordAcknowledgmentV1]struct{}, len(admission.AcknowledgedCorruptRecords))
+	for _, record := range admission.AcknowledgedCorruptRecords {
+		acknowledged[record] = struct{}{}
 	}
 	for _, record := range records {
-		if _, ok := acknowledged[filepath.Base(record.Path)]; !ok {
+		identity := store.CorruptRecordAcknowledgmentV1{Name: filepath.Base(record.Path), Fingerprint: record.Fingerprint}
+		if _, ok := acknowledged[identity]; !ok {
 			return true
 		}
 	}

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -3,6 +3,7 @@ package automatic
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -95,14 +96,14 @@ func NewController(decisions store.LoopDecisionStore, economics store.EconomicsS
 	}, nil
 }
 
-func (c *Controller) Commission(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
+func (c *Controller) Commission(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, authorization Authorization) (_ Decision, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	release, err := c.decisions.AcquireDecisionWriteLock()
 	if err != nil {
 		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
 	}
-	defer func() { _ = release() }()
+	defer releaseDecisionLock(release, &err)
 	if err := validateTrustedTarget(key, target, policy); err != nil {
 		return Decision{}, err
 	}
@@ -122,24 +123,21 @@ func (c *Controller) Commission(key store.PullRequestKeyV1, target store.ReviewT
 	return c.admit(key, policy, authorization, "automatic review explicitly commissioned")
 }
 
-func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, authorization Authorization) (Decision, error) {
+func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, authorization Authorization) (_ Decision, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	release, err := c.decisions.AcquireDecisionWriteLock()
 	if err != nil {
 		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
 	}
-	defer func() { _ = release() }()
+	defer releaseDecisionLock(release, &err)
 	if err := validateTrustedTarget(key, target, policy); err != nil {
 		return Decision{}, err
 	}
 
-	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
+	decisions, _, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
-	}
-	if len(corrupt) != 0 {
-		return Decision{}, fmt.Errorf("automatic review history contains %d corrupt record(s)", len(corrupt))
 	}
 	decisions = automaticDecisions(decisions)
 	if len(decisions) == 0 {
@@ -152,14 +150,14 @@ func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTarge
 	return c.admit(key, policy, authorization, "automatic review resumed by trusted decision")
 }
 
-func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, runID string) (Decision, error) {
+func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, runID string) (_ Decision, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	release, err := c.decisions.AcquireDecisionWriteLock()
 	if err != nil {
 		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
 	}
-	defer func() { _ = release() }()
+	defer releaseDecisionLock(release, &err)
 	if err := validateTrustedTarget(key, target, policy); err != nil {
 		return Decision{}, err
 	}
@@ -184,7 +182,7 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 	if latest.Decision == store.LoopDecisionStop || latest.Decision == store.LoopDecisionEscalate {
 		return decisionFromRecord(latest, false), nil
 	}
-	if len(corrupt) != 0 {
+	if hasCorruptDecisionAtOrAfter(corrupt, session.DecidedAt) {
 		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", store.BudgetStateV1{}, false)
 	}
 	for _, decision := range allDecisions {
@@ -223,14 +221,14 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 	return c.recordDecision(key, session, store.LoopDecisionContinue, "automatic review admitted within the configured lifecycle bounds", runID, budget, true)
 }
 
-func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time.Time, economics store.ReviewEconomicsV1) error {
+func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time.Time, economics store.ReviewEconomicsV1) (err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	release, err := c.decisions.AcquireDecisionWriteLock()
 	if err != nil {
 		return fmt.Errorf("lock automatic review decisions: %w", err)
 	}
-	defer func() { _ = release() }()
+	defer releaseDecisionLock(release, &err)
 
 	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
@@ -255,14 +253,14 @@ func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time
 	return nil
 }
 
-func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (Decision, error) {
+func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (_ Decision, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	release, err := c.decisions.AcquireDecisionWriteLock()
 	if err != nil {
 		return Decision{}, fmt.Errorf("lock automatic review decisions: %w", err)
 	}
-	defer func() { _ = release() }()
+	defer releaseDecisionLock(release, &err)
 
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
@@ -366,7 +364,15 @@ func (c *Controller) currentBudget(key store.PullRequestKeyV1, admission store.L
 	}
 	for runID := range runIDs {
 		economics, ok := byRun[runID]
-		if !ok || len(economics.ProviderUsage) == 0 {
+		if !ok {
+			budget.CostKnown = false
+			budget.CostUSDUsed = 0
+			return budget, false, nil
+		}
+		if len(economics.ProviderUsage) == 0 {
+			if economics.ReviewerCallCount == 0 && economics.ModelCallCount == 0 {
+				continue
+			}
 			budget.CostKnown = false
 			budget.CostUSDUsed = 0
 			return budget, false, nil
@@ -401,7 +407,13 @@ func activeSession(decisions []store.LoopDecisionV1) (store.LoopDecisionV1, []st
 			if decisions[i].SessionID == "" {
 				return store.LoopDecisionV1{}, nil, fmt.Errorf("automatic review admission has no session id")
 			}
-			return decisions[i], decisions[i:], nil
+			session := decisions[i:]
+			for _, decision := range session {
+				if decision.SessionID != decisions[i].SessionID {
+					return store.LoopDecisionV1{}, nil, fmt.Errorf("automatic review decision %q does not belong to active session %q", decision.ID, decisions[i].SessionID)
+				}
+			}
+			return decisions[i], session, nil
 		}
 	}
 	return store.LoopDecisionV1{}, nil, fmt.Errorf("automatic review has no durable trusted admission")
@@ -437,13 +449,18 @@ func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.
 
 func (c *Controller) nextDecisionTime(key store.PullRequestKeyV1) (time.Time, error) {
 	now := c.now().UTC()
-	decisions, _, err := c.decisions.ListLoopDecisions(key)
+	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("load automatic review decisions: %w", err)
 	}
 	for _, decision := range decisions {
 		if !now.After(decision.DecidedAt) {
 			now = decision.DecidedAt.Add(time.Nanosecond)
+		}
+	}
+	for _, record := range corrupt {
+		if !record.RecordedAt.IsZero() && !now.After(record.RecordedAt) {
+			now = record.RecordedAt.Add(time.Nanosecond)
 		}
 	}
 	return now, nil
@@ -478,6 +495,21 @@ func validateTrustedTarget(key store.PullRequestKeyV1, target store.ReviewTarget
 		return fmt.Errorf("automatic review target %s does not match requested pull request %s", target.PullRequest.String(), key.String())
 	}
 	return nil
+}
+
+func releaseDecisionLock(release func() error, err *error) {
+	if releaseErr := release(); releaseErr != nil {
+		*err = errors.Join(*err, fmt.Errorf("release automatic review decision lock: %w", releaseErr))
+	}
+}
+
+func hasCorruptDecisionAtOrAfter(records []store.CorruptRecord, startedAt time.Time) bool {
+	for _, record := range records {
+		if record.RecordedAt.IsZero() || !record.RecordedAt.Before(startedAt) {
+			return true
+		}
+	}
+	return false
 }
 
 func randomID() (string, error) {

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -177,6 +177,66 @@ func TestControllerDurationBoundAndDeadlineSpanLifecycle(t *testing.T) {
 	}
 }
 
+func TestControllerDurationStartsAtAdmissionDespiteFutureHistory(t *testing.T) {
+	started := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	now := started
+	dir := t.TempDir()
+	key := testKey()
+	future := store.LoopDecisionV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "future-semantic-decision",
+		PullRequest:   key,
+		RunID:         "future-run",
+		Scope:         store.LoopDecisionScopeSemanticConvergence,
+		Decision:      store.LoopDecisionContinue,
+		Reason:        "future clock skew",
+		Budget:        store.BudgetStateV1{Known: true},
+		DecidedAt:     started.Add(2 * time.Hour),
+	}
+	if _, err := store.NewFilesystemLoopDecisionStore(dir).SaveLoopDecision(future); err != nil {
+		t.Fatal(err)
+	}
+	controller := testController(t, dir, &now)
+	admission, err := controller.Commission(key, testTarget(), testPolicy(t, 10, 30*time.Minute, 0), testUserAuthorization(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !admission.Budget.StartedAt.Equal(started) {
+		t.Fatalf("duration started at %s, want actual admission time %s", admission.Budget.StartedAt, started)
+	}
+	now = started.Add(31 * time.Minute)
+	stopped, err := controller.AuthorizeReview(key, "run-after-duration")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.Kind != store.LoopDecisionStop {
+		t.Fatalf("future history postponed duration stop: %+v", stopped)
+	}
+}
+
+func TestControllerElapsedDurationDoesNotRegressWithClock(t *testing.T) {
+	started := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	now := started
+	controller := testController(t, t.TempDir(), &now)
+	key := testKey()
+	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 10, time.Hour, 0), testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	now = started.Add(20 * time.Minute)
+	first, err := controller.AuthorizeReview(key, "run-before-regression")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now = started.Add(10 * time.Minute)
+	second, err := controller.AuthorizeReview(key, "run-after-regression")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Budget.Elapsed < first.Budget.Elapsed {
+		t.Fatalf("elapsed duration regressed from %s to %s", first.Budget.Elapsed, second.Budget.Elapsed)
+	}
+}
+
 func TestControllerDoesNotCountSemanticConvergenceDecisionsAsReviewAdmissions(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -1,0 +1,331 @@
+package automatic
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+)
+
+var testIDCounter atomic.Int64
+
+func testKey() store.PullRequestKeyV1 {
+	return store.PullRequestKeyV1{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+}
+
+func testPolicy(t *testing.T, reviews int, duration time.Duration, cost float64) TrustedPolicy {
+	t.Helper()
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget: store.BudgetPolicyV1{
+			MaxIterations: reviews,
+			MaxDuration:   duration,
+			MaxCostUSD:    cost,
+		},
+	}, store.ReviewTargetV1{})
+	if err != nil {
+		t.Fatalf("NewTrustedPolicy: %v", err)
+	}
+	return policy
+}
+
+func testController(t *testing.T, dir string, now *time.Time) *Controller {
+	t.Helper()
+	controller, err := NewController(
+		store.NewFilesystemLoopDecisionStore(dir),
+		store.NewFilesystemEconomicsStore(dir),
+	)
+	if err != nil {
+		t.Fatalf("NewController: %v", err)
+	}
+	controller.now = func() time.Time { return *now }
+	controller.newID = func() (string, error) {
+		return fmt.Sprintf("id-%d", testIDCounter.Add(1)), nil
+	}
+	return controller
+}
+
+func testUserAuthorization(t *testing.T) Authorization {
+	t.Helper()
+	authorization, err := UserAuthorization("alice")
+	if err != nil {
+		t.Fatalf("UserAuthorization: %v", err)
+	}
+	return authorization
+}
+
+func TestControllerRequiresTrustedCommissionAndRecordsAdmission(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+
+	if _, err := controller.AuthorizeReview(key, "run-before-commission"); err == nil {
+		t.Fatal("expected uncommissioned automatic review to be rejected")
+	}
+
+	decision, err := controller.Commission(key, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t))
+	if err != nil {
+		t.Fatalf("Commission: %v", err)
+	}
+	if decision.Kind != store.LoopDecisionAdmit || decision.Allowed {
+		t.Fatalf("unexpected admission decision: %+v", decision)
+	}
+
+	records, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("ListLoopDecisions: corrupt=%v err=%v", corrupt, err)
+	}
+	if len(records) != 1 || records[0].AuthorizationKind != string(AuthorizationUser) || records[0].AuthorizedBy != "alice" {
+		t.Fatalf("trusted admission was not durably attributed: %+v", records)
+	}
+	if records[0].PolicySource == nil || records[0].PolicySource.Kind != config.SourceKindDefaults {
+		t.Fatalf("trusted policy source was not recorded: %+v", records[0].PolicySource)
+	}
+}
+
+func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 2, time.Hour, 0)
+	if _, err := controller.Commission(key, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, runID := range []string{"run-head-one", "run-head-two"} {
+		decision, err := controller.AuthorizeReview(key, runID)
+		if err != nil {
+			t.Fatalf("AuthorizeReview(%s): %v", runID, err)
+		}
+		if !decision.Allowed || decision.Kind != store.LoopDecisionContinue {
+			t.Fatalf("expected %s to be admitted, got %+v", runID, decision)
+		}
+	}
+	stopped, err := controller.AuthorizeReview(key, "run-head-three")
+	if err != nil {
+		t.Fatalf("AuthorizeReview(stop): %v", err)
+	}
+	if stopped.Allowed || stopped.Kind != store.LoopDecisionStop || !strings.Contains(stopped.Reason, "review bound") {
+		t.Fatalf("expected durable review-bound stop, got %+v", stopped)
+	}
+
+	restarted := testController(t, dir, &now)
+	stillStopped, err := restarted.AuthorizeReview(key, "run-after-restart")
+	if err != nil {
+		t.Fatalf("AuthorizeReview after restart: %v", err)
+	}
+	if stillStopped.Kind != store.LoopDecisionStop || stillStopped.Allowed {
+		t.Fatalf("restart bypassed exhausted budget: %+v", stillStopped)
+	}
+
+	workspace, err := WorkspaceAuthorization("scheduler-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := restarted.Resume(key, policy, workspace); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	resumed, err := restarted.AuthorizeReview(key, "run-after-resume")
+	if err != nil {
+		t.Fatalf("AuthorizeReview after resume: %v", err)
+	}
+	if !resumed.Allowed || resumed.Budget.IterationsUsed != 1 {
+		t.Fatalf("trusted resume did not start a new bounded session: %+v", resumed)
+	}
+}
+
+func TestControllerDurationBoundAndDeadlineSpanLifecycle(t *testing.T) {
+	started := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	now := started
+	controller := testController(t, t.TempDir(), &now)
+	key := testKey()
+	if _, err := controller.Commission(key, testPolicy(t, 10, 30*time.Minute, 0), testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	now = started.Add(10 * time.Minute)
+	allowed, err := controller.AuthorizeReview(key, "run-one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed.Allowed || !allowed.Deadline.Equal(started.Add(30*time.Minute)) {
+		t.Fatalf("expected lifecycle deadline %s, got %+v", started.Add(30*time.Minute), allowed)
+	}
+
+	now = started.Add(31 * time.Minute)
+	stopped, err := controller.AuthorizeReview(key, "run-two")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.Kind != store.LoopDecisionStop || !strings.Contains(stopped.Reason, "duration bound") {
+		t.Fatalf("expected duration-bound stop, got %+v", stopped)
+	}
+}
+
+func TestControllerDoesNotCountSemanticConvergenceDecisionsAsReviewAdmissions(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	if _, err := controller.Commission(key, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, "automatic-run-one"); err != nil {
+		t.Fatal(err)
+	}
+	semantic := store.LoopDecisionV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "semantic-decision",
+		PullRequest:   key,
+		RunID:         "automatic-run-one",
+		Scope:         store.LoopDecisionScopeSemanticConvergence,
+		Decision:      store.LoopDecisionContinue,
+		Reason:        "new actionable evidence",
+		Budget:        store.BudgetStateV1{Known: true},
+		DecidedAt:     now.Add(time.Minute),
+	}
+	if _, err := store.NewFilesystemLoopDecisionStore(dir).SaveLoopDecision(semantic); err != nil {
+		t.Fatalf("SaveLoopDecision: %v", err)
+	}
+
+	second, err := controller.AuthorizeReview(key, "automatic-run-two")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.Allowed || second.Budget.IterationsUsed != 2 {
+		t.Fatalf("semantic decision consumed the automatic review budget: %+v", second)
+	}
+}
+
+func TestControllerEnforcesMeasuredProviderCost(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	controller := testController(t, t.TempDir(), &now)
+	key := testKey()
+	if _, err := controller.Commission(key, testPolicy(t, 10, time.Hour, 1), testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
+		t.Fatal(err)
+	}
+	economics := store.ReviewEconomicsV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		RunID:         "run-one",
+		ProviderUsage: []store.ProviderUsageRecordV1{
+			{Provider: "anthropic", Usage: store.ProviderUsageV1{Known: true, CostUSD: 1.25}},
+		},
+	}
+	if err := controller.RecordEconomics(key, now, economics); err != nil {
+		t.Fatalf("RecordEconomics: %v", err)
+	}
+
+	stopped, err := controller.AuthorizeReview(key, "run-two")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.Kind != store.LoopDecisionStop || stopped.Budget.CostUSDUsed != 1.25 || !stopped.Budget.CostKnown {
+		t.Fatalf("expected measured provider-cost stop, got %+v", stopped)
+	}
+}
+
+func TestControllerEscalatesWhenConfiguredProviderUsageIsUnavailable(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	controller := testController(t, t.TempDir(), &now)
+	key := testKey()
+	if _, err := controller.Commission(key, testPolicy(t, 10, time.Hour, 5), testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
+		t.Fatal(err)
+	}
+	economics := store.ReviewEconomicsV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		RunID:         "run-one",
+		ProviderUsage: []store.ProviderUsageRecordV1{
+			{Provider: "codex", Usage: store.ProviderUsageV1{Known: false}},
+		},
+	}
+	if err := controller.RecordEconomics(key, now, economics); err != nil {
+		t.Fatal(err)
+	}
+
+	escalated, err := controller.AuthorizeReview(key, "run-two")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if escalated.Kind != store.LoopDecisionEscalate || escalated.Allowed || !strings.Contains(escalated.Reason, "could not be measured") {
+		t.Fatalf("expected unavailable provider usage to escalate, got %+v", escalated)
+	}
+	again, err := controller.AuthorizeReview(key, "run-three")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Kind != store.LoopDecisionEscalate || again.Allowed {
+		t.Fatalf("escalation did not block subsequent automatic work: %+v", again)
+	}
+}
+
+func TestTrustedPolicyRejectsReviewedWorktreeAndHead(t *testing.T) {
+	target := store.ReviewTargetV1{Revision: store.RevisionEvidenceV1{HeadObjectID: "head-sha"}}
+	base := store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Budget:        store.BudgetPolicyV1{MaxIterations: 1},
+	}
+
+	filesystem := base
+	filesystem.Source = store.PolicySourceV1{Kind: config.SourceKindFilesystem, Locator: "/review/worktree/.acr.yaml"}
+	if _, err := NewTrustedPolicy(filesystem, target); err == nil {
+		t.Fatal("expected reviewed-worktree policy to be rejected")
+	}
+
+	head := base
+	head.Source = store.PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: "head-sha"}
+	if _, err := NewTrustedPolicy(head, target); err == nil {
+		t.Fatal("expected reviewed-head policy to be rejected")
+	}
+}
+
+func TestControllerRecordsExplicitEscalationAndTrustedResume(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 2, time.Hour, 0)
+	if _, err := controller.Commission(key, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Escalate(key, "operator decision required"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(key, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	records, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("ListLoopDecisions: corrupt=%v err=%v", corrupt, err)
+	}
+	want := []store.LoopDecisionKindV1{
+		store.LoopDecisionAdmit,
+		store.LoopDecisionContinue,
+		store.LoopDecisionEscalate,
+		store.LoopDecisionAdmit,
+	}
+	if len(records) != len(want) {
+		t.Fatalf("got %d durable decisions, want %d: %+v", len(records), len(want), records)
+	}
+	for i := range want {
+		if records[i].Decision != want[i] || records[i].Reason == "" || !records[i].Budget.Known {
+			t.Fatalf("decision %d was not durably reasoned with budget state: %+v", i, records[i])
+		}
+	}
+}

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -20,6 +20,11 @@ func testKey() store.PullRequestKeyV1 {
 	return store.PullRequestKeyV1{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
 }
 
+func testTarget() store.ReviewTargetV1 {
+	key := testKey()
+	return store.ReviewTargetV1{PullRequest: &key}
+}
+
 func testPolicy(t *testing.T, reviews int, duration time.Duration, cost float64) TrustedPolicy {
 	t.Helper()
 	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
@@ -30,7 +35,7 @@ func testPolicy(t *testing.T, reviews int, duration time.Duration, cost float64)
 			MaxDuration:   duration,
 			MaxCostUSD:    cost,
 		},
-	}, store.ReviewTargetV1{})
+	}, testTarget())
 	if err != nil {
 		t.Fatalf("NewTrustedPolicy: %v", err)
 	}
@@ -72,7 +77,7 @@ func TestControllerRequiresTrustedCommissionAndRecordsAdmission(t *testing.T) {
 		t.Fatal("expected uncommissioned automatic review to be rejected")
 	}
 
-	decision, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t))
+	decision, err := controller.Commission(key, testTarget(), testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t))
 	if err != nil {
 		t.Fatalf("Commission: %v", err)
 	}
@@ -98,7 +103,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 	controller := testController(t, dir, &now)
 	key := testKey()
 	policy := testPolicy(t, 2, time.Hour, 0)
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -132,7 +137,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := restarted.Resume(key, store.ReviewTargetV1{}, policy, workspace); err != nil {
+	if _, err := restarted.Resume(key, testTarget(), policy, workspace); err != nil {
 		t.Fatalf("Resume: %v", err)
 	}
 	resumed, err := restarted.AuthorizeReview(key, "run-after-resume")
@@ -149,7 +154,7 @@ func TestControllerDurationBoundAndDeadlineSpanLifecycle(t *testing.T) {
 	now := started
 	controller := testController(t, t.TempDir(), &now)
 	key := testKey()
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 10, 30*time.Minute, 0), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 10, 30*time.Minute, 0), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -177,7 +182,7 @@ func TestControllerDoesNotCountSemanticConvergenceDecisionsAsReviewAdmissions(t 
 	dir := t.TempDir()
 	controller := testController(t, dir, &now)
 	key := testKey()
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "automatic-run-one"); err != nil {
@@ -211,7 +216,7 @@ func TestControllerEnforcesMeasuredProviderCost(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	controller := testController(t, t.TempDir(), &now)
 	key := testKey()
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 10, time.Hour, 1), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 10, time.Hour, 1), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
@@ -241,7 +246,7 @@ func TestControllerEscalatesWhenConfiguredProviderUsageIsUnavailable(t *testing.
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	controller := testController(t, t.TempDir(), &now)
 	key := testKey()
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 10, time.Hour, 5), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 10, time.Hour, 5), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
@@ -275,7 +280,8 @@ func TestControllerEscalatesWhenConfiguredProviderUsageIsUnavailable(t *testing.
 }
 
 func TestTrustedPolicyRejectsReviewedWorktreeAndHead(t *testing.T) {
-	target := store.ReviewTargetV1{Revision: store.RevisionEvidenceV1{HeadObjectID: "head-sha"}}
+	target := testTarget()
+	target.Revision.HeadObjectID = "head-sha"
 	base := store.AdjudicationPolicyV1{
 		SchemaVersion: store.CurrentSchemaVersion,
 		Budget:        store.BudgetPolicyV1{MaxIterations: 1},
@@ -313,6 +319,36 @@ func TestTrustedPolicyCannotBeReusedForAnotherTarget(t *testing.T) {
 	}
 }
 
+func TestTrustedPolicyRequiresPullRequestIdentity(t *testing.T) {
+	_, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 1},
+	}, store.ReviewTargetV1{})
+	if err == nil {
+		t.Fatal("expected target without pull request identity to be rejected")
+	}
+}
+
+func TestTrustedPolicyCopiesTargetIdentity(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	controller := testController(t, t.TempDir(), &now)
+	target := testTarget()
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 1},
+	}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target.PullRequest.Repository = "other-repo"
+	mutatedKey := *target.PullRequest
+	if _, err := controller.Commission(mutatedKey, target, policy, testUserAuthorization(t)); err == nil {
+		t.Fatal("expected caller mutation not to rebind trusted policy")
+	}
+}
+
 func TestControllerSerializesReviewAdmissionAcrossInstances(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()
@@ -320,7 +356,7 @@ func TestControllerSerializesReviewAdmissionAcrossInstances(t *testing.T) {
 	second := testController(t, dir, &now)
 	key := testKey()
 	policy := testPolicy(t, 1, time.Hour, 0)
-	if _, err := first.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+	if _, err := first.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -361,7 +397,7 @@ func TestControllerRejectsRunIDReusedAcrossSessions(t *testing.T) {
 	controller := testController(t, dir, &now)
 	key := testKey()
 	policy := testPolicy(t, 1, time.Hour, 0)
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "reused-run"); err != nil {
@@ -370,7 +406,7 @@ func TestControllerRejectsRunIDReusedAcrossSessions(t *testing.T) {
 	if _, err := controller.AuthorizeReview(key, "stop-run"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.Resume(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "reused-run"); err == nil {
@@ -383,7 +419,7 @@ func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
 	dir := t.TempDir()
 	controller := testController(t, dir, &now)
 	key := testKey()
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	decisionDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "loop_decisions")
@@ -405,7 +441,7 @@ func TestControllerRecordsExplicitEscalationAndTrustedResume(t *testing.T) {
 	controller := testController(t, dir, &now)
 	key := testKey()
 	policy := testPolicy(t, 2, time.Hour, 0)
-	if _, err := controller.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
@@ -414,7 +450,7 @@ func TestControllerRecordsExplicitEscalationAndTrustedResume(t *testing.T) {
 	if _, err := controller.Escalate(key, "operator decision required"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.Resume(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -399,6 +399,52 @@ func TestControllerClassifiesCorruptEconomicsByConfiguredBudget(t *testing.T) {
 	}
 }
 
+func TestControllerIgnoresCorruptEconomicsOutsideActiveSession(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 3, time.Hour, 5)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "old-session-run"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Escalate(key, "trusted restart requested"); err != nil {
+		t.Fatal(err)
+	}
+	economicsDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "economics")
+	if err := os.MkdirAll(economicsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(economicsDir, "20260731T120001.000000000Z-old-corrupt.json"), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "active-session-run"); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.RecordEconomics(key, now, store.ReviewEconomicsV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		RunID:         "active-session-run",
+		ProviderUsage: []store.ProviderUsageRecordV1{
+			{Provider: "codex", Usage: store.ProviderUsageV1{Known: true, CostUSD: 1}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	decision, err := controller.AuthorizeReview(key, testTarget(), policy, "next-active-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decision.Allowed || decision.Budget.CostUSDUsed != 1 || !decision.Budget.CostKnown {
+		t.Fatalf("unrelated corrupt economics poisoned active session: %+v", decision)
+	}
+}
+
 func TestControllerSkipsBudgetEconomicsReadWithoutCostLimit(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -22,6 +22,14 @@ type failingEconomicsStore struct {
 	failAfter int
 }
 
+type releaseFailingDecisionStore struct {
+	store.LoopDecisionStore
+}
+
+func (s *releaseFailingDecisionStore) AcquireDecisionWriteLock() (func() error, error) {
+	return func() error { return fmt.Errorf("release failed") }, nil
+}
+
 func (s *failingEconomicsStore) ListEconomics(key store.PullRequestKeyV1) ([]store.EconomicsRecordV1, []store.CorruptRecord, error) {
 	s.listCalls++
 	if s.listCalls > s.failAfter {
@@ -691,7 +699,8 @@ func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
 	dir := t.TempDir()
 	controller := testController(t, dir, &now)
 	key := testKey()
-	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
+	policy := testPolicy(t, 2, time.Hour, 0)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	decisionDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "loop_decisions")
@@ -704,6 +713,70 @@ func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
 	}
 	if escalated.Kind != store.LoopDecisionEscalate || escalated.Budget.Known {
 		t.Fatalf("expected corrupt history escalation with unknown budget, got %+v", escalated)
+	}
+	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatalf("trusted resume after corruption escalation: %v", err)
+	}
+	resumed, err := controller.AuthorizeReview(key, testTarget(), policy, "run-after-resume")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resumed.Allowed {
+		t.Fatalf("trusted resume did not isolate corrupt prior session: %+v", resumed)
+	}
+}
+
+func TestActiveSessionRejectsDecisionFromAnotherSession(t *testing.T) {
+	admission := store.LoopDecisionV1{ID: "admission", SessionID: "session-a", Decision: store.LoopDecisionAdmit}
+	foreign := store.LoopDecisionV1{ID: "foreign", SessionID: "session-b", Decision: store.LoopDecisionContinue}
+	if _, _, err := activeSession([]store.LoopDecisionV1{admission, foreign}); err == nil {
+		t.Fatal("expected decision from another session to be rejected")
+	}
+}
+
+func TestControllerTreatsZeroCallEconomicsAsKnownZero(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	controller := testController(t, t.TempDir(), &now)
+	key := testKey()
+	policy := testPolicy(t, 3, time.Hour, 5)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "zero-call-run"); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.RecordEconomics(key, now, store.ReviewEconomicsV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		RunID:         "zero-call-run",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	decision, err := controller.AuthorizeReview(key, testTarget(), policy, "run-after-zero-call")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decision.Allowed || !decision.Budget.CostKnown || decision.Budget.CostUSDUsed != 0 {
+		t.Fatalf("zero-call economics were not treated as known zero: %+v", decision)
+	}
+}
+
+func TestControllerPropagatesDecisionLockReleaseFailure(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller, err := NewController(
+		&releaseFailingDecisionStore{LoopDecisionStore: store.NewFilesystemLoopDecisionStore(dir)},
+		store.NewFilesystemEconomicsStore(dir),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.now = func() time.Time { return now }
+	controller.newID = func() (string, error) {
+		return fmt.Sprintf("id-%d", testIDCounter.Add(1)), nil
+	}
+	_, err = controller.Commission(testKey(), testTarget(), testPolicy(t, 1, time.Hour, 0), testUserAuthorization(t))
+	if err == nil || !strings.Contains(err.Error(), "release automatic review decision lock") {
+		t.Fatalf("expected lock release failure, got %v", err)
 	}
 }
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -45,7 +45,15 @@ func testKey() store.PullRequestKeyV1 {
 
 func testTarget() store.ReviewTargetV1 {
 	key := testKey()
-	return store.ReviewTargetV1{PullRequest: &key}
+	return store.ReviewTargetV1{
+		RepositoryRoot: "/repo",
+		WorktreeRoot:   "/repo/worktree",
+		Revision: store.RevisionEvidenceV1{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "refs/remotes/origin/main",
+		},
+		PullRequest: &key,
+	}
 }
 
 func testPolicy(t *testing.T, reviews int, duration time.Duration, cost float64) TrustedPolicy {
@@ -239,6 +247,39 @@ func TestControllerDurationStartsAtAdmissionDespiteFutureHistory(t *testing.T) {
 	}
 	if stopped.Kind != store.LoopDecisionStop {
 		t.Fatalf("future history postponed duration stop: %+v", stopped)
+	}
+}
+
+func TestControllerSamplesAdmissionClockOnce(t *testing.T) {
+	first := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	second := first.Add(-time.Minute)
+	dir := t.TempDir()
+	controller, err := NewController(
+		store.NewFilesystemLoopDecisionStore(dir),
+		store.NewFilesystemEconomicsStore(dir),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	times := []time.Time{first, second}
+	calls := 0
+	controller.now = func() time.Time {
+		value := times[calls]
+		calls++
+		return value
+	}
+	controller.newID = func() (string, error) {
+		return fmt.Sprintf("id-%d", testIDCounter.Add(1)), nil
+	}
+	admission, err := controller.Commission(testKey(), testTarget(), testPolicy(t, 1, time.Hour, 0), testUserAuthorization(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("sampled admission clock %d times, want 1", calls)
+	}
+	if !admission.Budget.StartedAt.Equal(first) {
+		t.Fatalf("admission started at %s, want %s", admission.Budget.StartedAt, first)
 	}
 }
 
@@ -510,8 +551,10 @@ func TestTrustedPolicyCannotBeReusedForAnotherTarget(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	controller := testController(t, t.TempDir(), &now)
 	key := testKey()
-	targetA := store.ReviewTargetV1{Revision: store.RevisionEvidenceV1{HeadObjectID: "head-a"}, PullRequest: &key}
-	targetB := store.ReviewTargetV1{Revision: store.RevisionEvidenceV1{HeadObjectID: "head-b"}, PullRequest: &key}
+	targetA := testTarget()
+	targetA.Revision.HeadObjectID = "head-a"
+	targetB := testTarget()
+	targetB.Revision.HeadObjectID = "head-b"
 	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
 		SchemaVersion: store.CurrentSchemaVersion,
 		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
@@ -533,6 +576,18 @@ func TestTrustedPolicyRequiresPullRequestIdentity(t *testing.T) {
 	}, store.ReviewTargetV1{})
 	if err == nil {
 		t.Fatal("expected target without pull request identity to be rejected")
+	}
+}
+
+func TestTrustedPolicyRejectsIncompleteReviewTarget(t *testing.T) {
+	key := testKey()
+	_, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 1},
+	}, store.ReviewTargetV1{PullRequest: &key})
+	if err == nil {
+		t.Fatal("expected incomplete review target to be rejected")
 	}
 }
 
@@ -744,12 +799,16 @@ func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
 			resumedAdmission = record
 		}
 	}
-	if !reflect.DeepEqual(resumedAdmission.AcknowledgedCorruptFiles, []string{"malformed.json"}) {
+	wantAcknowledgment := []store.CorruptRecordAcknowledgmentV1{{
+		Name:        "malformed.json",
+		Fingerprint: corrupt[0].Fingerprint,
+	}}
+	if !reflect.DeepEqual(resumedAdmission.AcknowledgedCorruptRecords, wantAcknowledgment) {
 		t.Fatalf("trusted resume did not durably acknowledge corrupt history: %+v", resumedAdmission)
 	}
 }
 
-func TestControllerEscalatesForCorruptionCreatedAfterTrustedResume(t *testing.T) {
+func TestControllerEscalatesForCorruptionReplacedAfterTrustedResume(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()
 	controller := testController(t, dir, &now)
@@ -768,15 +827,15 @@ func TestControllerEscalatesForCorruptionCreatedAfterTrustedResume(t *testing.T)
 	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(decisionDir, "new-corrupt.json"), []byte("not json"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(decisionDir, "old-corrupt.json"), []byte("different invalid json"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	decision, err := testAuthorize(t, controller, key, "run-after-new-corruption")
+	decision, err := testAuthorize(t, controller, key, "run-after-replaced-corruption")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if decision.Kind != store.LoopDecisionEscalate || decision.Budget.Known {
-		t.Fatalf("expected new corruption to fail closed, got %+v", decision)
+		t.Fatalf("expected replaced corruption to fail closed, got %+v", decision)
 	}
 }
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -704,7 +705,7 @@ func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	decisionDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "loop_decisions")
-	if err := os.WriteFile(filepath.Join(decisionDir, "20260731T120001.000000000Z-corrupt.json"), []byte("not json"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(decisionDir, "malformed.json"), []byte("not json"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	escalated, err := testAuthorize(t, controller, key, "run-after-corruption")
@@ -723,6 +724,88 @@ func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
 	}
 	if !resumed.Allowed {
 		t.Fatalf("trusted resume did not isolate corrupt prior session: %+v", resumed)
+	}
+	if err := controller.RecordEconomics(key, now, store.ReviewEconomicsV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		RunID:         "run-after-resume",
+	}); err != nil {
+		t.Fatalf("record economics after trusted resume: %v", err)
+	}
+	if _, err := controller.Escalate(key, "operator decision required"); err != nil {
+		t.Fatalf("explicit escalation after trusted resume: %v", err)
+	}
+	records, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 1 {
+		t.Fatalf("ListLoopDecisions: corrupt=%v err=%v", corrupt, err)
+	}
+	var resumedAdmission store.LoopDecisionV1
+	for _, record := range records {
+		if record.Decision == store.LoopDecisionAdmit {
+			resumedAdmission = record
+		}
+	}
+	if !reflect.DeepEqual(resumedAdmission.AcknowledgedCorruptFiles, []string{"malformed.json"}) {
+		t.Fatalf("trusted resume did not durably acknowledge corrupt history: %+v", resumedAdmission)
+	}
+}
+
+func TestControllerEscalatesForCorruptionCreatedAfterTrustedResume(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 2, time.Hour, 0)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	decisionDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "loop_decisions")
+	if err := os.WriteFile(filepath.Join(decisionDir, "old-corrupt.json"), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := testAuthorize(t, controller, key, "run-before-resume"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(decisionDir, "new-corrupt.json"), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	decision, err := testAuthorize(t, controller, key, "run-after-new-corruption")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Kind != store.LoopDecisionEscalate || decision.Budget.Known {
+		t.Fatalf("expected new corruption to fail closed, got %+v", decision)
+	}
+}
+
+func TestControllerResumeRejectsDecisionFromAnotherSession(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 2, time.Hour, 0)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Second)
+	foreign := store.LoopDecisionV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "foreign-stop",
+		PullRequest:   key,
+		SessionID:     "foreign-session",
+		Scope:         store.LoopDecisionScopeAutomaticExecution,
+		Decision:      store.LoopDecisionStop,
+		Reason:        "foreign stop",
+		Budget:        store.BudgetStateV1{Known: true, IterationsLimit: 2},
+		DecidedAt:     now,
+	}
+	if _, err := store.NewFilesystemLoopDecisionStore(dir).SaveLoopDecision(foreign); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err == nil {
+		t.Fatal("expected resume to reject a terminal decision from another session")
 	}
 }
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -27,6 +27,19 @@ type releaseFailingDecisionStore struct {
 	store.LoopDecisionStore
 }
 
+type unreadableCorruptDecisionStore struct {
+	store.LoopDecisionStore
+	reportCorruption bool
+}
+
+func (s *unreadableCorruptDecisionStore) ListLoopDecisions(key store.PullRequestKeyV1) ([]store.LoopDecisionV1, []store.CorruptRecord, error) {
+	decisions, corrupt, err := s.LoopDecisionStore.ListLoopDecisions(key)
+	if s.reportCorruption {
+		corrupt = append(corrupt, store.CorruptRecord{Path: "/unreadable/corrupt.json"})
+	}
+	return decisions, corrupt, err
+}
+
 func (s *releaseFailingDecisionStore) AcquireDecisionWriteLock() (func() error, error) {
 	return func() error { return fmt.Errorf("release failed") }, nil
 }
@@ -836,6 +849,40 @@ func TestControllerEscalatesForCorruptionReplacedAfterTrustedResume(t *testing.T
 	}
 	if decision.Kind != store.LoopDecisionEscalate || decision.Budget.Known {
 		t.Fatalf("expected replaced corruption to fail closed, got %+v", decision)
+	}
+}
+
+func TestControllerRejectsResumeForUnacknowledgeableCorruption(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	decisionStore := &unreadableCorruptDecisionStore{LoopDecisionStore: store.NewFilesystemLoopDecisionStore(dir)}
+	controller, err := NewController(decisionStore, store.NewFilesystemEconomicsStore(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.now = func() time.Time { return now }
+	controller.newID = func() (string, error) {
+		return fmt.Sprintf("id-%d", testIDCounter.Add(1)), nil
+	}
+	key := testKey()
+	policy := testPolicy(t, 2, time.Hour, 0)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Escalate(key, "operator decision required"); err != nil {
+		t.Fatal(err)
+	}
+	decisionStore.reportCorruption = true
+	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err == nil || !strings.Contains(err.Error(), "cannot be durably acknowledged") {
+		t.Fatalf("expected unacknowledgeable corruption to reject resume, got %v", err)
+	}
+	decisionStore.reportCorruption = false
+	decisions, corrupt, err := decisionStore.ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("ListLoopDecisions: corrupt=%v err=%v", corrupt, err)
+	}
+	if len(decisions) != 2 || decisions[len(decisions)-1].Decision != store.LoopDecisionEscalate {
+		t.Fatalf("failed resume persisted a new admission: %+v", decisions)
 	}
 }
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -16,6 +16,20 @@ import (
 
 var testIDCounter atomic.Int64
 
+type failingEconomicsStore struct {
+	store.EconomicsStore
+	listCalls int
+	failAfter int
+}
+
+func (s *failingEconomicsStore) ListEconomics(key store.PullRequestKeyV1) ([]store.EconomicsRecordV1, []store.CorruptRecord, error) {
+	s.listCalls++
+	if s.listCalls > s.failAfter {
+		return nil, nil, fmt.Errorf("economics backend unavailable")
+	}
+	return s.EconomicsStore.ListEconomics(key)
+}
+
 func testKey() store.PullRequestKeyV1 {
 	return store.PullRequestKeyV1{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
 }
@@ -382,6 +396,37 @@ func TestControllerClassifiesCorruptEconomicsByConfiguredBudget(t *testing.T) {
 				t.Fatalf("unexpected corruption decision: %+v", decision)
 			}
 		})
+	}
+}
+
+func TestControllerSkipsBudgetEconomicsReadWithoutCostLimit(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	economics := &failingEconomicsStore{
+		EconomicsStore: store.NewFilesystemEconomicsStore(dir),
+		failAfter:      2,
+	}
+	controller, err := NewController(store.NewFilesystemLoopDecisionStore(dir), economics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.now = func() time.Time { return now }
+	controller.newID = func() (string, error) {
+		return fmt.Sprintf("id-%d", testIDCounter.Add(1)), nil
+	}
+	key := testKey()
+	policy := testPolicy(t, 3, time.Hour, 0)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-one"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-two"); err != nil {
+		t.Fatal(err)
+	}
+	if economics.listCalls != 2 {
+		t.Fatalf("got %d economics reads, want only the two run-id checks", economics.listCalls)
 	}
 }
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -344,6 +344,47 @@ func TestControllerEscalatesWhenConfiguredProviderUsageIsUnavailable(t *testing.
 	}
 }
 
+func TestControllerClassifiesCorruptEconomicsByConfiguredBudget(t *testing.T) {
+	tests := []struct {
+		name     string
+		cost     float64
+		wantKind store.LoopDecisionKindV1
+		allowed  bool
+	}{
+		{name: "no cost bound", cost: 0, wantKind: store.LoopDecisionContinue, allowed: true},
+		{name: "cost bound", cost: 5, wantKind: store.LoopDecisionEscalate, allowed: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+			dir := t.TempDir()
+			controller := testController(t, dir, &now)
+			key := testKey()
+			policy := testPolicy(t, 3, time.Hour, tt.cost)
+			if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-before-corruption"); err != nil {
+				t.Fatal(err)
+			}
+			economicsDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "economics")
+			if err := os.MkdirAll(economicsDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(economicsDir, "20260731T120001.000000000Z-corrupt.json"), []byte("not json"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			decision, err := controller.AuthorizeReview(key, testTarget(), policy, "run-after-corruption")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Kind != tt.wantKind || decision.Allowed != tt.allowed {
+				t.Fatalf("unexpected corruption decision: %+v", decision)
+			}
+		})
+	}
+}
+
 func TestTrustedPolicyRejectsReviewedWorktreeAndHead(t *testing.T) {
 	target := testTarget()
 	target.Revision.HeadObjectID = "head-sha"

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -67,13 +67,18 @@ func testUserAuthorization(t *testing.T) Authorization {
 	return authorization
 }
 
+func testAuthorize(t *testing.T, controller *Controller, key store.PullRequestKeyV1, runID string) (Decision, error) {
+	t.Helper()
+	return controller.AuthorizeReview(key, testTarget(), testPolicy(t, 1, time.Hour, 0), runID)
+}
+
 func TestControllerRequiresTrustedCommissionAndRecordsAdmission(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()
 	controller := testController(t, dir, &now)
 	key := testKey()
 
-	if _, err := controller.AuthorizeReview(key, "run-before-commission"); err == nil {
+	if _, err := testAuthorize(t, controller, key, "run-before-commission"); err == nil {
 		t.Fatal("expected uncommissioned automatic review to be rejected")
 	}
 
@@ -108,7 +113,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 	}
 
 	for _, runID := range []string{"run-head-one", "run-head-two"} {
-		decision, err := controller.AuthorizeReview(key, runID)
+		decision, err := testAuthorize(t, controller, key, runID)
 		if err != nil {
 			t.Fatalf("AuthorizeReview(%s): %v", runID, err)
 		}
@@ -116,7 +121,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 			t.Fatalf("expected %s to be admitted, got %+v", runID, decision)
 		}
 	}
-	stopped, err := controller.AuthorizeReview(key, "run-head-three")
+	stopped, err := testAuthorize(t, controller, key, "run-head-three")
 	if err != nil {
 		t.Fatalf("AuthorizeReview(stop): %v", err)
 	}
@@ -125,7 +130,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 	}
 
 	restarted := testController(t, dir, &now)
-	stillStopped, err := restarted.AuthorizeReview(key, "run-after-restart")
+	stillStopped, err := testAuthorize(t, restarted, key, "run-after-restart")
 	if err != nil {
 		t.Fatalf("AuthorizeReview after restart: %v", err)
 	}
@@ -140,7 +145,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 	if _, err := restarted.Resume(key, testTarget(), policy, workspace); err != nil {
 		t.Fatalf("Resume: %v", err)
 	}
-	resumed, err := restarted.AuthorizeReview(key, "run-after-resume")
+	resumed, err := testAuthorize(t, restarted, key, "run-after-resume")
 	if err != nil {
 		t.Fatalf("AuthorizeReview after resume: %v", err)
 	}
@@ -159,7 +164,7 @@ func TestControllerDurationBoundAndDeadlineSpanLifecycle(t *testing.T) {
 	}
 
 	now = started.Add(10 * time.Minute)
-	allowed, err := controller.AuthorizeReview(key, "run-one")
+	allowed, err := testAuthorize(t, controller, key, "run-one")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +173,7 @@ func TestControllerDurationBoundAndDeadlineSpanLifecycle(t *testing.T) {
 	}
 
 	now = started.Add(31 * time.Minute)
-	stopped, err := controller.AuthorizeReview(key, "run-two")
+	stopped, err := testAuthorize(t, controller, key, "run-two")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +210,7 @@ func TestControllerDurationStartsAtAdmissionDespiteFutureHistory(t *testing.T) {
 		t.Fatalf("duration started at %s, want actual admission time %s", admission.Budget.StartedAt, started)
 	}
 	now = started.Add(31 * time.Minute)
-	stopped, err := controller.AuthorizeReview(key, "run-after-duration")
+	stopped, err := testAuthorize(t, controller, key, "run-after-duration")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,12 +228,12 @@ func TestControllerElapsedDurationDoesNotRegressWithClock(t *testing.T) {
 		t.Fatal(err)
 	}
 	now = started.Add(20 * time.Minute)
-	first, err := controller.AuthorizeReview(key, "run-before-regression")
+	first, err := testAuthorize(t, controller, key, "run-before-regression")
 	if err != nil {
 		t.Fatal(err)
 	}
 	now = started.Add(10 * time.Minute)
-	second, err := controller.AuthorizeReview(key, "run-after-regression")
+	second, err := testAuthorize(t, controller, key, "run-after-regression")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +250,7 @@ func TestControllerDoesNotCountSemanticConvergenceDecisionsAsReviewAdmissions(t 
 	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, "automatic-run-one"); err != nil {
+	if _, err := testAuthorize(t, controller, key, "automatic-run-one"); err != nil {
 		t.Fatal(err)
 	}
 	semantic := store.LoopDecisionV1{
@@ -263,7 +268,7 @@ func TestControllerDoesNotCountSemanticConvergenceDecisionsAsReviewAdmissions(t 
 		t.Fatalf("SaveLoopDecision: %v", err)
 	}
 
-	second, err := controller.AuthorizeReview(key, "automatic-run-two")
+	second, err := testAuthorize(t, controller, key, "automatic-run-two")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +284,7 @@ func TestControllerEnforcesMeasuredProviderCost(t *testing.T) {
 	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 10, time.Hour, 1), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
+	if _, err := testAuthorize(t, controller, key, "run-one"); err != nil {
 		t.Fatal(err)
 	}
 	economics := store.ReviewEconomicsV1{
@@ -293,7 +298,7 @@ func TestControllerEnforcesMeasuredProviderCost(t *testing.T) {
 		t.Fatalf("RecordEconomics: %v", err)
 	}
 
-	stopped, err := controller.AuthorizeReview(key, "run-two")
+	stopped, err := testAuthorize(t, controller, key, "run-two")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +314,7 @@ func TestControllerEscalatesWhenConfiguredProviderUsageIsUnavailable(t *testing.
 	if _, err := controller.Commission(key, testTarget(), testPolicy(t, 10, time.Hour, 5), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
+	if _, err := testAuthorize(t, controller, key, "run-one"); err != nil {
 		t.Fatal(err)
 	}
 	economics := store.ReviewEconomicsV1{
@@ -323,14 +328,14 @@ func TestControllerEscalatesWhenConfiguredProviderUsageIsUnavailable(t *testing.
 		t.Fatal(err)
 	}
 
-	escalated, err := controller.AuthorizeReview(key, "run-two")
+	escalated, err := testAuthorize(t, controller, key, "run-two")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if escalated.Kind != store.LoopDecisionEscalate || escalated.Allowed || !strings.Contains(escalated.Reason, "could not be measured") {
 		t.Fatalf("expected unavailable provider usage to escalate, got %+v", escalated)
 	}
-	again, err := controller.AuthorizeReview(key, "run-three")
+	again, err := testAuthorize(t, controller, key, "run-three")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,6 +414,81 @@ func TestTrustedPolicyCopiesTargetIdentity(t *testing.T) {
 	}
 }
 
+func TestControllerRevalidatesTrustedTargetForEachRun(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	targetA := testTarget()
+	targetA.Revision.HeadObjectID = "head-a"
+	policyRecord := store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 2},
+	}
+	policyA, err := NewTrustedPolicy(policyRecord, targetA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, targetA, policyA, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	targetB := testTarget()
+	targetB.Revision.HeadObjectID = "head-b"
+	if _, err := controller.AuthorizeReview(key, targetB, policyA, "run-head-b"); err == nil {
+		t.Fatal("expected policy validated for old head to be rejected")
+	}
+	policyB, err := NewTrustedPolicy(policyRecord, targetB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, targetB, policyB, "run-head-b"); err != nil {
+		t.Fatalf("AuthorizeReview with current target: %v", err)
+	}
+	records, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("ListLoopDecisions: corrupt=%v err=%v", corrupt, err)
+	}
+	if records[0].ReviewTarget == nil || records[0].ReviewTarget.Revision.HeadObjectID != "head-a" {
+		t.Fatalf("admission did not preserve trusted target revision: %+v", records[0].ReviewTarget)
+	}
+}
+
+func TestControllerRejectsRunIDAcrossDecisionScopesAndEconomics(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 3, time.Hour, 0)
+	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	semantic := store.LoopDecisionV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		ID:            "semantic-collision",
+		PullRequest:   key,
+		RunID:         "semantic-run",
+		Scope:         store.LoopDecisionScopeSemanticConvergence,
+		Decision:      store.LoopDecisionContinue,
+		Reason:        "semantic routing",
+		Budget:        store.BudgetStateV1{Known: true},
+		DecidedAt:     now.Add(time.Minute),
+	}
+	if _, err := store.NewFilesystemLoopDecisionStore(dir).SaveLoopDecision(semantic); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "semantic-run"); err == nil {
+		t.Fatal("expected cross-scope run id collision to be rejected")
+	}
+	economics := store.ReviewEconomicsV1{SchemaVersion: store.CurrentSchemaVersion, RunID: "economics-run"}
+	if _, err := store.NewFilesystemEconomicsStore(dir).SaveEconomics(key, now.Add(2*time.Minute), economics); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "economics-run"); err == nil {
+		t.Fatal("expected economics run id collision to be rejected")
+	}
+}
+
 func TestControllerSerializesReviewAdmissionAcrossInstances(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()
@@ -432,7 +512,7 @@ func TestControllerSerializesReviewAdmissionAcrossInstances(t *testing.T) {
 		go func(index int, controller *Controller) {
 			defer group.Done()
 			<-start
-			decision, err := controller.AuthorizeReview(key, fmt.Sprintf("concurrent-run-%d", index))
+			decision, err := testAuthorize(t, controller, key, fmt.Sprintf("concurrent-run-%d", index))
 			results <- result{decision: decision, err: err}
 		}(index, controller)
 	}
@@ -460,16 +540,16 @@ func TestControllerRejectsRunIDReusedAcrossSessions(t *testing.T) {
 	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, "reused-run"); err != nil {
+	if _, err := testAuthorize(t, controller, key, "reused-run"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, "stop-run"); err != nil {
+	if _, err := testAuthorize(t, controller, key, "stop-run"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, "reused-run"); err == nil {
+	if _, err := testAuthorize(t, controller, key, "reused-run"); err == nil {
 		t.Fatal("expected run id reused across sessions to be rejected")
 	}
 }
@@ -486,7 +566,7 @@ func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(decisionDir, "20260731T120001.000000000Z-corrupt.json"), []byte("not json"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	escalated, err := controller.AuthorizeReview(key, "run-after-corruption")
+	escalated, err := testAuthorize(t, controller, key, "run-after-corruption")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +584,7 @@ func TestControllerRecordsExplicitEscalationAndTrustedResume(t *testing.T) {
 	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
+	if _, err := testAuthorize(t, controller, key, "run-one"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.Escalate(key, "operator decision required"); err != nil {

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -2,7 +2,10 @@ package automatic
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -69,7 +72,7 @@ func TestControllerRequiresTrustedCommissionAndRecordsAdmission(t *testing.T) {
 		t.Fatal("expected uncommissioned automatic review to be rejected")
 	}
 
-	decision, err := controller.Commission(key, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t))
+	decision, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t))
 	if err != nil {
 		t.Fatalf("Commission: %v", err)
 	}
@@ -95,7 +98,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 	controller := testController(t, dir, &now)
 	key := testKey()
 	policy := testPolicy(t, 2, time.Hour, 0)
-	if _, err := controller.Commission(key, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -129,7 +132,7 @@ func TestControllerReviewBoundPersistsAcrossRunsAndRequiresResume(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := restarted.Resume(key, policy, workspace); err != nil {
+	if _, err := restarted.Resume(key, store.ReviewTargetV1{}, policy, workspace); err != nil {
 		t.Fatalf("Resume: %v", err)
 	}
 	resumed, err := restarted.AuthorizeReview(key, "run-after-resume")
@@ -146,7 +149,7 @@ func TestControllerDurationBoundAndDeadlineSpanLifecycle(t *testing.T) {
 	now := started
 	controller := testController(t, t.TempDir(), &now)
 	key := testKey()
-	if _, err := controller.Commission(key, testPolicy(t, 10, 30*time.Minute, 0), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 10, 30*time.Minute, 0), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -174,7 +177,7 @@ func TestControllerDoesNotCountSemanticConvergenceDecisionsAsReviewAdmissions(t 
 	dir := t.TempDir()
 	controller := testController(t, dir, &now)
 	key := testKey()
-	if _, err := controller.Commission(key, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "automatic-run-one"); err != nil {
@@ -208,7 +211,7 @@ func TestControllerEnforcesMeasuredProviderCost(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	controller := testController(t, t.TempDir(), &now)
 	key := testKey()
-	if _, err := controller.Commission(key, testPolicy(t, 10, time.Hour, 1), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 10, time.Hour, 1), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
@@ -238,7 +241,7 @@ func TestControllerEscalatesWhenConfiguredProviderUsageIsUnavailable(t *testing.
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	controller := testController(t, t.TempDir(), &now)
 	key := testKey()
-	if _, err := controller.Commission(key, testPolicy(t, 10, time.Hour, 5), testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 10, time.Hour, 5), testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
@@ -291,13 +294,118 @@ func TestTrustedPolicyRejectsReviewedWorktreeAndHead(t *testing.T) {
 	}
 }
 
+func TestTrustedPolicyCannotBeReusedForAnotherTarget(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	controller := testController(t, t.TempDir(), &now)
+	key := testKey()
+	targetA := store.ReviewTargetV1{Revision: store.RevisionEvidenceV1{HeadObjectID: "head-a"}, PullRequest: &key}
+	targetB := store.ReviewTargetV1{Revision: store.RevisionEvidenceV1{HeadObjectID: "head-b"}, PullRequest: &key}
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 1},
+	}, targetA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, targetB, policy, testUserAuthorization(t)); err == nil {
+		t.Fatal("expected policy reuse for another target to be rejected")
+	}
+}
+
+func TestControllerSerializesReviewAdmissionAcrossInstances(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	first := testController(t, dir, &now)
+	second := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 1, time.Hour, 0)
+	if _, err := first.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		decision Decision
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	var group sync.WaitGroup
+	for index, controller := range []*Controller{first, second} {
+		group.Add(1)
+		go func(index int, controller *Controller) {
+			defer group.Done()
+			<-start
+			decision, err := controller.AuthorizeReview(key, fmt.Sprintf("concurrent-run-%d", index))
+			results <- result{decision: decision, err: err}
+		}(index, controller)
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	allowed := 0
+	for result := range results {
+		if result.err == nil && result.decision.Allowed {
+			allowed++
+		}
+	}
+	if allowed != 1 {
+		t.Fatalf("got %d concurrently admitted reviews, want 1", allowed)
+	}
+}
+
+func TestControllerRejectsRunIDReusedAcrossSessions(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	policy := testPolicy(t, 1, time.Hour, 0)
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, "reused-run"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, "stop-run"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, "reused-run"); err == nil {
+		t.Fatal("expected run id reused across sessions to be rejected")
+	}
+}
+
+func TestControllerRecordsUnknownBudgetForCorruptHistory(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, testPolicy(t, 2, time.Hour, 0), testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	decisionDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "loop_decisions")
+	if err := os.WriteFile(filepath.Join(decisionDir, "20260731T120001.000000000Z-corrupt.json"), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	escalated, err := controller.AuthorizeReview(key, "run-after-corruption")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if escalated.Kind != store.LoopDecisionEscalate || escalated.Budget.Known {
+		t.Fatalf("expected corrupt history escalation with unknown budget, got %+v", escalated)
+	}
+}
+
 func TestControllerRecordsExplicitEscalationAndTrustedResume(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()
 	controller := testController(t, dir, &now)
 	key := testKey()
 	policy := testPolicy(t, 2, time.Hour, 0)
-	if _, err := controller.Commission(key, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Commission(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.AuthorizeReview(key, "run-one"); err != nil {
@@ -306,7 +414,7 @@ func TestControllerRecordsExplicitEscalationAndTrustedResume(t *testing.T) {
 	if _, err := controller.Escalate(key, "operator decision required"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.Resume(key, policy, testUserAuthorization(t)); err != nil {
+	if _, err := controller.Resume(key, store.ReviewTargetV1{}, policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -462,6 +462,56 @@ func TestControllerClassifiesCorruptEconomicsByConfiguredBudget(t *testing.T) {
 	}
 }
 
+func TestControllerFailsClosedForCorruptActiveEconomicsWithValidReplacement(t *testing.T) {
+	tests := []struct {
+		name        string
+		cost        float64
+		corruptName string
+		wantKind    store.LoopDecisionKindV1
+		allowed     bool
+	}{
+		{name: "cost disabled", cost: 0, corruptName: "20260731T120001.000000000Z-run-with-corruption.json", wantKind: store.LoopDecisionContinue, allowed: true},
+		{name: "active run", cost: 5, corruptName: "20260731T120001.000000000Z-run-with-corruption.json", wantKind: store.LoopDecisionEscalate, allowed: false},
+		{name: "unknown association", cost: 5, corruptName: "malformed.json", wantKind: store.LoopDecisionEscalate, allowed: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+			dir := t.TempDir()
+			controller := testController(t, dir, &now)
+			key := testKey()
+			policy := testPolicy(t, 3, time.Hour, tt.cost)
+			if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-with-corruption"); err != nil {
+				t.Fatal(err)
+			}
+			economicsDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "economics")
+			if err := os.MkdirAll(economicsDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			corruptPath := filepath.Join(economicsDir, tt.corruptName)
+			if err := os.WriteFile(corruptPath, []byte("not json"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := controller.RecordEconomics(key, now.Add(2*time.Second), store.ReviewEconomicsV1{
+				SchemaVersion: store.CurrentSchemaVersion,
+				RunID:         "run-with-corruption",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			decision, err := controller.AuthorizeReview(key, testTarget(), policy, "run-after-corruption")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Kind != tt.wantKind || decision.Allowed != tt.allowed {
+				t.Fatalf("unexpected decision with corrupt active economics: %+v", decision)
+			}
+		})
+	}
+}
+
 func TestControllerIgnoresCorruptEconomicsOutsideActiveSession(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,11 +72,12 @@ type Config struct {
 }
 
 type AdjudicationConfig struct {
-	MaxIterations       *int     `yaml:"max_iterations"`
-	MaxCostUSD          *float64 `yaml:"max_cost_usd"`
-	StopOnCleanRun      *bool    `yaml:"stop_on_clean_run"`
-	StopOnNoNewFindings *bool    `yaml:"stop_on_no_new_findings"`
-	EvaluationGuidance  *string  `yaml:"evaluation_guidance"`
+	MaxIterations       *int      `yaml:"max_iterations"`
+	MaxDuration         *Duration `yaml:"max_duration"`
+	MaxCostUSD          *float64  `yaml:"max_cost_usd"`
+	StopOnCleanRun      *bool     `yaml:"stop_on_clean_run"`
+	StopOnNoNewFindings *bool     `yaml:"stop_on_no_new_findings"`
+	EvaluationGuidance  *string   `yaml:"evaluation_guidance"`
 }
 
 type WatchConfig struct {
@@ -191,7 +192,7 @@ var knownWatchKeys = []string{"poll_interval", "settle_time", "max_reviews", "ma
 
 var knownFilterKeys = []string{"exclude_patterns"}
 
-var knownAdjudicationKeys = []string{"max_iterations", "max_cost_usd", "stop_on_clean_run", "stop_on_no_new_findings", "evaluation_guidance"}
+var knownAdjudicationKeys = []string{"max_iterations", "max_duration", "max_cost_usd", "stop_on_clean_run", "stop_on_no_new_findings", "evaluation_guidance"}
 
 func checkUnknownKeys(data []byte) []string {
 	var warnings []string
@@ -416,6 +417,9 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.AdjudicationMaxIterations < 0 {
 		errs = append(errs, fmt.Sprintf("adjudication.max_iterations must be >= 0, got %d", r.AdjudicationMaxIterations))
 	}
+	if r.AdjudicationMaxDuration < 0 {
+		errs = append(errs, fmt.Sprintf("adjudication.max_duration must be >= 0, got %s", r.AdjudicationMaxDuration))
+	}
 	if r.AdjudicationMaxCostUSD < 0 || math.IsNaN(r.AdjudicationMaxCostUSD) || math.IsInf(r.AdjudicationMaxCostUSD, 0) {
 		errs = append(errs, fmt.Sprintf("adjudication.max_cost_usd must be a finite number >= 0, got %g", r.AdjudicationMaxCostUSD))
 	}
@@ -478,6 +482,7 @@ type ResolvedConfig struct {
 	WatchUncertain    string
 
 	AdjudicationMaxIterations int
+	AdjudicationMaxDuration   time.Duration
 	AdjudicationMaxCostUSD    float64
 }
 
@@ -792,6 +797,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		}
 		if cfg.Adjudication.MaxIterations != nil {
 			result.AdjudicationMaxIterations = *cfg.Adjudication.MaxIterations
+		}
+		if cfg.Adjudication.MaxDuration != nil {
+			result.AdjudicationMaxDuration = cfg.Adjudication.MaxDuration.AsDuration()
 		}
 		if cfg.Adjudication.MaxCostUSD != nil {
 			result.AdjudicationMaxCostUSD = *cfg.Adjudication.MaxCostUSD

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -653,6 +653,7 @@ func TestLoadFromPathWithWarnings_AdjudicationSection(t *testing.T) {
 
 	content := `adjudication:
   max_iterations: 5
+  max_duration: 2h
   max_cost_usd: 2.5
   stop_on_clean_run: true
   stop_on_no_new_findings: false
@@ -673,6 +674,9 @@ func TestLoadFromPathWithWarnings_AdjudicationSection(t *testing.T) {
 	adjudication := result.Config.Adjudication
 	if adjudication.MaxIterations == nil || *adjudication.MaxIterations != 5 {
 		t.Errorf("expected max_iterations=5, got %v", adjudication.MaxIterations)
+	}
+	if adjudication.MaxDuration == nil || adjudication.MaxDuration.AsDuration() != 2*time.Hour {
+		t.Errorf("expected max_duration=2h, got %v", adjudication.MaxDuration)
 	}
 	if adjudication.MaxCostUSD == nil || *adjudication.MaxCostUSD != 2.5 {
 		t.Errorf("expected max_cost_usd=2.5, got %v", adjudication.MaxCostUSD)
@@ -1763,10 +1767,11 @@ func TestValidate_WatchBounds(t *testing.T) {
 func TestValidate_AdjudicationBounds(t *testing.T) {
 	resolved := Defaults
 	resolved.AdjudicationMaxIterations = -1
+	resolved.AdjudicationMaxDuration = -time.Second
 	resolved.AdjudicationMaxCostUSD = -0.01
 
 	errs := resolved.ValidateAll()
-	for _, want := range []string{"adjudication.max_iterations", "adjudication.max_cost_usd"} {
+	for _, want := range []string{"adjudication.max_iterations", "adjudication.max_duration", "adjudication.max_cost_usd"} {
 		found := false
 		for _, e := range errs {
 			if strings.Contains(e, want) {
@@ -1810,12 +1815,16 @@ func TestValidate_AdjudicationMaxCostUSDRejectsNonFiniteValues(t *testing.T) {
 
 func TestResolve_AdjudicationBudget(t *testing.T) {
 	maxIterations := -1
+	maxDuration := Duration(-time.Second)
 	maxCostUSD := -0.01
-	cfg := &Config{Adjudication: AdjudicationConfig{MaxIterations: &maxIterations, MaxCostUSD: &maxCostUSD}}
+	cfg := &Config{Adjudication: AdjudicationConfig{MaxIterations: &maxIterations, MaxDuration: &maxDuration, MaxCostUSD: &maxCostUSD}}
 
 	resolved := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
 	if resolved.AdjudicationMaxIterations != maxIterations {
 		t.Errorf("AdjudicationMaxIterations = %d, want %d", resolved.AdjudicationMaxIterations, maxIterations)
+	}
+	if resolved.AdjudicationMaxDuration != -time.Second {
+		t.Errorf("AdjudicationMaxDuration = %s, want %s", resolved.AdjudicationMaxDuration, -time.Second)
 	}
 	if resolved.AdjudicationMaxCostUSD != maxCostUSD {
 		t.Errorf("AdjudicationMaxCostUSD = %g, want %g", resolved.AdjudicationMaxCostUSD, maxCostUSD)

--- a/internal/store/corrupt.go
+++ b/internal/store/corrupt.go
@@ -9,9 +9,8 @@ import (
 )
 
 type CorruptRecord struct {
-	Path       string
-	RecordedAt time.Time
-	Err        error
+	Path string
+	Err  error
 }
 
 type timestampedRecord[T any] struct {
@@ -38,14 +37,12 @@ func listRecords[T any](dir string, decode func([]byte) (T, error)) ([]T, []Corr
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			recordedAt, _ := parseRecordTimestamp(name)
-			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("read %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("read %s: %w", path, err)})
 			continue
 		}
 		record, err := decode(data)
 		if err != nil {
-			recordedAt, _ := parseRecordTimestamp(name)
-			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("decode %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
 			continue
 		}
 		records = append(records, record)
@@ -77,12 +74,12 @@ func listTimestampedRecords[T any](dir string, decode func([]byte) (T, error)) (
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("read %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("read %s: %w", path, err)})
 			continue
 		}
 		record, err := decode(data)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("decode %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
 			continue
 		}
 		records = append(records, timestampedRecord[T]{recordedAt: recordedAt, record: record})

--- a/internal/store/corrupt.go
+++ b/internal/store/corrupt.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,8 +11,9 @@ import (
 )
 
 type CorruptRecord struct {
-	Path string
-	Err  error
+	Path        string
+	Fingerprint string
+	Err         error
 }
 
 type timestampedRecord[T any] struct {
@@ -42,7 +45,7 @@ func listRecords[T any](dir string, decode func([]byte) (T, error)) ([]T, []Corr
 		}
 		record, err := decode(data)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, Fingerprint: corruptFingerprint(data), Err: fmt.Errorf("decode %s: %w", path, err)})
 			continue
 		}
 		records = append(records, record)
@@ -79,10 +82,15 @@ func listTimestampedRecords[T any](dir string, decode func([]byte) (T, error)) (
 		}
 		record, err := decode(data)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, Fingerprint: corruptFingerprint(data), Err: fmt.Errorf("decode %s: %w", path, err)})
 			continue
 		}
 		records = append(records, timestampedRecord[T]{recordedAt: recordedAt, record: record})
 	}
 	return records, corrupt, nil
+}
+
+func corruptFingerprint(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/store/corrupt.go
+++ b/internal/store/corrupt.go
@@ -12,6 +12,7 @@ import (
 
 type CorruptRecord struct {
 	Path        string
+	RecordID    string
 	Fingerprint string
 	Err         error
 }
@@ -75,14 +76,19 @@ func listTimestampedRecords[T any](dir string, decode func([]byte) (T, error)) (
 			corrupt = append(corrupt, CorruptRecord{Path: path, Err: err})
 			continue
 		}
+		recordID, err := parseRecordID(name)
+		if err != nil {
+			corrupt = append(corrupt, CorruptRecord{Path: path, Err: err})
+			continue
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("read %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, RecordID: recordID, Err: fmt.Errorf("read %s: %w", path, err)})
 			continue
 		}
 		record, err := decode(data)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Fingerprint: corruptFingerprint(data), Err: fmt.Errorf("decode %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, RecordID: recordID, Fingerprint: corruptFingerprint(data), Err: fmt.Errorf("decode %s: %w", path, err)})
 			continue
 		}
 		records = append(records, timestampedRecord[T]{recordedAt: recordedAt, record: record})

--- a/internal/store/corrupt.go
+++ b/internal/store/corrupt.go
@@ -9,8 +9,9 @@ import (
 )
 
 type CorruptRecord struct {
-	Path string
-	Err  error
+	Path       string
+	RecordedAt time.Time
+	Err        error
 }
 
 type timestampedRecord[T any] struct {
@@ -37,12 +38,14 @@ func listRecords[T any](dir string, decode func([]byte) (T, error)) ([]T, []Corr
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("read %s: %w", path, err)})
+			recordedAt, _ := parseRecordTimestamp(name)
+			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("read %s: %w", path, err)})
 			continue
 		}
 		record, err := decode(data)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
+			recordedAt, _ := parseRecordTimestamp(name)
+			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("decode %s: %w", path, err)})
 			continue
 		}
 		records = append(records, record)
@@ -74,12 +77,12 @@ func listTimestampedRecords[T any](dir string, decode func([]byte) (T, error)) (
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("read %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("read %s: %w", path, err)})
 			continue
 		}
 		record, err := decode(data)
 		if err != nil {
-			corrupt = append(corrupt, CorruptRecord{Path: path, Err: fmt.Errorf("decode %s: %w", path, err)})
+			corrupt = append(corrupt, CorruptRecord{Path: path, RecordedAt: recordedAt, Err: fmt.Errorf("decode %s: %w", path, err)})
 			continue
 		}
 		records = append(records, timestampedRecord[T]{recordedAt: recordedAt, record: record})

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -129,6 +129,11 @@ func (d LoopDecisionV1) Validate() error {
 	if err := d.Scope.Validate(); err != nil {
 		return err
 	}
+	if d.Scope == LoopDecisionScopeAutomaticExecution {
+		if err := validateNonEmpty("loop decision session_id", d.SessionID); err != nil {
+			return err
+		}
+	}
 	if d.Decision == LoopDecisionContinue || (d.Scope != LoopDecisionScopeAutomaticExecution && (d.Decision == LoopDecisionStop || d.Decision == LoopDecisionEscalate)) {
 		if err := validateNonEmpty("loop decision run_id", d.RunID); err != nil {
 			return err

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -184,5 +184,13 @@ func (d LoopDecisionV1) Validate() error {
 	if d.DecidedAt.IsZero() {
 		return fmt.Errorf("loop decision decided_at is required")
 	}
+	if d.Decision == LoopDecisionAdmit && d.Budget.DurationLimit > 0 {
+		if d.Budget.StartedAt.IsZero() {
+			return fmt.Errorf("duration-bounded loop decision admission requires a start time")
+		}
+		if d.Budget.StartedAt.After(d.DecidedAt) {
+			return fmt.Errorf("loop decision admission budget cannot start after the decision")
+		}
+	}
 	return nil
 }

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -107,6 +107,7 @@ type LoopDecisionV1 struct {
 	AuthorizedBy              string              `json:"authorized_by,omitempty"`
 	PolicySource              *PolicySourceV1     `json:"policy_source,omitempty"`
 	ReviewTarget              *ReviewTargetV1     `json:"review_target,omitempty"`
+	AcknowledgedCorruptFiles  []string            `json:"acknowledged_corrupt_files,omitempty"`
 	Scope                     LoopDecisionScopeV1 `json:"scope,omitempty"`
 	Decision                  LoopDecisionKindV1  `json:"decision"`
 	Reason                    string              `json:"reason"`
@@ -173,6 +174,13 @@ func (d LoopDecisionV1) Validate() error {
 		if !d.Budget.Known || (d.Budget.IterationsLimit == 0 && d.Budget.DurationLimit == 0) {
 			return fmt.Errorf("loop decision admission requires a known review or duration bound")
 		}
+		for _, name := range d.AcknowledgedCorruptFiles {
+			if err := validateRecordID("acknowledged corrupt decision file", name); err != nil {
+				return err
+			}
+		}
+	} else if len(d.AcknowledgedCorruptFiles) != 0 {
+		return fmt.Errorf("acknowledged corrupt decision files require an admission decision")
 	}
 	if err := d.Decision.Validate(); err != nil {
 		return err

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -156,6 +156,9 @@ func (d LoopDecisionV1) Validate() error {
 		if err := d.PolicySource.Validate(); err != nil {
 			return err
 		}
+		if !d.Budget.Known || (d.Budget.IterationsLimit == 0 && d.Budget.DurationLimit == 0) {
+			return fmt.Errorf("loop decision admission requires a known review or duration bound")
+		}
 	}
 	if err := d.Decision.Validate(); err != nil {
 		return err

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -156,6 +156,15 @@ func (d LoopDecisionV1) Validate() error {
 		if err := d.PolicySource.Validate(); err != nil {
 			return err
 		}
+		if d.ReviewTarget == nil || d.ReviewTarget.PullRequest == nil {
+			return fmt.Errorf("loop decision admission requires a pull-request review target")
+		}
+		if *d.ReviewTarget.PullRequest != d.PullRequest {
+			return fmt.Errorf("loop decision admission review target does not match pull request")
+		}
+		if err := ValidatePolicySourceOutsideReview(*d.PolicySource, *d.ReviewTarget); err != nil {
+			return fmt.Errorf("loop decision admission policy source: %w", err)
+		}
 		if !d.Budget.Known || (d.Budget.IterationsLimit == 0 && d.Budget.DurationLimit == 0) {
 			return fmt.Errorf("loop decision admission requires a known review or duration bound")
 		}

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -106,6 +106,7 @@ type LoopDecisionV1 struct {
 	AuthorizationKind         string              `json:"authorization_kind,omitempty"`
 	AuthorizedBy              string              `json:"authorized_by,omitempty"`
 	PolicySource              *PolicySourceV1     `json:"policy_source,omitempty"`
+	ReviewTarget              *ReviewTargetV1     `json:"review_target,omitempty"`
 	Scope                     LoopDecisionScopeV1 `json:"scope,omitempty"`
 	Decision                  LoopDecisionKindV1  `json:"decision"`
 	Reason                    string              `json:"reason"`

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -8,7 +8,24 @@ import (
 
 type LoopDecisionKindV1 string
 
+type LoopDecisionScopeV1 string
+
 const (
+	LoopDecisionScopeAutomaticExecution  LoopDecisionScopeV1 = "automatic_execution"
+	LoopDecisionScopeSemanticConvergence LoopDecisionScopeV1 = "semantic_convergence"
+)
+
+func (s LoopDecisionScopeV1) Validate() error {
+	switch s {
+	case "", LoopDecisionScopeAutomaticExecution, LoopDecisionScopeSemanticConvergence:
+		return nil
+	default:
+		return fmt.Errorf("unknown loop decision scope %q", s)
+	}
+}
+
+const (
+	LoopDecisionAdmit    LoopDecisionKindV1 = "admit"
 	LoopDecisionContinue LoopDecisionKindV1 = "continue"
 	LoopDecisionStop     LoopDecisionKindV1 = "stop"
 	LoopDecisionEscalate LoopDecisionKindV1 = "escalate"
@@ -16,7 +33,7 @@ const (
 
 func (k LoopDecisionKindV1) Validate() error {
 	switch k {
-	case LoopDecisionContinue, LoopDecisionStop, LoopDecisionEscalate:
+	case LoopDecisionAdmit, LoopDecisionContinue, LoopDecisionStop, LoopDecisionEscalate:
 		return nil
 	default:
 		return fmt.Errorf("unknown loop decision kind %q", k)
@@ -24,22 +41,29 @@ func (k LoopDecisionKindV1) Validate() error {
 }
 
 type BudgetStateV1 struct {
-	Known           bool    `json:"known"`
-	IterationsUsed  int     `json:"iterations_used"`
-	IterationsLimit int     `json:"iterations_limit"`
-	CostUSDUsed     float64 `json:"cost_usd_used"`
-	CostUSDLimit    float64 `json:"cost_usd_limit"`
+	Known           bool          `json:"known"`
+	IterationsUsed  int           `json:"iterations_used"`
+	IterationsLimit int           `json:"iterations_limit"`
+	StartedAt       time.Time     `json:"started_at,omitempty"`
+	Elapsed         time.Duration `json:"elapsed"`
+	DurationLimit   time.Duration `json:"duration_limit"`
+	CostKnown       bool          `json:"cost_known"`
+	CostUSDUsed     float64       `json:"cost_usd_used"`
+	CostUSDLimit    float64       `json:"cost_usd_limit"`
 }
 
 func (b BudgetStateV1) Validate() error {
 	if !b.Known {
-		if b.IterationsUsed != 0 || b.IterationsLimit != 0 || b.CostUSDUsed != 0 || b.CostUSDLimit != 0 {
+		if b.IterationsUsed != 0 || b.IterationsLimit != 0 || !b.StartedAt.IsZero() || b.Elapsed != 0 || b.DurationLimit != 0 || b.CostKnown || b.CostUSDUsed != 0 || b.CostUSDLimit != 0 {
 			return fmt.Errorf("budget state marked unknown must not carry nonzero measurements")
 		}
 		return nil
 	}
 	if b.IterationsUsed < 0 || b.IterationsLimit < 0 {
 		return fmt.Errorf("known budget iteration counts must not be negative")
+	}
+	if b.Elapsed < 0 || b.DurationLimit < 0 {
+		return fmt.Errorf("known budget durations must not be negative")
 	}
 	if isInvalidKnownCost(b.CostUSDUsed) || isInvalidKnownCost(b.CostUSDLimit) {
 		return fmt.Errorf("known budget cost must be a finite number that is not negative")
@@ -52,16 +76,21 @@ func isInvalidKnownCost(cost float64) bool {
 }
 
 type LoopDecisionV1 struct {
-	SchemaVersion             int                `json:"schema_version"`
-	ID                        string             `json:"id"`
-	PullRequest               PullRequestKeyV1   `json:"pull_request"`
-	RunID                     string             `json:"run_id"`
-	Decision                  LoopDecisionKindV1 `json:"decision"`
-	Reason                    string             `json:"reason"`
-	IterationCount            int                `json:"iteration_count"`
-	Budget                    BudgetStateV1      `json:"budget"`
-	SupportingAdjudicationIDs []string           `json:"supporting_adjudication_ids,omitempty"`
-	DecidedAt                 time.Time          `json:"decided_at"`
+	SchemaVersion             int                 `json:"schema_version"`
+	ID                        string              `json:"id"`
+	PullRequest               PullRequestKeyV1    `json:"pull_request"`
+	RunID                     string              `json:"run_id,omitempty"`
+	SessionID                 string              `json:"session_id,omitempty"`
+	AuthorizationKind         string              `json:"authorization_kind,omitempty"`
+	AuthorizedBy              string              `json:"authorized_by,omitempty"`
+	PolicySource              *PolicySourceV1     `json:"policy_source,omitempty"`
+	Scope                     LoopDecisionScopeV1 `json:"scope,omitempty"`
+	Decision                  LoopDecisionKindV1  `json:"decision"`
+	Reason                    string              `json:"reason"`
+	IterationCount            int                 `json:"iteration_count"`
+	Budget                    BudgetStateV1       `json:"budget"`
+	SupportingAdjudicationIDs []string            `json:"supporting_adjudication_ids,omitempty"`
+	DecidedAt                 time.Time           `json:"decided_at"`
 }
 
 func (d LoopDecisionV1) Validate() error {
@@ -74,8 +103,36 @@ func (d LoopDecisionV1) Validate() error {
 	if err := d.PullRequest.Validate(); err != nil {
 		return err
 	}
-	if err := validateNonEmpty("loop decision run_id", d.RunID); err != nil {
+	if err := d.Scope.Validate(); err != nil {
 		return err
+	}
+	if d.Decision == LoopDecisionContinue {
+		if err := validateNonEmpty("loop decision run_id", d.RunID); err != nil {
+			return err
+		}
+	}
+	if d.Decision == LoopDecisionAdmit {
+		if d.Scope != LoopDecisionScopeAutomaticExecution {
+			return fmt.Errorf("loop decision admission requires automatic_execution scope")
+		}
+		if err := validateNonEmpty("loop decision session_id", d.SessionID); err != nil {
+			return err
+		}
+		if err := validateNonEmpty("loop decision authorization_kind", d.AuthorizationKind); err != nil {
+			return err
+		}
+		if d.AuthorizationKind != "user" && d.AuthorizationKind != "workspace_controller" {
+			return fmt.Errorf("loop decision authorization_kind %q is not trusted", d.AuthorizationKind)
+		}
+		if err := validateNonEmpty("loop decision authorized_by", d.AuthorizedBy); err != nil {
+			return err
+		}
+		if d.PolicySource == nil {
+			return fmt.Errorf("loop decision policy_source is required for admission")
+		}
+		if err := d.PolicySource.Validate(); err != nil {
+			return err
+		}
 	}
 	if err := d.Decision.Validate(); err != nil {
 		return err

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"time"
@@ -52,6 +53,24 @@ type BudgetStateV1 struct {
 	CostUSDLimit    float64       `json:"cost_usd_limit"`
 }
 
+func (b *BudgetStateV1) UnmarshalJSON(data []byte) error {
+	type budgetState BudgetStateV1
+	decoded := struct {
+		budgetState
+		CostKnown *bool `json:"cost_known"`
+	}{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*b = BudgetStateV1(decoded.budgetState)
+	if decoded.CostKnown == nil {
+		b.CostKnown = b.Known
+	} else {
+		b.CostKnown = *decoded.CostKnown
+	}
+	return nil
+}
+
 func (b BudgetStateV1) Validate() error {
 	if !b.Known {
 		if b.IterationsUsed != 0 || b.IterationsLimit != 0 || !b.StartedAt.IsZero() || b.Elapsed != 0 || b.DurationLimit != 0 || b.CostKnown || b.CostUSDUsed != 0 || b.CostUSDLimit != 0 {
@@ -67,6 +86,9 @@ func (b BudgetStateV1) Validate() error {
 	}
 	if isInvalidKnownCost(b.CostUSDUsed) || isInvalidKnownCost(b.CostUSDLimit) {
 		return fmt.Errorf("known budget cost must be a finite number that is not negative")
+	}
+	if !b.CostKnown && b.CostUSDUsed != 0 {
+		return fmt.Errorf("budget with unknown cost must not carry measured cost usage")
 	}
 	return nil
 }
@@ -106,7 +128,7 @@ func (d LoopDecisionV1) Validate() error {
 	if err := d.Scope.Validate(); err != nil {
 		return err
 	}
-	if d.Decision == LoopDecisionContinue {
+	if d.Decision == LoopDecisionContinue || (d.Scope != LoopDecisionScopeAutomaticExecution && (d.Decision == LoopDecisionStop || d.Decision == LoopDecisionEscalate)) {
 		if err := validateNonEmpty("loop decision run_id", d.RunID); err != nil {
 			return err
 		}

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -98,23 +98,28 @@ func isInvalidKnownCost(cost float64) bool {
 }
 
 type LoopDecisionV1 struct {
-	SchemaVersion             int                 `json:"schema_version"`
-	ID                        string              `json:"id"`
-	PullRequest               PullRequestKeyV1    `json:"pull_request"`
-	RunID                     string              `json:"run_id,omitempty"`
-	SessionID                 string              `json:"session_id,omitempty"`
-	AuthorizationKind         string              `json:"authorization_kind,omitempty"`
-	AuthorizedBy              string              `json:"authorized_by,omitempty"`
-	PolicySource              *PolicySourceV1     `json:"policy_source,omitempty"`
-	ReviewTarget              *ReviewTargetV1     `json:"review_target,omitempty"`
-	AcknowledgedCorruptFiles  []string            `json:"acknowledged_corrupt_files,omitempty"`
-	Scope                     LoopDecisionScopeV1 `json:"scope,omitempty"`
-	Decision                  LoopDecisionKindV1  `json:"decision"`
-	Reason                    string              `json:"reason"`
-	IterationCount            int                 `json:"iteration_count"`
-	Budget                    BudgetStateV1       `json:"budget"`
-	SupportingAdjudicationIDs []string            `json:"supporting_adjudication_ids,omitempty"`
-	DecidedAt                 time.Time           `json:"decided_at"`
+	SchemaVersion              int                             `json:"schema_version"`
+	ID                         string                          `json:"id"`
+	PullRequest                PullRequestKeyV1                `json:"pull_request"`
+	RunID                      string                          `json:"run_id,omitempty"`
+	SessionID                  string                          `json:"session_id,omitempty"`
+	AuthorizationKind          string                          `json:"authorization_kind,omitempty"`
+	AuthorizedBy               string                          `json:"authorized_by,omitempty"`
+	PolicySource               *PolicySourceV1                 `json:"policy_source,omitempty"`
+	ReviewTarget               *ReviewTargetV1                 `json:"review_target,omitempty"`
+	AcknowledgedCorruptRecords []CorruptRecordAcknowledgmentV1 `json:"acknowledged_corrupt_records,omitempty"`
+	Scope                      LoopDecisionScopeV1             `json:"scope,omitempty"`
+	Decision                   LoopDecisionKindV1              `json:"decision"`
+	Reason                     string                          `json:"reason"`
+	IterationCount             int                             `json:"iteration_count"`
+	Budget                     BudgetStateV1                   `json:"budget"`
+	SupportingAdjudicationIDs  []string                        `json:"supporting_adjudication_ids,omitempty"`
+	DecidedAt                  time.Time                       `json:"decided_at"`
+}
+
+type CorruptRecordAcknowledgmentV1 struct {
+	Name        string `json:"name"`
+	Fingerprint string `json:"fingerprint"`
 }
 
 func (d LoopDecisionV1) Validate() error {
@@ -165,6 +170,9 @@ func (d LoopDecisionV1) Validate() error {
 		if d.ReviewTarget == nil || d.ReviewTarget.PullRequest == nil {
 			return fmt.Errorf("loop decision admission requires a pull-request review target")
 		}
+		if err := d.ReviewTarget.Validate(); err != nil {
+			return fmt.Errorf("loop decision admission review target: %w", err)
+		}
 		if *d.ReviewTarget.PullRequest != d.PullRequest {
 			return fmt.Errorf("loop decision admission review target does not match pull request")
 		}
@@ -174,12 +182,15 @@ func (d LoopDecisionV1) Validate() error {
 		if !d.Budget.Known || (d.Budget.IterationsLimit == 0 && d.Budget.DurationLimit == 0) {
 			return fmt.Errorf("loop decision admission requires a known review or duration bound")
 		}
-		for _, name := range d.AcknowledgedCorruptFiles {
-			if err := validateRecordID("acknowledged corrupt decision file", name); err != nil {
+		for _, acknowledgment := range d.AcknowledgedCorruptRecords {
+			if err := validateRecordID("acknowledged corrupt decision file", acknowledgment.Name); err != nil {
+				return err
+			}
+			if err := validateNonEmpty("acknowledged corrupt decision fingerprint", acknowledgment.Fingerprint); err != nil {
 				return err
 			}
 		}
-	} else if len(d.AcknowledgedCorruptFiles) != 0 {
+	} else if len(d.AcknowledgedCorruptRecords) != 0 {
 		return fmt.Errorf("acknowledged corrupt decision files require an admission decision")
 	}
 	if err := d.Decision.Validate(); err != nil {

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -27,6 +27,7 @@ func TestLoopDecisionV1_RoundTripAllKinds(t *testing.T) {
 					Known:           true,
 					IterationsUsed:  2,
 					IterationsLimit: 5,
+					CostKnown:       true,
 					CostUSDUsed:     1.5,
 					CostUSDLimit:    10,
 				},
@@ -99,6 +100,44 @@ func TestBudgetStateV1_ValidateRejectsUnknownWithNonzeroMeasurements(t *testing.
 	unknown := BudgetStateV1{Known: false, IterationsUsed: 1}
 	if err := unknown.Validate(); err == nil {
 		t.Fatal("expected an error for unknown budget state with a nonzero measurement")
+	}
+}
+
+func TestBudgetStateV1_UnmarshalLegacyKnownCost(t *testing.T) {
+	data := []byte(`{"known":true,"cost_usd_used":1.5,"cost_usd_limit":10}`)
+	var budget BudgetStateV1
+	if err := json.Unmarshal(data, &budget); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !budget.CostKnown || budget.CostUSDUsed != 1.5 {
+		t.Fatalf("legacy known cost was not preserved: %+v", budget)
+	}
+}
+
+func TestBudgetStateV1_ValidateRejectsUnknownCostWithMeasuredUsage(t *testing.T) {
+	budget := BudgetStateV1{Known: true, CostKnown: false, CostUSDUsed: 1}
+	if err := budget.Validate(); err == nil {
+		t.Fatal("expected unknown cost with measured usage to fail validation")
+	}
+}
+
+func TestLoopDecisionV1_SemanticTerminalRequiresRunID(t *testing.T) {
+	decision := LoopDecisionV1{
+		SchemaVersion: CurrentSchemaVersion,
+		ID:            "semantic-stop",
+		PullRequest:   testPullRequestKey(),
+		Scope:         LoopDecisionScopeSemanticConvergence,
+		Decision:      LoopDecisionStop,
+		Reason:        "converged",
+		Budget:        BudgetStateV1{Known: true},
+		DecidedAt:     time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
+	}
+	if err := decision.Validate(); err == nil {
+		t.Fatal("expected semantic terminal decision without run id to fail validation")
+	}
+	decision.Scope = LoopDecisionScopeAutomaticExecution
+	if err := decision.Validate(); err != nil {
+		t.Fatalf("automatic terminal decision should not require a run id: %v", err)
 	}
 }
 

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -217,8 +217,25 @@ func TestLoopDecisionV1_SemanticTerminalRequiresRunID(t *testing.T) {
 		t.Fatal("expected semantic terminal decision without run id to fail validation")
 	}
 	decision.Scope = LoopDecisionScopeAutomaticExecution
+	decision.SessionID = "session-1"
 	if err := decision.Validate(); err != nil {
 		t.Fatalf("automatic terminal decision should not require a run id: %v", err)
+	}
+}
+
+func TestLoopDecisionV1_AutomaticDecisionRequiresSessionID(t *testing.T) {
+	decision := LoopDecisionV1{
+		SchemaVersion: CurrentSchemaVersion,
+		ID:            "automatic-stop",
+		PullRequest:   testPullRequestKey(),
+		Scope:         LoopDecisionScopeAutomaticExecution,
+		Decision:      LoopDecisionStop,
+		Reason:        "stopped",
+		Budget:        BudgetStateV1{Known: true},
+		DecidedAt:     time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
+	}
+	if err := decision.Validate(); err == nil {
+		t.Fatal("expected automatic decision without session id to fail validation")
 	}
 }
 

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -55,14 +55,16 @@ func TestLoopDecisionV1_RoundTripAllKinds(t *testing.T) {
 }
 
 func TestLoopDecisionV1_AdmissionRequiresAuthorizationAndPolicy(t *testing.T) {
+	key := testPullRequestKey()
 	decision := LoopDecisionV1{
 		SchemaVersion:     CurrentSchemaVersion,
 		ID:                "admission-1",
-		PullRequest:       testPullRequestKey(),
+		PullRequest:       key,
 		SessionID:         "session-1",
 		AuthorizationKind: "user",
 		AuthorizedBy:      "alice",
 		PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
+		ReviewTarget:      &ReviewTargetV1{PullRequest: &key},
 		Scope:             LoopDecisionScopeAutomaticExecution,
 		Decision:          LoopDecisionAdmit,
 		Reason:            "commissioned",
@@ -79,14 +81,16 @@ func TestLoopDecisionV1_AdmissionRequiresAuthorizationAndPolicy(t *testing.T) {
 }
 
 func TestLoopDecisionV1_AdmissionRequiresBoundedBudget(t *testing.T) {
+	key := testPullRequestKey()
 	decision := LoopDecisionV1{
 		SchemaVersion:     CurrentSchemaVersion,
 		ID:                "admission-unbounded",
-		PullRequest:       testPullRequestKey(),
+		PullRequest:       key,
 		SessionID:         "session-unbounded",
 		AuthorizationKind: "user",
 		AuthorizedBy:      "alice",
 		PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
+		ReviewTarget:      &ReviewTargetV1{PullRequest: &key},
 		Scope:             LoopDecisionScopeAutomaticExecution,
 		Decision:          LoopDecisionAdmit,
 		Reason:            "commissioned",
@@ -99,6 +103,49 @@ func TestLoopDecisionV1_AdmissionRequiresBoundedBudget(t *testing.T) {
 	decision.Budget = BudgetStateV1{}
 	if err := decision.Validate(); err == nil {
 		t.Fatal("expected admission with unknown budget to fail")
+	}
+}
+
+func TestLoopDecisionV1_AdmissionRequiresTrustedTargetSourceBinding(t *testing.T) {
+	key := testPullRequestKey()
+	target := ReviewTargetV1{
+		Revision:    RevisionEvidenceV1{HeadObjectID: "reviewed-head"},
+		PullRequest: &key,
+	}
+	valid := func() LoopDecisionV1 {
+		return LoopDecisionV1{
+			SchemaVersion:     CurrentSchemaVersion,
+			ID:                "admission-target",
+			PullRequest:       key,
+			SessionID:         "session-target",
+			AuthorizationKind: "user",
+			AuthorizedBy:      "alice",
+			PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
+			ReviewTarget:      &target,
+			Scope:             LoopDecisionScopeAutomaticExecution,
+			Decision:          LoopDecisionAdmit,
+			Reason:            "commissioned",
+			Budget:            BudgetStateV1{Known: true, IterationsLimit: 1},
+			DecidedAt:         time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
+		}
+	}
+
+	missingTarget := valid()
+	missingTarget.ReviewTarget = nil
+	if err := missingTarget.Validate(); err == nil {
+		t.Fatal("expected admission without target to fail")
+	}
+	mismatched := valid()
+	otherKey := key
+	otherKey.Number++
+	mismatched.ReviewTarget = &ReviewTargetV1{PullRequest: &otherKey}
+	if err := mismatched.Validate(); err == nil {
+		t.Fatal("expected admission with mismatched target to fail")
+	}
+	reviewedSource := valid()
+	reviewedSource.PolicySource = &PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: "reviewed-head"}
+	if err := reviewedSource.Validate(); err == nil {
+		t.Fatal("expected admission sourced from reviewed head to fail")
 	}
 }
 

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -10,6 +10,22 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
 )
 
+func validLoopDecisionTarget(key PullRequestKeyV1) ReviewTargetV1 {
+	return ReviewTargetV1{
+		RepositoryRoot: "/repo",
+		WorktreeRoot:   "/repo/worktree",
+		Revision: RevisionEvidenceV1{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "refs/remotes/origin/main",
+		},
+		PullRequest: &key,
+	}
+}
+
+func pointerTo[T any](value T) *T {
+	return &value
+}
+
 func TestLoopDecisionV1_RoundTripAllKinds(t *testing.T) {
 	kinds := []LoopDecisionKindV1{LoopDecisionContinue, LoopDecisionStop, LoopDecisionEscalate}
 
@@ -64,7 +80,7 @@ func TestLoopDecisionV1_AdmissionRequiresAuthorizationAndPolicy(t *testing.T) {
 		AuthorizationKind: "user",
 		AuthorizedBy:      "alice",
 		PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
-		ReviewTarget:      &ReviewTargetV1{PullRequest: &key},
+		ReviewTarget:      pointerTo(validLoopDecisionTarget(key)),
 		Scope:             LoopDecisionScopeAutomaticExecution,
 		Decision:          LoopDecisionAdmit,
 		Reason:            "commissioned",
@@ -90,7 +106,7 @@ func TestLoopDecisionV1_AdmissionRequiresBoundedBudget(t *testing.T) {
 		AuthorizationKind: "user",
 		AuthorizedBy:      "alice",
 		PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
-		ReviewTarget:      &ReviewTargetV1{PullRequest: &key},
+		ReviewTarget:      pointerTo(validLoopDecisionTarget(key)),
 		Scope:             LoopDecisionScopeAutomaticExecution,
 		Decision:          LoopDecisionAdmit,
 		Reason:            "commissioned",
@@ -109,26 +125,29 @@ func TestLoopDecisionV1_AdmissionRequiresBoundedBudget(t *testing.T) {
 func TestLoopDecisionV1_AcknowledgedCorruptFilesRequireSafeAdmissionNames(t *testing.T) {
 	key := testPullRequestKey()
 	decision := LoopDecisionV1{
-		SchemaVersion:            CurrentSchemaVersion,
-		ID:                       "admission-corrupt-history",
-		PullRequest:              key,
-		SessionID:                "session-corrupt-history",
-		AuthorizationKind:        "user",
-		AuthorizedBy:             "alice",
-		PolicySource:             &PolicySourceV1{Kind: config.SourceKindDefaults},
-		ReviewTarget:             &ReviewTargetV1{PullRequest: &key},
-		AcknowledgedCorruptFiles: []string{"malformed.json"},
-		Scope:                    LoopDecisionScopeAutomaticExecution,
-		Decision:                 LoopDecisionAdmit,
-		Reason:                   "trusted recovery",
-		Budget:                   BudgetStateV1{Known: true, IterationsLimit: 1},
-		DecidedAt:                time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
+		SchemaVersion:     CurrentSchemaVersion,
+		ID:                "admission-corrupt-history",
+		PullRequest:       key,
+		SessionID:         "session-corrupt-history",
+		AuthorizationKind: "user",
+		AuthorizedBy:      "alice",
+		PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
+		ReviewTarget:      pointerTo(validLoopDecisionTarget(key)),
+		AcknowledgedCorruptRecords: []CorruptRecordAcknowledgmentV1{{
+			Name:        "malformed.json",
+			Fingerprint: "fingerprint",
+		}},
+		Scope:     LoopDecisionScopeAutomaticExecution,
+		Decision:  LoopDecisionAdmit,
+		Reason:    "trusted recovery",
+		Budget:    BudgetStateV1{Known: true, IterationsLimit: 1},
+		DecidedAt: time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
 	}
 	if err := decision.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
 	unsafe := decision
-	unsafe.AcknowledgedCorruptFiles = []string{"../malformed.json"}
+	unsafe.AcknowledgedCorruptRecords = []CorruptRecordAcknowledgmentV1{{Name: "../malformed.json", Fingerprint: "fingerprint"}}
 	if err := unsafe.Validate(); err == nil {
 		t.Fatal("expected unsafe acknowledged filename to fail validation")
 	}
@@ -145,10 +164,8 @@ func TestLoopDecisionV1_AcknowledgedCorruptFilesRequireSafeAdmissionNames(t *tes
 
 func TestLoopDecisionV1_AdmissionRequiresTrustedTargetSourceBinding(t *testing.T) {
 	key := testPullRequestKey()
-	target := ReviewTargetV1{
-		Revision:    RevisionEvidenceV1{HeadObjectID: "reviewed-head"},
-		PullRequest: &key,
-	}
+	target := validLoopDecisionTarget(key)
+	target.Revision.HeadObjectID = "reviewed-head"
 	valid := func() LoopDecisionV1 {
 		return LoopDecisionV1{
 			SchemaVersion:     CurrentSchemaVersion,
@@ -175,9 +192,15 @@ func TestLoopDecisionV1_AdmissionRequiresTrustedTargetSourceBinding(t *testing.T
 	mismatched := valid()
 	otherKey := key
 	otherKey.Number++
-	mismatched.ReviewTarget = &ReviewTargetV1{PullRequest: &otherKey}
+	mismatchedTarget := validLoopDecisionTarget(otherKey)
+	mismatched.ReviewTarget = &mismatchedTarget
 	if err := mismatched.Validate(); err == nil {
 		t.Fatal("expected admission with mismatched target to fail")
+	}
+	incomplete := valid()
+	incomplete.ReviewTarget = &ReviewTargetV1{PullRequest: &key}
+	if err := incomplete.Validate(); err == nil {
+		t.Fatal("expected admission with an incomplete review target to fail")
 	}
 	reviewedSource := valid()
 	reviewedSource.PolicySource = &PolicySourceV1{Kind: config.SourceKindRepositoryRevision, Revision: "reviewed-head"}

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -147,6 +147,16 @@ func TestLoopDecisionV1_AdmissionRequiresTrustedTargetSourceBinding(t *testing.T
 	if err := reviewedSource.Validate(); err == nil {
 		t.Fatal("expected admission sourced from reviewed head to fail")
 	}
+	duration := valid()
+	duration.Budget.IterationsLimit = 0
+	duration.Budget.DurationLimit = time.Hour
+	if err := duration.Validate(); err == nil {
+		t.Fatal("expected duration admission without start time to fail")
+	}
+	duration.Budget.StartedAt = duration.DecidedAt.Add(time.Minute)
+	if err := duration.Validate(); err == nil {
+		t.Fatal("expected duration admission starting after its decision to fail")
+	}
 }
 
 func TestBudgetStateV1_KnownZeroDistinguishableFromUnknown(t *testing.T) {

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
 )
 
 func TestLoopDecisionV1_RoundTripAllKinds(t *testing.T) {
@@ -48,6 +50,30 @@ func TestLoopDecisionV1_RoundTripAllKinds(t *testing.T) {
 				t.Fatalf("round trip mismatch: got %+v, want %+v", decoded, decision)
 			}
 		})
+	}
+}
+
+func TestLoopDecisionV1_AdmissionRequiresAuthorizationAndPolicy(t *testing.T) {
+	decision := LoopDecisionV1{
+		SchemaVersion:     CurrentSchemaVersion,
+		ID:                "admission-1",
+		PullRequest:       testPullRequestKey(),
+		SessionID:         "session-1",
+		AuthorizationKind: "user",
+		AuthorizedBy:      "alice",
+		PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
+		Scope:             LoopDecisionScopeAutomaticExecution,
+		Decision:          LoopDecisionAdmit,
+		Reason:            "commissioned",
+		Budget:            BudgetStateV1{Known: true},
+		DecidedAt:         time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
+	}
+	if err := decision.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	decision.AuthorizedBy = ""
+	if err := decision.Validate(); err == nil {
+		t.Fatal("expected admission without a trusted actor to fail validation")
 	}
 }
 

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -66,7 +66,7 @@ func TestLoopDecisionV1_AdmissionRequiresAuthorizationAndPolicy(t *testing.T) {
 		Scope:             LoopDecisionScopeAutomaticExecution,
 		Decision:          LoopDecisionAdmit,
 		Reason:            "commissioned",
-		Budget:            BudgetStateV1{Known: true},
+		Budget:            BudgetStateV1{Known: true, IterationsLimit: 1},
 		DecidedAt:         time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
 	}
 	if err := decision.Validate(); err != nil {
@@ -75,6 +75,30 @@ func TestLoopDecisionV1_AdmissionRequiresAuthorizationAndPolicy(t *testing.T) {
 	decision.AuthorizedBy = ""
 	if err := decision.Validate(); err == nil {
 		t.Fatal("expected admission without a trusted actor to fail validation")
+	}
+}
+
+func TestLoopDecisionV1_AdmissionRequiresBoundedBudget(t *testing.T) {
+	decision := LoopDecisionV1{
+		SchemaVersion:     CurrentSchemaVersion,
+		ID:                "admission-unbounded",
+		PullRequest:       testPullRequestKey(),
+		SessionID:         "session-unbounded",
+		AuthorizationKind: "user",
+		AuthorizedBy:      "alice",
+		PolicySource:      &PolicySourceV1{Kind: config.SourceKindDefaults},
+		Scope:             LoopDecisionScopeAutomaticExecution,
+		Decision:          LoopDecisionAdmit,
+		Reason:            "commissioned",
+		Budget:            BudgetStateV1{Known: true},
+		DecidedAt:         time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
+	}
+	if err := decision.Validate(); err == nil {
+		t.Fatal("expected known admission without review or duration bound to fail")
+	}
+	decision.Budget = BudgetStateV1{}
+	if err := decision.Validate(); err == nil {
+		t.Fatal("expected admission with unknown budget to fail")
 	}
 }
 

--- a/internal/store/loopdecision_test.go
+++ b/internal/store/loopdecision_test.go
@@ -106,6 +106,43 @@ func TestLoopDecisionV1_AdmissionRequiresBoundedBudget(t *testing.T) {
 	}
 }
 
+func TestLoopDecisionV1_AcknowledgedCorruptFilesRequireSafeAdmissionNames(t *testing.T) {
+	key := testPullRequestKey()
+	decision := LoopDecisionV1{
+		SchemaVersion:            CurrentSchemaVersion,
+		ID:                       "admission-corrupt-history",
+		PullRequest:              key,
+		SessionID:                "session-corrupt-history",
+		AuthorizationKind:        "user",
+		AuthorizedBy:             "alice",
+		PolicySource:             &PolicySourceV1{Kind: config.SourceKindDefaults},
+		ReviewTarget:             &ReviewTargetV1{PullRequest: &key},
+		AcknowledgedCorruptFiles: []string{"malformed.json"},
+		Scope:                    LoopDecisionScopeAutomaticExecution,
+		Decision:                 LoopDecisionAdmit,
+		Reason:                   "trusted recovery",
+		Budget:                   BudgetStateV1{Known: true, IterationsLimit: 1},
+		DecidedAt:                time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC),
+	}
+	if err := decision.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	unsafe := decision
+	unsafe.AcknowledgedCorruptFiles = []string{"../malformed.json"}
+	if err := unsafe.Validate(); err == nil {
+		t.Fatal("expected unsafe acknowledged filename to fail validation")
+	}
+	nonAdmission := decision
+	nonAdmission.Decision = LoopDecisionStop
+	nonAdmission.AuthorizationKind = ""
+	nonAdmission.AuthorizedBy = ""
+	nonAdmission.PolicySource = nil
+	nonAdmission.ReviewTarget = nil
+	if err := nonAdmission.Validate(); err == nil {
+		t.Fatal("expected non-admission acknowledgment to fail validation")
+	}
+}
+
 func TestLoopDecisionV1_AdmissionRequiresTrustedTargetSourceBinding(t *testing.T) {
 	key := testPullRequestKey()
 	target := ReviewTargetV1{

--- a/internal/store/loopdecisionstore.go
+++ b/internal/store/loopdecisionstore.go
@@ -9,6 +9,7 @@ import (
 type LoopDecisionStore interface {
 	SaveLoopDecision(decision LoopDecisionV1) (string, error)
 	ListLoopDecisions(key PullRequestKeyV1) ([]LoopDecisionV1, []CorruptRecord, error)
+	AcquireDecisionWriteLock() (func() error, error)
 }
 
 type FilesystemLoopDecisionStore struct {
@@ -60,4 +61,12 @@ func (s *FilesystemLoopDecisionStore) ListLoopDecisions(key PullRequestKeyV1) ([
 		return nil, nil, err
 	}
 	return listRecords(dir, decodeLoopDecision)
+}
+
+func (s *FilesystemLoopDecisionStore) AcquireDecisionWriteLock() (func() error, error) {
+	lock, err := AcquireWriteLock(s.dataDir)
+	if err != nil {
+		return nil, err
+	}
+	return lock.Release, nil
 }

--- a/internal/store/paths.go
+++ b/internal/store/paths.go
@@ -104,3 +104,14 @@ func parseRecordTimestamp(name string) (time.Time, error) {
 	}
 	return ts, nil
 }
+
+func parseRecordID(name string) (string, error) {
+	if !strings.HasSuffix(name, ".json") || len(name) <= recordTimestampLen+1+len(".json") {
+		return "", fmt.Errorf("record filename %q has no record id", name)
+	}
+	id := strings.TrimSuffix(name[recordTimestampLen+1:], ".json")
+	if err := validateRecordID("record", id); err != nil {
+		return "", err
+	}
+	return id, nil
+}

--- a/internal/store/policy.go
+++ b/internal/store/policy.go
@@ -3,16 +3,21 @@ package store
 import (
 	"fmt"
 	"math"
+	"time"
 )
 
 type BudgetPolicyV1 struct {
-	MaxIterations int     `json:"max_iterations"`
-	MaxCostUSD    float64 `json:"max_cost_usd"`
+	MaxIterations int           `json:"max_iterations"`
+	MaxDuration   time.Duration `json:"max_duration"`
+	MaxCostUSD    float64       `json:"max_cost_usd"`
 }
 
 func (p BudgetPolicyV1) Validate() error {
 	if p.MaxIterations < 0 {
 		return fmt.Errorf("budget policy max_iterations must not be negative")
+	}
+	if p.MaxDuration < 0 {
+		return fmt.Errorf("budget policy max_duration must not be negative")
 	}
 	if p.MaxCostUSD < 0 || math.IsNaN(p.MaxCostUSD) || math.IsInf(p.MaxCostUSD, 0) {
 		return fmt.Errorf("budget policy max_cost_usd must be a finite number that is not negative")

--- a/internal/store/policy_resolve.go
+++ b/internal/store/policy_resolve.go
@@ -27,6 +27,9 @@ func ResolveAdjudicationPolicy(ctx context.Context, source config.Source, target
 		if adjudication.MaxIterations != nil {
 			policy.Budget.MaxIterations = *adjudication.MaxIterations
 		}
+		if adjudication.MaxDuration != nil {
+			policy.Budget.MaxDuration = adjudication.MaxDuration.AsDuration()
+		}
 		if adjudication.MaxCostUSD != nil {
 			policy.Budget.MaxCostUSD = *adjudication.MaxCostUSD
 		}

--- a/internal/store/policy_resolve_test.go
+++ b/internal/store/policy_resolve_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
 )
@@ -56,6 +57,7 @@ func policyResolveGitOutput(t *testing.T, repositoryRoot string, args ...string)
 
 const trustedAdjudicationConfig = `adjudication:
   max_iterations: 5
+  max_duration: 2h
   max_cost_usd: 10
   stop_on_clean_run: true
   stop_on_no_new_findings: true
@@ -95,6 +97,9 @@ func TestResolveAdjudicationPolicy_IgnoresConflictingWorktreeConfig(t *testing.T
 
 	if policy.Budget.MaxIterations != 5 || policy.Budget.MaxCostUSD != 10 {
 		t.Fatalf("expected trusted budget policy, got %+v; the reviewed head's worktree config must never supply this data", policy.Budget)
+	}
+	if policy.Budget.MaxDuration != 2*time.Hour {
+		t.Fatalf("expected trusted duration budget, got %+v", policy.Budget)
 	}
 	if !policy.Stop.StopOnCleanRun || !policy.Stop.StopOnNoNewFindings {
 		t.Fatalf("expected trusted stop policy, got %+v", policy.Stop)

--- a/internal/store/policy_test.go
+++ b/internal/store/policy_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
 )
@@ -20,7 +21,7 @@ func TestAdjudicationPolicyV1_RoundTrip(t *testing.T) {
 			ConfigPresent: true,
 			ConfigDigest:  "digest",
 		},
-		Budget:             BudgetPolicyV1{MaxIterations: 5, MaxCostUSD: 10},
+		Budget:             BudgetPolicyV1{MaxIterations: 5, MaxDuration: time.Hour, MaxCostUSD: 10},
 		Stop:               StopPolicyV1{StopOnCleanRun: true, StopOnNoNewFindings: true},
 		EvaluationGuidance: "prefer precision over recall",
 	}
@@ -61,6 +62,7 @@ func TestAdjudicationPolicyV1_Validate(t *testing.T) {
 		{name: "filesystem source rejected", mutate: func(p *AdjudicationPolicyV1) { p.Source = PolicySourceV1{Kind: config.SourceKindFilesystem} }, wantErr: true},
 		{name: "empty source kind rejected", mutate: func(p *AdjudicationPolicyV1) { p.Source = PolicySourceV1{} }, wantErr: true},
 		{name: "negative max iterations", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxIterations = -1 }, wantErr: true},
+		{name: "negative max duration", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxDuration = -time.Second }, wantErr: true},
 		{name: "negative max cost", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxCostUSD = -1 }, wantErr: true},
 		{name: "NaN max cost", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxCostUSD = math.NaN() }, wantErr: true},
 		{name: "infinite max cost", mutate: func(p *AdjudicationPolicyV1) { p.Budget.MaxCostUSD = math.Inf(1) }, wantErr: true},


### PR DESCRIPTION
## What changed

- add a reusable, presentation-neutral automatic review controller
- require explicit user or trusted workspace-controller commissioning
- enforce lifecycle-wide review, duration, and measured provider-cost bounds across head changes
- persist admission, continue, stop, escalation, budget, authorization, and trusted policy-source evidence
- require a trusted resume after a stop or escalation
- expose the lifecycle deadline and durable economics recording boundary for future scheduler integration

## Why

The persistent review workspace needs automatic work to be explicitly authorized, finite, restart-safe, and protected from pull request or review-worktree configuration. This supplies that controller without adding a scheduler, TUI, command, or changing existing `acr` and `acr watch` behavior.

Approved Steward contract: `automatic-review-controller@1`

Frozen contract hash: `26aeb639f531cb3070a3910c64033efe9cad98a542ad914fe0ec2268100809f7`

## Validation

- `make check`
- `go test -count=1 ./internal/automatic ./internal/store ./internal/config`
- `go test -race -count=1 ./internal/automatic ./internal/store ./internal/config`

Closes #224
