### PR TITLE
Schedule bounded workspace reviews

### DIFF
--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -14,6 +14,8 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/store"
 )
 
+var ErrRevisionAlreadyAuthorized = errors.New("effective pull request revision already authorized for automatic review")
+
 type AuthorizationKind string
 
 const (
@@ -187,11 +189,17 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 		return decisionFromRecord(latest, false), nil
 	}
 	if hasUnacknowledgedCorruptDecisions(corrupt, session) {
-		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", store.BudgetStateV1{}, false)
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", nil, store.BudgetStateV1{}, false)
 	}
 	for _, decision := range allDecisions {
 		if decision.RunID == runID {
 			return Decision{}, fmt.Errorf("automatic review run %q already has a durable decision", runID)
+		}
+		if decision.Scope == store.LoopDecisionScopeAutomaticExecution &&
+			decision.Decision == store.LoopDecisionContinue &&
+			decision.ReviewTarget != nil &&
+			sameEffectiveRevision(*decision.ReviewTarget, target) {
+			return Decision{}, fmt.Errorf("%w: %s", ErrRevisionAlreadyAuthorized, target.Revision.HeadObjectID)
 		}
 	}
 	economics, _, err := c.economics.ListEconomics(key)
@@ -209,20 +217,20 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 		return Decision{}, err
 	}
 	if budget.IterationsLimit > 0 && budget.IterationsUsed >= budget.IterationsLimit {
-		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the review bound was reached", "", budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the review bound was reached", "", nil, budget, false)
 	}
 	if budget.DurationLimit > 0 && budget.Elapsed >= budget.DurationLimit {
-		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the lifecycle duration bound was reached", "", budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the lifecycle duration bound was reached", "", nil, budget, false)
 	}
 	if budget.CostUSDLimit > 0 && !usageAvailable {
-		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because configured provider usage could not be measured", "", budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because configured provider usage could not be measured", "", nil, budget, false)
 	}
 	if budget.CostUSDLimit > 0 && budget.CostUSDUsed >= budget.CostUSDLimit {
-		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the provider usage bound was reached", "", budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the provider usage bound was reached", "", nil, budget, false)
 	}
 
 	budget.IterationsUsed++
-	return c.recordDecision(key, session, store.LoopDecisionContinue, "automatic review admitted within the configured lifecycle bounds", runID, budget, true)
+	return c.recordDecision(key, session, store.LoopDecisionContinue, "automatic review admitted within the configured lifecycle bounds", runID, &target, budget, true)
 }
 
 func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time.Time, economics store.ReviewEconomicsV1) (err error) {
@@ -283,13 +291,13 @@ func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (_ Deci
 		return Decision{}, err
 	}
 	if hasUnacknowledgedCorruptDecisions(corrupt, session) {
-		return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", store.BudgetStateV1{}, false)
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", nil, store.BudgetStateV1{}, false)
 	}
 	budget, _, err := c.currentBudget(key, session, sessionDecisions)
 	if err != nil {
 		return Decision{}, err
 	}
-	return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", budget, false)
+	return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", nil, budget, false)
 }
 
 func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization, reason string, corrupt []store.CorruptRecord) (Decision, error) {
@@ -452,7 +460,7 @@ func activeSession(decisions []store.LoopDecisionV1) (store.LoopDecisionV1, []st
 	return store.LoopDecisionV1{}, nil, fmt.Errorf("automatic review has no durable trusted admission")
 }
 
-func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.LoopDecisionV1, kind store.LoopDecisionKindV1, reason, runID string, budget store.BudgetStateV1, allowed bool) (Decision, error) {
+func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.LoopDecisionV1, kind store.LoopDecisionKindV1, reason, runID string, target *store.ReviewTargetV1, budget store.BudgetStateV1, allowed bool) (Decision, error) {
 	id, err := c.newID()
 	if err != nil {
 		return Decision{}, fmt.Errorf("create automatic review decision id: %w", err)
@@ -474,10 +482,25 @@ func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.
 		Budget:         budget,
 		DecidedAt:      decidedAt,
 	}
+	if target != nil {
+		targetCopy := *target
+		if target.PullRequest != nil {
+			keyCopy := *target.PullRequest
+			targetCopy.PullRequest = &keyCopy
+		}
+		record.ReviewTarget = &targetCopy
+	}
 	if _, err := c.decisions.SaveLoopDecision(record); err != nil {
 		return Decision{}, fmt.Errorf("record automatic review decision: %w", err)
 	}
 	return decisionFromRecord(record, allowed), nil
+}
+
+func sameEffectiveRevision(left, right store.ReviewTargetV1) bool {
+	return left.Revision.HeadObjectID != "" &&
+		left.Revision.BaseObjectID != "" &&
+		left.Revision.HeadObjectID == right.Revision.HeadObjectID &&
+		left.Revision.BaseObjectID == right.Revision.BaseObjectID
 }
 
 func (c *Controller) nextDecisionTime(key store.PullRequestKeyV1, now time.Time) (time.Time, error) {

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -218,8 +218,11 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 			decision.ReviewTarget != nil &&
 			sameEffectiveRevision(*decision.ReviewTarget, target) {
 			run, exists := runsByID[decision.RunID]
-			if !exists || run.Status == string(domain.ReviewStatusCompleted) {
+			if exists && run.Status == string(domain.ReviewStatusCompleted) {
 				return Decision{}, fmt.Errorf("%w: %s", ErrRevisionAlreadyAuthorized, target.Revision.HeadObjectID)
+			}
+			if !exists && decision.SessionID == session.SessionID {
+				return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because an active review reservation has no durable run", "", nil, latest.Budget, false)
 			}
 		}
 	}

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -215,6 +215,21 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 	for _, run := range runs {
 		runsByID[run.ID] = run
 	}
+	for _, decision := range sessionDecisions {
+		if decision.Scope != store.LoopDecisionScopeAutomaticExecution ||
+			decision.Decision != store.LoopDecisionContinue ||
+			decision.SessionID != session.SessionID {
+			continue
+		}
+		if _, exists := runsByID[decision.RunID]; exists {
+			continue
+		}
+		budget, _, err := c.currentBudget(key, session, sessionDecisions)
+		if err != nil {
+			return Decision{}, err
+		}
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because an active review reservation has no durable run", "", nil, "", budget, false)
+	}
 	for _, decision := range allDecisions {
 		if decision.RunID == runID {
 			return Decision{}, fmt.Errorf("automatic review run %q already has a durable decision", runID)
@@ -224,9 +239,6 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 			decision.ReviewTarget != nil &&
 			sameEffectiveRevision(*decision.ReviewTarget, target) {
 			run, exists := runsByID[decision.RunID]
-			if !exists && decision.SessionID == session.SessionID {
-				return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because an active review reservation has no durable run", "", nil, "", latest.Budget, false)
-			}
 			if exists && run.Status == string(domain.ReviewStatusCompleted) && sameReviewEvidence(decision.EvidenceIdentity, evidenceIdentity) {
 				return Decision{}, fmt.Errorf("%w: %s", ErrRevisionAlreadyAuthorized, target.Revision.HeadObjectID)
 			}

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/store"
 )
 
@@ -82,21 +83,26 @@ type Decision struct {
 type Controller struct {
 	decisions store.LoopDecisionStore
 	economics store.EconomicsStore
+	runs      store.RunStore
 	now       func() time.Time
 	newID     func() (string, error)
 	mu        sync.Mutex
 }
 
-func NewController(decisions store.LoopDecisionStore, economics store.EconomicsStore) (*Controller, error) {
+func NewController(decisions store.LoopDecisionStore, economics store.EconomicsStore, runs store.RunStore) (*Controller, error) {
 	if decisions == nil {
 		return nil, fmt.Errorf("automatic review decision store is required")
 	}
 	if economics == nil {
 		return nil, fmt.Errorf("automatic review economics store is required")
 	}
+	if runs == nil {
+		return nil, fmt.Errorf("automatic review run store is required")
+	}
 	return &Controller{
 		decisions: decisions,
 		economics: economics,
+		runs:      runs,
 		now:       time.Now,
 		newID:     randomID,
 	}, nil
@@ -113,7 +119,6 @@ func (c *Controller) Commission(key store.PullRequestKeyV1, target store.ReviewT
 	if err := validateTrustedTarget(key, target, policy); err != nil {
 		return Decision{}, err
 	}
-
 	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
@@ -140,7 +145,6 @@ func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTarge
 	if err := validateTrustedTarget(key, target, policy); err != nil {
 		return Decision{}, err
 	}
-
 	decisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
@@ -167,6 +171,9 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 	if err := validateTrustedTarget(key, target, policy); err != nil {
 		return Decision{}, err
 	}
+	if target.Revision.HeadObjectID == "" || target.Revision.BaseObjectID == "" {
+		return Decision{}, fmt.Errorf("automatic review target must have resolved object ids")
+	}
 
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
@@ -191,6 +198,17 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 	if hasUnacknowledgedCorruptDecisions(corrupt, session) {
 		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", nil, store.BudgetStateV1{}, false)
 	}
+	runs, corruptRuns, err := c.runs.ListRuns(key)
+	if err != nil {
+		return Decision{}, fmt.Errorf("load automatic review runs: %w", err)
+	}
+	if len(corruptRuns) != 0 {
+		return Decision{}, fmt.Errorf("automatic review run history contains %d corrupt record(s)", len(corruptRuns))
+	}
+	runsByID := make(map[string]store.ReviewRunV1, len(runs))
+	for _, run := range runs {
+		runsByID[run.ID] = run
+	}
 	for _, decision := range allDecisions {
 		if decision.RunID == runID {
 			return Decision{}, fmt.Errorf("automatic review run %q already has a durable decision", runID)
@@ -199,7 +217,10 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 			decision.Decision == store.LoopDecisionContinue &&
 			decision.ReviewTarget != nil &&
 			sameEffectiveRevision(*decision.ReviewTarget, target) {
-			return Decision{}, fmt.Errorf("%w: %s", ErrRevisionAlreadyAuthorized, target.Revision.HeadObjectID)
+			run, exists := runsByID[decision.RunID]
+			if !exists || run.Status == string(domain.ReviewStatusCompleted) {
+				return Decision{}, fmt.Errorf("%w: %s", ErrRevisionAlreadyAuthorized, target.Revision.HeadObjectID)
+			}
 		}
 	}
 	economics, _, err := c.economics.ListEconomics(key)

--- a/internal/automatic/controller.go
+++ b/internal/automatic/controller.go
@@ -17,6 +17,8 @@ import (
 
 var ErrRevisionAlreadyAuthorized = errors.New("effective pull request revision already authorized for automatic review")
 
+const automaticRevisionEvidenceIdentity = "automatic-revision"
+
 type AuthorizationKind string
 
 const (
@@ -160,7 +162,7 @@ func (c *Controller) Resume(key store.PullRequestKeyV1, target store.ReviewTarge
 	return c.admit(key, policy, authorization, "automatic review resumed by trusted decision", corrupt)
 }
 
-func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, runID string) (_ Decision, err error) {
+func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.ReviewTargetV1, policy TrustedPolicy, runID string, evidence ...string) (_ Decision, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	release, err := c.decisions.AcquireDecisionWriteLock()
@@ -179,6 +181,10 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 	if runID == "" {
 		return Decision{}, fmt.Errorf("automatic review run id is required")
 	}
+	evidenceIdentity, err := reviewEvidenceIdentity(evidence)
+	if err != nil {
+		return Decision{}, err
+	}
 	allDecisions, corrupt, err := c.decisions.ListLoopDecisions(key)
 	if err != nil {
 		return Decision{}, fmt.Errorf("load automatic review decisions: %w", err)
@@ -196,7 +202,7 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 		return decisionFromRecord(latest, false), nil
 	}
 	if hasUnacknowledgedCorruptDecisions(corrupt, session) {
-		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", nil, store.BudgetStateV1{}, false)
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review history is incomplete because durable decision records are corrupt", "", nil, "", store.BudgetStateV1{}, false)
 	}
 	runs, corruptRuns, err := c.runs.ListRuns(key)
 	if err != nil {
@@ -218,11 +224,11 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 			decision.ReviewTarget != nil &&
 			sameEffectiveRevision(*decision.ReviewTarget, target) {
 			run, exists := runsByID[decision.RunID]
-			if exists && run.Status == string(domain.ReviewStatusCompleted) {
-				return Decision{}, fmt.Errorf("%w: %s", ErrRevisionAlreadyAuthorized, target.Revision.HeadObjectID)
-			}
 			if !exists && decision.SessionID == session.SessionID {
-				return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because an active review reservation has no durable run", "", nil, latest.Budget, false)
+				return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because an active review reservation has no durable run", "", nil, "", latest.Budget, false)
+			}
+			if exists && run.Status == string(domain.ReviewStatusCompleted) && sameReviewEvidence(decision.EvidenceIdentity, evidenceIdentity) {
+				return Decision{}, fmt.Errorf("%w: %s", ErrRevisionAlreadyAuthorized, target.Revision.HeadObjectID)
 			}
 		}
 	}
@@ -241,20 +247,20 @@ func (c *Controller) AuthorizeReview(key store.PullRequestKeyV1, target store.Re
 		return Decision{}, err
 	}
 	if budget.IterationsLimit > 0 && budget.IterationsUsed >= budget.IterationsLimit {
-		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the review bound was reached", "", nil, budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the review bound was reached", "", nil, "", budget, false)
 	}
 	if budget.DurationLimit > 0 && budget.Elapsed >= budget.DurationLimit {
-		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the lifecycle duration bound was reached", "", nil, budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the lifecycle duration bound was reached", "", nil, "", budget, false)
 	}
 	if budget.CostUSDLimit > 0 && !usageAvailable {
-		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because configured provider usage could not be measured", "", nil, budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, "automatic review requires trusted intervention because configured provider usage could not be measured", "", nil, "", budget, false)
 	}
 	if budget.CostUSDLimit > 0 && budget.CostUSDUsed >= budget.CostUSDLimit {
-		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the provider usage bound was reached", "", nil, budget, false)
+		return c.recordDecision(key, session, store.LoopDecisionStop, "automatic review stopped because the provider usage bound was reached", "", nil, "", budget, false)
 	}
 
 	budget.IterationsUsed++
-	return c.recordDecision(key, session, store.LoopDecisionContinue, "automatic review admitted within the configured lifecycle bounds", runID, &target, budget, true)
+	return c.recordDecision(key, session, store.LoopDecisionContinue, "automatic review admitted within the configured lifecycle bounds", runID, &target, evidenceIdentity, budget, true)
 }
 
 func (c *Controller) RecordEconomics(key store.PullRequestKeyV1, recordedAt time.Time, economics store.ReviewEconomicsV1) (err error) {
@@ -315,13 +321,13 @@ func (c *Controller) Escalate(key store.PullRequestKeyV1, reason string) (_ Deci
 		return Decision{}, err
 	}
 	if hasUnacknowledgedCorruptDecisions(corrupt, session) {
-		return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", nil, store.BudgetStateV1{}, false)
+		return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", nil, "", store.BudgetStateV1{}, false)
 	}
 	budget, _, err := c.currentBudget(key, session, sessionDecisions)
 	if err != nil {
 		return Decision{}, err
 	}
-	return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", nil, budget, false)
+	return c.recordDecision(key, session, store.LoopDecisionEscalate, reason, "", nil, "", budget, false)
 }
 
 func (c *Controller) admit(key store.PullRequestKeyV1, policy TrustedPolicy, authorization Authorization, reason string, corrupt []store.CorruptRecord) (Decision, error) {
@@ -484,7 +490,7 @@ func activeSession(decisions []store.LoopDecisionV1) (store.LoopDecisionV1, []st
 	return store.LoopDecisionV1{}, nil, fmt.Errorf("automatic review has no durable trusted admission")
 }
 
-func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.LoopDecisionV1, kind store.LoopDecisionKindV1, reason, runID string, target *store.ReviewTargetV1, budget store.BudgetStateV1, allowed bool) (Decision, error) {
+func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.LoopDecisionV1, kind store.LoopDecisionKindV1, reason, runID string, target *store.ReviewTargetV1, evidenceIdentity string, budget store.BudgetStateV1, allowed bool) (Decision, error) {
 	id, err := c.newID()
 	if err != nil {
 		return Decision{}, fmt.Errorf("create automatic review decision id: %w", err)
@@ -494,17 +500,18 @@ func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.
 		return Decision{}, err
 	}
 	record := store.LoopDecisionV1{
-		SchemaVersion:  store.CurrentSchemaVersion,
-		ID:             id,
-		PullRequest:    key,
-		RunID:          runID,
-		SessionID:      admission.SessionID,
-		Scope:          store.LoopDecisionScopeAutomaticExecution,
-		Decision:       kind,
-		Reason:         reason,
-		IterationCount: budget.IterationsUsed,
-		Budget:         budget,
-		DecidedAt:      decidedAt,
+		SchemaVersion:    store.CurrentSchemaVersion,
+		ID:               id,
+		PullRequest:      key,
+		RunID:            runID,
+		EvidenceIdentity: evidenceIdentity,
+		SessionID:        admission.SessionID,
+		Scope:            store.LoopDecisionScopeAutomaticExecution,
+		Decision:         kind,
+		Reason:           reason,
+		IterationCount:   budget.IterationsUsed,
+		Budget:           budget,
+		DecidedAt:        decidedAt,
 	}
 	if target != nil {
 		targetCopy := *target
@@ -518,6 +525,30 @@ func (c *Controller) recordDecision(key store.PullRequestKeyV1, admission store.
 		return Decision{}, fmt.Errorf("record automatic review decision: %w", err)
 	}
 	return decisionFromRecord(record, allowed), nil
+}
+
+func reviewEvidenceIdentity(evidence []string) (string, error) {
+	if len(evidence) > 1 {
+		return "", fmt.Errorf("automatic review accepts at most one evidence identity")
+	}
+	if len(evidence) == 0 {
+		return automaticRevisionEvidenceIdentity, nil
+	}
+	identity := strings.TrimSpace(evidence[0])
+	if identity == "" {
+		return "", fmt.Errorf("automatic review evidence identity is required")
+	}
+	return identity, nil
+}
+
+func sameReviewEvidence(left, right string) bool {
+	if left == "" {
+		left = automaticRevisionEvidenceIdentity
+	}
+	if right == "" {
+		right = automaticRevisionEvidenceIdentity
+	}
+	return left == right
 }
 
 func sameEffectiveRevision(left, right store.ReviewTargetV1) bool {

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -1,6 +1,7 @@
 package automatic
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/store"
 )
 
@@ -64,6 +66,8 @@ func testTarget() store.ReviewTargetV1 {
 		Revision: store.RevisionEvidenceV1{
 			RequestedBaseRef: "main",
 			ResolvedBaseRef:  "refs/remotes/origin/main",
+			HeadObjectID:     "head-object",
+			BaseObjectID:     "base-object",
 		},
 		PullRequest: &key,
 	}
@@ -91,6 +95,7 @@ func testController(t *testing.T, dir string, now *time.Time) *Controller {
 	controller, err := NewController(
 		store.NewFilesystemLoopDecisionStore(dir),
 		store.NewFilesystemEconomicsStore(dir),
+		store.NewFilesystemRunStore(dir),
 	)
 	if err != nil {
 		t.Fatalf("NewController: %v", err)
@@ -113,7 +118,122 @@ func testUserAuthorization(t *testing.T) Authorization {
 
 func testAuthorize(t *testing.T, controller *Controller, key store.PullRequestKeyV1, runID string) (Decision, error) {
 	t.Helper()
-	return controller.AuthorizeReview(key, testTarget(), testPolicy(t, 1, time.Hour, 0), runID)
+	target := testTarget()
+	target.Revision.HeadObjectID = "head-" + runID
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 1, MaxDuration: time.Hour},
+	}, target)
+	if err != nil {
+		t.Fatalf("NewTrustedPolicy: %v", err)
+	}
+	return controller.AuthorizeReview(key, target, policy, runID)
+}
+
+func authorizeWithHead(t *testing.T, controller *Controller, key store.PullRequestKeyV1, policy TrustedPolicy, runID string) (Decision, error) {
+	t.Helper()
+	target := testTarget()
+	target.Revision.HeadObjectID = "head-" + runID
+	policy.target = target
+	return controller.AuthorizeReview(key, target, policy, runID)
+}
+
+func saveAutomaticRun(t *testing.T, dir, runID string, target store.ReviewTargetV1, status domain.ReviewStatus) {
+	t.Helper()
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"inert"},
+		SummarizerAgent:   "inert",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := domain.ReviewRun{
+		ID:                       runID,
+		Target:                   target.ToDomain(),
+		Trigger:                  domain.ReviewTriggerDesk,
+		Engine:                   domain.ReviewEngine{Name: "acr", Version: "test"},
+		StartedAt:                time.Unix(1, 0),
+		CompletedAt:              time.Unix(2, 0),
+		Configuration:            configuration,
+		ConfigurationSource:      domain.ConfigurationSourceIdentity{Kind: "test"},
+		ConfigurationFingerprint: configuration.Fingerprint(),
+		Status:                   status,
+	}
+	if status == domain.ReviewStatusCompleted {
+		run.Conclusion = domain.ReviewConclusionClean
+	} else {
+		run.Failure = &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: string(status)}
+	}
+	schema, err := store.ToReviewRunSchema(run, store.RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.NewFilesystemRunStore(dir).SaveRun(schema); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestControllerDeduplicatesCompletedRevisionButAllowsFailedAndInterruptedRetries(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	target := testTarget()
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 10},
+	}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, target, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, target, policy, "failed-run"); err != nil {
+		t.Fatal(err)
+	}
+	saveAutomaticRun(t, dir, "failed-run", target, domain.ReviewStatusFailed)
+	if _, err := controller.AuthorizeReview(key, target, policy, "interrupted-run"); err != nil {
+		t.Fatalf("failed revision was not retryable: %v", err)
+	}
+	saveAutomaticRun(t, dir, "interrupted-run", target, domain.ReviewStatusInterrupted)
+	if _, err := controller.AuthorizeReview(key, target, policy, "completed-run"); err != nil {
+		t.Fatalf("interrupted revision was not retryable: %v", err)
+	}
+	saveAutomaticRun(t, dir, "completed-run", target, domain.ReviewStatusCompleted)
+	if _, err := controller.Escalate(key, "trusted review"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(key, target, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, target, policy, "duplicate-run"); !errors.Is(err, ErrRevisionAlreadyAuthorized) {
+		t.Fatalf("completed revision after resume error = %v, want duplicate rejection", err)
+	}
+}
+
+func TestControllerRejectsUnresolvedAutomaticTarget(t *testing.T) {
+	now := time.Now()
+	controller := testController(t, t.TempDir(), &now)
+	key := testKey()
+	target := testTarget()
+	policy := testPolicy(t, 2, time.Hour, 0)
+	if _, err := controller.Commission(key, target, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	target.Revision.HeadObjectID = ""
+	policy.target = target
+	if _, err := controller.AuthorizeReview(key, target, policy, "unresolved-run"); err == nil || !strings.Contains(err.Error(), "resolved object ids") {
+		t.Fatalf("AuthorizeReview error = %v, want unresolved target rejection", err)
+	}
 }
 
 func TestControllerRequiresTrustedCommissionAndRecordsAdmission(t *testing.T) {
@@ -270,6 +390,7 @@ func TestControllerSamplesAdmissionClockOnce(t *testing.T) {
 	controller, err := NewController(
 		store.NewFilesystemLoopDecisionStore(dir),
 		store.NewFilesystemEconomicsStore(dir),
+		store.NewFilesystemRunStore(dir),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -441,7 +562,7 @@ func TestControllerClassifiesCorruptEconomicsByConfiguredBudget(t *testing.T) {
 			if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-before-corruption"); err != nil {
+			if _, err := authorizeWithHead(t, controller, key, policy, "run-before-corruption"); err != nil {
 				t.Fatal(err)
 			}
 			economicsDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "economics")
@@ -451,7 +572,7 @@ func TestControllerClassifiesCorruptEconomicsByConfiguredBudget(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(economicsDir, "20260731T120001.000000000Z-corrupt.json"), []byte("not json"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			decision, err := controller.AuthorizeReview(key, testTarget(), policy, "run-after-corruption")
+			decision, err := authorizeWithHead(t, controller, key, policy, "run-after-corruption")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -484,7 +605,7 @@ func TestControllerFailsClosedForCorruptActiveEconomicsWithValidReplacement(t *t
 			if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-with-corruption"); err != nil {
+			if _, err := authorizeWithHead(t, controller, key, policy, "run-with-corruption"); err != nil {
 				t.Fatal(err)
 			}
 			economicsDir := filepath.Join(dir, "prs", key.Host, key.Owner, key.Repository, fmt.Sprintf("%d", key.Number), "economics")
@@ -501,7 +622,7 @@ func TestControllerFailsClosedForCorruptActiveEconomicsWithValidReplacement(t *t
 			}); err != nil {
 				t.Fatal(err)
 			}
-			decision, err := controller.AuthorizeReview(key, testTarget(), policy, "run-after-corruption")
+			decision, err := authorizeWithHead(t, controller, key, policy, "run-after-corruption")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -521,7 +642,7 @@ func TestControllerIgnoresCorruptEconomicsOutsideActiveSession(t *testing.T) {
 	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "old-session-run"); err != nil {
+	if _, err := authorizeWithHead(t, controller, key, policy, "old-session-run"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := controller.Escalate(key, "trusted restart requested"); err != nil {
@@ -537,7 +658,7 @@ func TestControllerIgnoresCorruptEconomicsOutsideActiveSession(t *testing.T) {
 	if _, err := controller.Resume(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "active-session-run"); err != nil {
+	if _, err := authorizeWithHead(t, controller, key, policy, "active-session-run"); err != nil {
 		t.Fatal(err)
 	}
 	if err := controller.RecordEconomics(key, now, store.ReviewEconomicsV1{
@@ -549,7 +670,7 @@ func TestControllerIgnoresCorruptEconomicsOutsideActiveSession(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	decision, err := controller.AuthorizeReview(key, testTarget(), policy, "next-active-run")
+	decision, err := authorizeWithHead(t, controller, key, policy, "next-active-run")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -565,7 +686,7 @@ func TestControllerSkipsBudgetEconomicsReadWithoutCostLimit(t *testing.T) {
 		EconomicsStore: store.NewFilesystemEconomicsStore(dir),
 		failAfter:      2,
 	}
-	controller, err := NewController(store.NewFilesystemLoopDecisionStore(dir), economics)
+	controller, err := NewController(store.NewFilesystemLoopDecisionStore(dir), economics, store.NewFilesystemRunStore(dir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -578,10 +699,10 @@ func TestControllerSkipsBudgetEconomicsReadWithoutCostLimit(t *testing.T) {
 	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-one"); err != nil {
+	if _, err := authorizeWithHead(t, controller, key, policy, "run-one"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "run-two"); err != nil {
+	if _, err := authorizeWithHead(t, controller, key, policy, "run-two"); err != nil {
 		t.Fatal(err)
 	}
 	if economics.listCalls != 2 {
@@ -906,7 +1027,7 @@ func TestControllerRejectsResumeForUnacknowledgeableCorruption(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()
 	decisionStore := &unreadableCorruptDecisionStore{LoopDecisionStore: store.NewFilesystemLoopDecisionStore(dir)}
-	controller, err := NewController(decisionStore, store.NewFilesystemEconomicsStore(dir))
+	controller, err := NewController(decisionStore, store.NewFilesystemEconomicsStore(dir), store.NewFilesystemRunStore(dir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -981,7 +1102,7 @@ func TestControllerTreatsZeroCallEconomicsAsKnownZero(t *testing.T) {
 	if _, err := controller.Commission(key, testTarget(), policy, testUserAuthorization(t)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := controller.AuthorizeReview(key, testTarget(), policy, "zero-call-run"); err != nil {
+	if _, err := authorizeWithHead(t, controller, key, policy, "zero-call-run"); err != nil {
 		t.Fatal(err)
 	}
 	if err := controller.RecordEconomics(key, now, store.ReviewEconomicsV1{
@@ -990,7 +1111,7 @@ func TestControllerTreatsZeroCallEconomicsAsKnownZero(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	decision, err := controller.AuthorizeReview(key, testTarget(), policy, "run-after-zero-call")
+	decision, err := authorizeWithHead(t, controller, key, policy, "run-after-zero-call")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1005,6 +1126,7 @@ func TestControllerPropagatesDecisionLockReleaseFailure(t *testing.T) {
 	controller, err := NewController(
 		&releaseFailingDecisionStore{LoopDecisionStore: store.NewFilesystemLoopDecisionStore(dir)},
 		store.NewFilesystemEconomicsStore(dir),
+		store.NewFilesystemRunStore(dir),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -236,6 +236,45 @@ func TestControllerRejectsUnresolvedAutomaticTarget(t *testing.T) {
 	}
 }
 
+func TestControllerEscalatesOrphanReservationAndResumeRecovers(t *testing.T) {
+	now := time.Date(2026, 8, 4, 13, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	target := testTarget()
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 5},
+	}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, target, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, target, policy, "orphan-run"); err != nil {
+		t.Fatal(err)
+	}
+	escalated, err := controller.AuthorizeReview(key, target, policy, "blocked-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if escalated.Allowed || escalated.Kind != store.LoopDecisionEscalate {
+		t.Fatalf("orphan decision = %+v, want controlled escalation", escalated)
+	}
+	decisions, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 || decisions[len(decisions)-1].Decision != store.LoopDecisionEscalate {
+		t.Fatalf("durable decisions = %+v, corrupt = %+v, err = %v", decisions, corrupt, err)
+	}
+	if _, err := controller.Resume(key, target, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if decision, err := controller.AuthorizeReview(key, target, policy, "recovered-run"); err != nil || !decision.Allowed {
+		t.Fatalf("post-resume authorization = %+v, err = %v", decision, err)
+	}
+}
+
 func TestControllerRequiresTrustedCommissionAndRecordsAdmission(t *testing.T) {
 	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
 	dir := t.TempDir()

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -128,7 +128,11 @@ func testAuthorize(t *testing.T, controller *Controller, key store.PullRequestKe
 	if err != nil {
 		t.Fatalf("NewTrustedPolicy: %v", err)
 	}
-	return controller.AuthorizeReview(key, target, policy, runID)
+	decision, err := controller.AuthorizeReview(key, target, policy, runID)
+	if err == nil && decision.Allowed {
+		saveAutomaticRunToStore(t, controller.runs, runID, target, domain.ReviewStatusCompleted)
+	}
+	return decision, err
 }
 
 func authorizeWithHead(t *testing.T, controller *Controller, key store.PullRequestKeyV1, policy TrustedPolicy, runID string) (Decision, error) {
@@ -136,10 +140,19 @@ func authorizeWithHead(t *testing.T, controller *Controller, key store.PullReque
 	target := testTarget()
 	target.Revision.HeadObjectID = "head-" + runID
 	policy.target = target
-	return controller.AuthorizeReview(key, target, policy, runID)
+	decision, err := controller.AuthorizeReview(key, target, policy, runID)
+	if err == nil && decision.Allowed {
+		saveAutomaticRunToStore(t, controller.runs, runID, target, domain.ReviewStatusCompleted)
+	}
+	return decision, err
 }
 
 func saveAutomaticRun(t *testing.T, dir, runID string, target store.ReviewTargetV1, status domain.ReviewStatus) {
+	t.Helper()
+	saveAutomaticRunToStore(t, store.NewFilesystemRunStore(dir), runID, target, status)
+}
+
+func saveAutomaticRunToStore(t *testing.T, runStore store.RunStore, runID string, target store.ReviewTargetV1, status domain.ReviewStatus) {
 	t.Helper()
 	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
 		Reviewers:         1,
@@ -175,7 +188,7 @@ func saveAutomaticRun(t *testing.T, dir, runID string, target store.ReviewTarget
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.NewFilesystemRunStore(dir).SaveRun(schema); err != nil {
+	if _, err := runStore.SaveRun(schema); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -272,6 +285,97 @@ func TestControllerEscalatesOrphanReservationAndResumeRecovers(t *testing.T) {
 	}
 	if decision, err := controller.AuthorizeReview(key, target, policy, "recovered-run"); err != nil || !decision.Allowed {
 		t.Fatalf("post-resume authorization = %+v, err = %v", decision, err)
+	}
+}
+
+func TestControllerEscalatesCrossControllerOrphanForDifferentRevision(t *testing.T) {
+	now := time.Date(2026, 8, 4, 13, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	first := testController(t, dir, &now)
+	second := testController(t, dir, &now)
+	key := testKey()
+	firstTarget := testTarget()
+	secondTarget := testTarget()
+	secondTarget.Revision.HeadObjectID = "replacement-head"
+	policyRecord := store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 5},
+	}
+	firstPolicy, err := NewTrustedPolicy(policyRecord, firstTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPolicy, err := NewTrustedPolicy(policyRecord, secondTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.Commission(key, firstTarget, firstPolicy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.AuthorizeReview(key, firstTarget, firstPolicy, "active-first-head"); err != nil {
+		t.Fatal(err)
+	}
+	escalated, err := second.AuthorizeReview(key, secondTarget, secondPolicy, "blocked-replacement-head")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if escalated.Allowed || escalated.Kind != store.LoopDecisionEscalate {
+		t.Fatalf("different-head orphan decision = %+v, want controlled escalation", escalated)
+	}
+	decisions, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("decisions = %+v, corrupt = %+v, err = %v", decisions, corrupt, err)
+	}
+	var continues int
+	for _, decision := range decisions {
+		if decision.Decision == store.LoopDecisionContinue {
+			continues++
+		}
+	}
+	if continues != 1 || decisions[len(decisions)-1].Decision != store.LoopDecisionEscalate {
+		t.Fatalf("durable decisions = %+v", decisions)
+	}
+}
+
+func TestControllerOrphanEscalationRefreshesBudget(t *testing.T) {
+	now := time.Date(2026, 8, 4, 13, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	target := testTarget()
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget: store.BudgetPolicyV1{
+			MaxIterations: 5,
+			MaxDuration:   2 * time.Hour,
+		},
+	}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, target, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, target, policy, "orphan-budget-run"); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(37 * time.Minute)
+	escalated, err := controller.AuthorizeReview(key, target, policy, "blocked-budget-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if escalated.Kind != store.LoopDecisionEscalate || escalated.Budget.Elapsed != 37*time.Minute || escalated.Budget.IterationsUsed != 1 {
+		t.Fatalf("refreshed orphan budget = %+v", escalated)
+	}
+	decisions, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("decisions = %+v, corrupt = %+v, err = %v", decisions, corrupt, err)
+	}
+	latest := decisions[len(decisions)-1]
+	if latest.Budget.Elapsed != 37*time.Minute || latest.Budget.IterationsUsed != 1 {
+		t.Fatalf("durable refreshed budget = %+v", latest.Budget)
 	}
 }
 

--- a/internal/automatic/controller_test.go
+++ b/internal/automatic/controller_test.go
@@ -256,7 +256,7 @@ func TestControllerEscalatesOrphanReservationAndResumeRecovers(t *testing.T) {
 	if _, err := controller.AuthorizeReview(key, target, policy, "orphan-run"); err != nil {
 		t.Fatal(err)
 	}
-	escalated, err := controller.AuthorizeReview(key, target, policy, "blocked-run")
+	escalated, err := controller.AuthorizeReview(key, target, policy, "blocked-run", "discussion:new-evidence")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,6 +272,48 @@ func TestControllerEscalatesOrphanReservationAndResumeRecovers(t *testing.T) {
 	}
 	if decision, err := controller.AuthorizeReview(key, target, policy, "recovered-run"); err != nil || !decision.Allowed {
 		t.Fatalf("post-resume authorization = %+v, err = %v", decision, err)
+	}
+}
+
+func TestControllerDeduplicatesCompletedTargetByEvidenceIdentity(t *testing.T) {
+	now := time.Date(2026, 8, 4, 14, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	controller := testController(t, dir, &now)
+	key := testKey()
+	target := testTarget()
+	policy, err := NewTrustedPolicy(store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 5},
+	}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, target, policy, testUserAuthorization(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, target, policy, "discussion-a", "discussion:evidence-a"); err != nil {
+		t.Fatal(err)
+	}
+	saveAutomaticRun(t, dir, "discussion-a", target, domain.ReviewStatusCompleted)
+	if _, err := controller.AuthorizeReview(key, target, policy, "discussion-a-repeat", "discussion:evidence-a"); !errors.Is(err, ErrRevisionAlreadyAuthorized) {
+		t.Fatalf("repeated discussion evidence error = %v, want duplicate rejection", err)
+	}
+	if decision, err := controller.AuthorizeReview(key, target, policy, "discussion-b", "discussion:evidence-b"); err != nil || !decision.Allowed {
+		t.Fatalf("new discussion evidence decision = %+v, err = %v", decision, err)
+	}
+	decisions, corrupt, err := store.NewFilesystemLoopDecisionStore(dir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("decisions = %+v, corrupt = %+v, err = %v", decisions, corrupt, err)
+	}
+	var identities []string
+	for _, decision := range decisions {
+		if decision.Decision == store.LoopDecisionContinue {
+			identities = append(identities, decision.EvidenceIdentity)
+		}
+	}
+	if fmt.Sprint(identities) != "[discussion:evidence-a discussion:evidence-b]" {
+		t.Fatalf("evidence identities = %v", identities)
 	}
 }
 

--- a/internal/domain/result.go
+++ b/internal/domain/result.go
@@ -54,6 +54,7 @@ type ReviewStats struct {
 	SummarizerDuration  time.Duration
 	FPFilterDuration    time.Duration
 	FPFilteredCount     int
+	ModelCallCount      int
 }
 
 func (s *ReviewStats) AllFailed() bool {

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -60,32 +60,45 @@ func (s *Summarizer) SummarizePullRequestFromDirs(ctx context.Context, key domai
 	return s.summarizeContext(ctx, prCtx, agentDir)
 }
 
+func (s *Summarizer) SummarizePullRequestFromDirsWithModelCalls(ctx context.Context, key domain.PullRequestKey, repositoryDir, agentDir string) (string, int, error) {
+	prCtx, err := FetchPRContextForPullRequest(ctx, key, repositoryDir)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to fetch PR context: %w", err)
+	}
+	return s.summarizeContextWithModelCalls(ctx, prCtx, agentDir)
+}
+
 func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext, workDir string) (string, error) {
+	summary, _, err := s.summarizeContextWithModelCalls(ctx, prCtx, workDir)
+	return summary, err
+}
+
+func (s *Summarizer) summarizeContextWithModelCalls(ctx context.Context, prCtx *PRContext, workDir string) (string, int, error) {
 	if !prCtx.HasContent() {
-		return "", nil
+		return "", 0, nil
 	}
 
 	input := s.buildInput(prCtx)
 
 	ag, err := agent.NewAgentWithModel(s.agentName, s.model)
 	if err != nil {
-		return "", fmt.Errorf("failed to create agent: %w", err)
+		return "", 0, fmt.Errorf("failed to create agent: %w", err)
 	}
 
 	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: summarizePrompt, Input: []byte(input), WorkDir: workDir})
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", ctx.Err()
+			return "", 1, ctx.Err()
 		}
-		return "", fmt.Errorf("agent execution failed: %w", err)
+		return "", 1, fmt.Errorf("agent execution failed: %w", err)
 	}
 	output, err := io.ReadAll(execResult)
 	closeErr := execResult.Close()
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", errors.Join(ctx.Err(), closeErr)
+			return "", 1, errors.Join(ctx.Err(), closeErr)
 		}
-		return "", errors.Join(fmt.Errorf("failed to read agent output: %w", err), closeErr)
+		return "", 1, errors.Join(fmt.Errorf("failed to read agent output: %w", err), closeErr)
 	}
 
 	summary := strings.TrimSpace(string(output))
@@ -96,7 +109,7 @@ func (s *Summarizer) summarizeContext(ctx context.Context, prCtx *PRContext, wor
 		summary = ""
 	}
 
-	return summary, s.handleCloseError(closeErr)
+	return summary, 1, s.handleCloseError(closeErr)
 }
 
 func (s *Summarizer) handleCloseError(err error) error {

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -22,14 +22,15 @@ type EvaluatedFinding struct {
 }
 
 type Result struct {
-	Grouped      domain.GroupedFindings
-	Removed      []EvaluatedFinding
-	RemovedCount int
-	Duration     time.Duration
-	EvalErrors   int
-	Skipped      bool
-	SkipReason   string
-	Warnings     []string
+	Grouped        domain.GroupedFindings
+	Removed        []EvaluatedFinding
+	RemovedCount   int
+	Duration       time.Duration
+	EvalErrors     int
+	ModelCallCount int
+	Skipped        bool
+	SkipReason     string
+	Warnings       []string
 }
 
 type Filter struct {
@@ -161,9 +162,17 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 	execResult, err := ag.ExecuteSummary(ctx, &agent.SummaryConfig{Prompt: prompt, Input: payload, WorkDir: f.workDir})
 	if err != nil {
 		if ctx.Err() != nil {
-			return skippedResult(grouped, start, "context canceled")
+			result := skippedResult(grouped, start, "context canceled")
+			result.ModelCallCount = 1
+			return result
 		}
-		return skippedResult(grouped, start, "LLM execution failed: "+err.Error())
+		result := skippedResult(grouped, start, "LLM execution failed: "+err.Error())
+		result.ModelCallCount = 1
+		return result
+	}
+	withModelCall := func(result *Result) *Result {
+		result.ModelCallCount = 1
+		return result
 	}
 
 	output, err := io.ReadAll(execResult)
@@ -176,26 +185,30 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 	}
 	if err != nil {
 		if ctx.Err() != nil {
-			return withWarnings(skippedResult(grouped, start, "context canceled"), warnings)
+			result := withWarnings(skippedResult(grouped, start, "context canceled"), warnings)
+			result.ModelCallCount = 1
+			return result
 		}
-		return withWarnings(skippedResult(grouped, start, "response read failed: "+err.Error()), warnings)
+		result := withWarnings(skippedResult(grouped, start, "response read failed: "+err.Error()), warnings)
+		result.ModelCallCount = 1
+		return result
 	}
 
 	parser, err := agent.NewSummaryParser(ag.Name())
 	if err != nil {
-		return withWarnings(skippedResult(grouped, start, "parser creation failed: "+err.Error()), warnings)
+		return withModelCall(withWarnings(skippedResult(grouped, start, "parser creation failed: "+err.Error()), warnings))
 	}
 
 	responseText, err := parser.ExtractText(output)
 	if err != nil {
-		return withWarnings(skippedResult(grouped, start, "response extraction failed: "+err.Error()), warnings)
+		return withModelCall(withWarnings(skippedResult(grouped, start, "response extraction failed: "+err.Error()), warnings))
 	}
 
 	var response evaluationResponse
 	if err := json.Unmarshal([]byte(responseText), &response); err != nil {
 		r := skippedResult(grouped, start, "response parse failed: "+err.Error())
 		r.EvalErrors = len(grouped.Findings)
-		return withWarnings(r, warnings)
+		return withModelCall(withWarnings(r, warnings))
 	}
 
 	evalMap := make(map[int]findingEvaluation)
@@ -229,7 +242,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		}
 	}
 
-	return withWarnings(&Result{
+	return withModelCall(withWarnings(&Result{
 		Grouped: domain.GroupedFindings{
 			Findings: kept,
 			Info:     grouped.Info,
@@ -238,5 +251,5 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		RemovedCount: len(removed),
 		Duration:     time.Since(start),
 		EvalErrors:   evalErrors,
-	}, warnings)
+	}, warnings))
 }

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -165,6 +165,7 @@ func (s *Service) Prepare(ctx context.Context, request Request) (*PreparedRun, e
 	if ctx == nil {
 		return nil, fmt.Errorf("review context is required")
 	}
+	request.Target = request.Target.Clone()
 	if err := validateRequest(request); err != nil {
 		return nil, err
 	}

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -36,7 +37,12 @@ type RevisionProvider func(context.Context, domain.ReviewTarget) (domain.Revisio
 
 type DiffProvider func(context.Context, domain.ReviewTarget) (string, error)
 
-type PriorFeedbackProvider func(context.Context, domain.ReviewTarget, string, string) (string, error)
+type PriorFeedbackResult struct {
+	Summary        string
+	ModelCallCount int
+}
+
+type PriorFeedbackProvider func(context.Context, domain.ReviewTarget, string, string) (PriorFeedbackResult, error)
 
 type RunIDGenerator func(time.Time) (string, error)
 
@@ -53,6 +59,46 @@ type serviceDependencies struct {
 
 type Service struct {
 	dependencies serviceDependencies
+}
+
+type PreparedRun struct {
+	service   *Service
+	request   Request
+	runID     string
+	startedAt time.Time
+	mu        sync.Mutex
+	executed  bool
+}
+
+func (p *PreparedRun) ID() string {
+	if p == nil {
+		return ""
+	}
+	return p.runID
+}
+
+func (p *PreparedRun) Target() domain.ReviewTarget {
+	if p == nil {
+		return domain.ReviewTarget{}
+	}
+	return p.request.Target.Clone()
+}
+
+func (p *PreparedRun) Run(ctx context.Context) (*domain.ReviewRun, error) {
+	if p == nil || p.service == nil {
+		return nil, fmt.Errorf("prepared review run is required")
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("review context is required")
+	}
+	p.mu.Lock()
+	if p.executed {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("prepared review run %q was already executed", p.runID)
+	}
+	p.executed = true
+	p.mu.Unlock()
+	return p.service.run(ctx, p.request, p.runID, p.startedAt)
 }
 
 func NewService(options ...Option) (*Service, error) {
@@ -112,6 +158,38 @@ func WithPriorFeedbackProvider(provider PriorFeedbackProvider) Option {
 	}
 }
 
+func (s *Service) Prepare(ctx context.Context, request Request) (*PreparedRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("review service is required")
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("review context is required")
+	}
+	if err := validateRequest(request); err != nil {
+		return nil, err
+	}
+	if err := git.ValidateWorktreeRepository(context.WithoutCancel(ctx), request.Target.RepositoryRoot, request.Target.WorktreeRoot); err != nil {
+		return nil, fmt.Errorf("invalid review request: %w", err)
+	}
+	startedAt := s.dependencies.now()
+	runID, err := s.dependencies.newRunID(startedAt)
+	if err != nil {
+		return nil, fmt.Errorf("create review run ID: %w", err)
+	}
+	if strings.TrimSpace(runID) == "" {
+		return nil, fmt.Errorf("create review run ID: empty ID")
+	}
+	revision, err := s.dependencies.revisions(ctx, request.Target)
+	if err != nil {
+		return nil, fmt.Errorf("resolve prepared review revision: %w", err)
+	}
+	if err := validateResolvedRevision(request.Target.Revision, revision); err != nil {
+		return nil, fmt.Errorf("resolve prepared review revision: %w", err)
+	}
+	request.Target.Revision = revision
+	return &PreparedRun{service: s, request: request, runID: runID, startedAt: startedAt}, nil
+}
+
 func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, error) {
 	if s == nil {
 		return nil, fmt.Errorf("review service is required")
@@ -134,7 +212,10 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if strings.TrimSpace(runID) == "" {
 		return nil, fmt.Errorf("create review run ID: empty ID")
 	}
+	return s.run(ctx, request, runID, startedAt)
+}
 
+func (s *Service) run(ctx context.Context, request Request, runID string, startedAt time.Time) (*domain.ReviewRun, error) {
 	run := &domain.ReviewRun{
 		ID:                       runID,
 		Target:                   request.Target.Clone(),
@@ -204,7 +285,10 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 
 	feedbackTask := s.startPriorFeedback(ctx, run.Target, values, emitter)
 	if feedbackTask != nil {
-		emitter.setBeforeCompletion(feedbackTask.stop)
+		emitter.setBeforeCompletion(func() {
+			feedbackTask.stop()
+			run.Stats.ModelCallCount += feedbackTask.modelCalls()
+		})
 	}
 
 	reviewerTimeout := scaledReviewerTimeout(values.Timeout, len(diff))
@@ -252,6 +336,9 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	results, wallClock, err := reviewRunner.Run(ctx)
 	run.ReviewerResults = cloneReviewerResults(results)
 	run.Stats = runner.BuildStats(results, values.Reviewers, wallClock)
+	for _, result := range run.ReviewerResults {
+		run.Stats.ModelCallCount += result.Attempts
+	}
 	run.RawFindings = cloneFindings(runner.CollectFindings(results))
 	run.AggregatedFindings = cloneAggregatedFindings(domain.AggregateFindings(run.RawFindings))
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseReviewers})
@@ -281,6 +368,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	parentContextErr := ctx.Err()
 	summaryCancel()
 	if summaryResult != nil {
+		run.Stats.ModelCallCount += summaryResult.ModelCallCount
 		run.Stats.SummarizerDuration = summaryResult.Duration
 		run.Summarizer = domain.SummarizerOutcome{
 			ExitCode: summaryResult.ExitCode,
@@ -337,7 +425,9 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 	if len(run.PreFilterSummary.Findings) == 0 {
 		feedbackTask.cancelAndComplete(emitter)
 	} else {
-		priorFeedback, err = feedbackTask.receive(ctx, emitter)
+		feedbackResult, feedbackErr := feedbackTask.receive(ctx, emitter)
+		priorFeedback = feedbackResult.Summary
+		err = feedbackErr
 		if err != nil {
 			return s.interrupt(run, domain.ReviewPhaseFeedback, err, emitter), nil
 		}
@@ -355,6 +445,7 @@ func (s *Service) Run(ctx context.Context, request Request) (*domain.ReviewRun, 
 		fpResult := fpfilter.NewWithAgent(summarizerAgent, values.FPThreshold, postProcessDir).Apply(fpCtx, finalGrouped, priorFeedback, reviewerOutputs)
 		fpCancel()
 		if fpResult != nil {
+			run.Stats.ModelCallCount += fpResult.ModelCallCount
 			finalGrouped = cloneGroupedFindings(fpResult.Grouped)
 			run.FalsePositiveFilter.Applied = !fpResult.Skipped
 			run.FalsePositiveFilter.Skipped = fpResult.Skipped
@@ -508,14 +599,15 @@ func (s *Service) initializeAgents(values domain.ReviewConfigurationValues) ([]a
 }
 
 type priorFeedbackResult struct {
-	summary string
-	err     error
+	result PriorFeedbackResult
+	err    error
 }
 
 type priorFeedbackTask struct {
-	result <-chan priorFeedbackResult
-	done   <-chan struct{}
-	cancel context.CancelFunc
+	result         <-chan priorFeedbackResult
+	done           <-chan struct{}
+	cancel         context.CancelFunc
+	modelCallCount int
 }
 
 func (s *Service) startPriorFeedback(ctx context.Context, target domain.ReviewTarget, values domain.ReviewConfigurationValues, emitter *eventEmitter) *priorFeedbackTask {
@@ -533,24 +625,25 @@ func (s *Service) startPriorFeedback(ctx context.Context, target domain.ReviewTa
 		if feedbackAgent == "" {
 			feedbackAgent = values.SummarizerAgent
 		}
-		summary, err := s.dependencies.priorFeedback(feedbackCtx, target, feedbackAgent, values.SummarizerModel)
-		result <- priorFeedbackResult{summary: summary, err: err}
+		feedbackResult, err := s.dependencies.priorFeedback(feedbackCtx, target, feedbackAgent, values.SummarizerModel)
+		task.modelCallCount = feedbackResult.ModelCallCount
+		result <- priorFeedbackResult{result: feedbackResult, err: err}
 	}()
 	return task
 }
 
-func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) (string, error) {
+func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) (PriorFeedbackResult, error) {
 	if t == nil {
-		return "", nil
+		return PriorFeedbackResult{}, nil
 	}
 	var feedbackResult priorFeedbackResult
 	select {
 	case feedbackResult = <-t.result:
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return PriorFeedbackResult{}, ctx.Err()
 	}
 	completion := "empty"
-	if feedbackResult.summary != "" {
+	if feedbackResult.result.Summary != "" {
 		completion = "summarized"
 	}
 	if feedbackResult.err != nil {
@@ -559,13 +652,13 @@ func (t *priorFeedbackTask) receive(ctx context.Context, emitter *eventEmitter) 
 	emitter.emit(Event{Kind: EventPhaseCompleted, Phase: domain.ReviewPhaseFeedback, Message: completion})
 	if feedbackResult.err != nil {
 		message := "prior feedback unavailable: " + feedbackResult.err.Error()
-		if feedbackResult.summary != "" {
+		if feedbackResult.result.Summary != "" {
 			message = "prior feedback warning: " + feedbackResult.err.Error()
 		}
 		emitter.emit(Event{Kind: EventWarning, Phase: domain.ReviewPhaseFeedback, Message: message})
-		return feedbackResult.summary, nil
+		return feedbackResult.result, nil
 	}
-	return feedbackResult.summary, nil
+	return feedbackResult.result, nil
 }
 
 func (t *priorFeedbackTask) stop() {
@@ -574,6 +667,14 @@ func (t *priorFeedbackTask) stop() {
 	}
 	t.cancel()
 	<-t.done
+}
+
+func (t *priorFeedbackTask) modelCalls() int {
+	if t == nil {
+		return 0
+	}
+	<-t.done
+	return t.modelCallCount
 }
 
 func (t *priorFeedbackTask) cancelAndComplete(emitter *eventEmitter) {
@@ -676,17 +777,18 @@ func loadDiff(ctx context.Context, target domain.ReviewTarget) (string, error) {
 	return git.GetDiff(ctx, target.Revision.BaseObjectID, target.WorktreeRoot)
 }
 
-func summarizePriorFeedback(ctx context.Context, target domain.ReviewTarget, agentName, model string) (string, error) {
+func summarizePriorFeedback(ctx context.Context, target domain.ReviewTarget, agentName, model string) (PriorFeedbackResult, error) {
 	if target.PullRequest == nil {
-		return "", nil
+		return PriorFeedbackResult{}, nil
 	}
 	agentDir, cleanupAgentDir, err := agent.NewIsolatedWorkDir()
 	if err != nil {
-		return "", fmt.Errorf("create isolated feedback workspace: %w", err)
+		return PriorFeedbackResult{}, fmt.Errorf("create isolated feedback workspace: %w", err)
 	}
 	defer cleanupAgentDir()
 	summary := feedback.NewSummarizer(agentName, model, false, nil)
-	return summary.SummarizePullRequestFromDirs(ctx, *target.PullRequest, target.WorktreeRoot, agentDir)
+	text, calls, err := summary.SummarizePullRequestFromDirsWithModelCalls(ctx, *target.PullRequest, target.WorktreeRoot, agentDir)
+	return PriorFeedbackResult{Summary: text, ModelCallCount: calls}, err
 }
 
 func defaultRunID(startedAt time.Time) (string, error) {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -209,6 +209,7 @@ func TestServicePreparedRunOwnsResolvedIdentity(t *testing.T) {
 	agent := &mockReviewAgent{name: "codex"}
 	service := serviceForTest(t, agent, "")
 	request := validRequest(t, t.TempDir())
+	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
 	prepared, err := service.Prepare(context.Background(), request)
 	if err != nil {
 		t.Fatalf("Prepare: %v", err)
@@ -216,9 +217,13 @@ func TestServicePreparedRunOwnsResolvedIdentity(t *testing.T) {
 	if prepared.ID() != "run-test" {
 		t.Fatalf("prepared ID = %q, want run-test", prepared.ID())
 	}
+	request.Target.PullRequest.Number = 99
 	target := prepared.Target()
 	if target.Revision.HeadObjectID != "head-object" || target.Revision.BaseObjectID != "base-object" {
 		t.Fatalf("prepared target is not resolved: %+v", target.Revision)
+	}
+	if target.PullRequest == nil || target.PullRequest.Number != 42 {
+		t.Fatalf("prepared pull request drifted after caller mutation: %+v", target.PullRequest)
 	}
 	run, err := prepared.Run(context.Background())
 	if err != nil {
@@ -226,6 +231,9 @@ func TestServicePreparedRunOwnsResolvedIdentity(t *testing.T) {
 	}
 	if run.ID != prepared.ID() || run.Target.Revision != target.Revision {
 		t.Fatalf("run identity = %q %+v, prepared = %q %+v", run.ID, run.Target.Revision, prepared.ID(), target.Revision)
+	}
+	if run.Target.PullRequest == nil || run.Target.PullRequest.Number != 42 {
+		t.Fatalf("run pull request drifted after caller mutation: %+v", run.Target.PullRequest)
 	}
 	if _, err := prepared.Run(context.Background()); err == nil {
 		t.Fatal("expected prepared run to be single use")

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -194,13 +194,69 @@ func serviceForTest(t *testing.T, reviewAgent agent.Agent, diff string, options 
 			return revision, nil
 		}),
 		WithDiffProvider(func(context.Context, domain.ReviewTarget) (string, error) { return diff, nil }),
-		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (string, error) { return "", nil }),
+		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (PriorFeedbackResult, error) {
+			return PriorFeedbackResult{}, nil
+		}),
 	}
 	service, err := NewService(append(baseOptions, options...)...)
 	if err != nil {
 		t.Fatalf("create service: %v", err)
 	}
 	return service
+}
+
+func TestServicePreparedRunOwnsResolvedIdentity(t *testing.T) {
+	agent := &mockReviewAgent{name: "codex"}
+	service := serviceForTest(t, agent, "")
+	request := validRequest(t, t.TempDir())
+	prepared, err := service.Prepare(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if prepared.ID() != "run-test" {
+		t.Fatalf("prepared ID = %q, want run-test", prepared.ID())
+	}
+	target := prepared.Target()
+	if target.Revision.HeadObjectID != "head-object" || target.Revision.BaseObjectID != "base-object" {
+		t.Fatalf("prepared target is not resolved: %+v", target.Revision)
+	}
+	run, err := prepared.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.ID != prepared.ID() || run.Target.Revision != target.Revision {
+		t.Fatalf("run identity = %q %+v, prepared = %q %+v", run.ID, run.Target.Revision, prepared.ID(), target.Revision)
+	}
+	if _, err := prepared.Run(context.Background()); err == nil {
+		t.Fatal("expected prepared run to be single use")
+	}
+}
+
+func TestServiceRecordsExactModelCallCount(t *testing.T) {
+	agent := &mockReviewAgent{name: "codex"}
+	request := validRequest(t, t.TempDir())
+	values := request.Configuration.Values()
+	values.FPFilterEnabled = true
+	values.PRFeedbackEnabled = true
+	configuration, err := domain.NewReviewConfiguration(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Configuration = configuration
+	request.Target.PullRequest = &domain.PullRequestKey{Host: "github.com", Owner: "owner", Repository: "repo", Number: 42}
+	service := serviceForTest(t, agent, "diff", WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (PriorFeedbackResult, error) {
+		return PriorFeedbackResult{Summary: "prior feedback", ModelCallCount: 1}, nil
+	}))
+	run, err := service.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Stats.ModelCallCount != 5 {
+		t.Fatalf("model calls = %d, want 5", run.Stats.ModelCallCount)
+	}
+	if agent.summaryCalls.Load() != 2 {
+		t.Fatalf("summary executions = %d, want summarizer and false-positive filter", agent.summaryCalls.Load())
+	}
 }
 
 func TestServiceRunsMockAgentsHeadlessly(t *testing.T) {
@@ -871,11 +927,11 @@ func TestServiceCancelsAndJoinsPriorFeedbackOnEarlyFailure(t *testing.T) {
 	}
 	var feedbackStopped atomic.Bool
 	var completionClock atomic.Int64
-	feedbackProvider := func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (string, error) {
+	feedbackProvider := func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (PriorFeedbackResult, error) {
 		<-ctx.Done()
 		feedbackStopped.Store(true)
 		completionClock.Store(2)
-		return "", ctx.Err()
+		return PriorFeedbackResult{}, ctx.Err()
 	}
 	request := validRequest(t, t.TempDir())
 	values := request.Configuration.Values()
@@ -962,10 +1018,10 @@ func TestServiceCancelsPriorFeedbackWhenSummaryHasNoFindings(t *testing.T) {
 		t,
 		reviewAgent,
 		"diff",
-		WithPriorFeedbackProvider(func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (string, error) {
+		WithPriorFeedbackProvider(func(ctx context.Context, _ domain.ReviewTarget, _, _ string) (PriorFeedbackResult, error) {
 			<-ctx.Done()
 			feedbackStopped.Store(true)
-			return "", ctx.Err()
+			return PriorFeedbackResult{}, ctx.Err()
 		}),
 	)
 
@@ -1027,8 +1083,8 @@ func TestServiceRetainsPriorFeedbackWhenCleanupWarns(t *testing.T) {
 		t,
 		reviewAgent,
 		"diff",
-		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (string, error) {
-			return "trusted prior feedback", errors.New("feedback cleanup failed")
+		WithPriorFeedbackProvider(func(context.Context, domain.ReviewTarget, string, string) (PriorFeedbackResult, error) {
+			return PriorFeedbackResult{Summary: "trusted prior feedback", ModelCallCount: 1}, errors.New("feedback cleanup failed")
 		}),
 	)
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,243 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/automatic"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/watch"
+)
+
+var ErrAutomaticReviewStopped = errors.New("automatic review is stopped")
+
+type Lifecycle interface {
+	Run(context.Context) watch.ExitReason
+}
+
+type Job struct {
+	Key       store.PullRequestKeyV1
+	Lifecycle Lifecycle
+}
+
+type Result struct {
+	Key    store.PullRequestKeyV1
+	Reason watch.ExitReason
+}
+
+type Scheduler struct {
+	capacity chan struct{}
+	mu       sync.Mutex
+	active   map[store.PullRequestKeyV1]struct{}
+}
+
+func New(concurrency int) (*Scheduler, error) {
+	if concurrency < 1 {
+		return nil, fmt.Errorf("scheduler concurrency must be positive")
+	}
+	return &Scheduler{
+		capacity: make(chan struct{}, concurrency),
+		active:   make(map[store.PullRequestKeyV1]struct{}),
+	}, nil
+}
+
+func (s *Scheduler) Run(ctx context.Context, jobs []Job) ([]Result, error) {
+	if s == nil {
+		return nil, fmt.Errorf("scheduler is required")
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("scheduler context is required")
+	}
+	seen := make(map[store.PullRequestKeyV1]struct{}, len(jobs))
+	for _, job := range jobs {
+		if err := job.Key.Validate(); err != nil {
+			return nil, err
+		}
+		if job.Lifecycle == nil {
+			return nil, fmt.Errorf("scheduler lifecycle is required for %s", job.Key.String())
+		}
+		if _, exists := seen[job.Key]; exists {
+			return nil, fmt.Errorf("pull request %s is already scheduled", job.Key.String())
+		}
+		seen[job.Key] = struct{}{}
+	}
+	s.mu.Lock()
+	for key := range seen {
+		if _, exists := s.active[key]; exists {
+			s.mu.Unlock()
+			return nil, fmt.Errorf("pull request %s is already scheduled", key.String())
+		}
+	}
+	for key := range seen {
+		s.active[key] = struct{}{}
+	}
+	s.mu.Unlock()
+
+	results := make([]Result, len(jobs))
+	var group sync.WaitGroup
+	for index, job := range jobs {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			defer s.release(job.Key)
+			select {
+			case s.capacity <- struct{}{}:
+				defer func() { <-s.capacity }()
+			case <-ctx.Done():
+				results[index] = Result{Key: job.Key, Reason: watch.ReasonInterrupted}
+				return
+			}
+			results[index] = Result{Key: job.Key, Reason: job.Lifecycle.Run(ctx)}
+		}()
+	}
+	group.Wait()
+	return results, nil
+}
+
+func (s *Scheduler) release(key store.PullRequestKeyV1) {
+	s.mu.Lock()
+	delete(s.active, key)
+	s.mu.Unlock()
+}
+
+type Controller interface {
+	AuthorizeReview(store.PullRequestKeyV1, store.ReviewTargetV1, automatic.TrustedPolicy, string) (automatic.Decision, error)
+	RecordEconomics(store.PullRequestKeyV1, time.Time, store.ReviewEconomicsV1) error
+}
+
+type PreparedCycle struct {
+	RunID  string
+	Target store.ReviewTargetV1
+	Policy automatic.TrustedPolicy
+	Run    func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error)
+}
+
+type PrepareCycle func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error)
+
+type BackgroundReview struct {
+	Key        store.PullRequestKeyV1
+	Controller Controller
+	Prepare    PrepareCycle
+	Now        func() time.Time
+}
+
+func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
+	if err := review.Key.Validate(); err != nil {
+		return watch.ReviewExecution{}, err
+	}
+	if review.Controller == nil {
+		return watch.ReviewExecution{}, fmt.Errorf("automatic review controller is required")
+	}
+	if review.Prepare == nil {
+		return watch.ReviewExecution{}, fmt.Errorf("automatic review preparation is required")
+	}
+	now := review.Now
+	if now == nil {
+		now = time.Now
+	}
+	return watch.ReviewExecution{RunCycle: func(ctx context.Context, reviewNumber int, trigger string, discussion []watch.Discussion, discussionRevision string) (watch.Cycle, error) {
+		prepared, err := review.Prepare(ctx, reviewNumber, trigger, discussion, discussionRevision)
+		if err != nil {
+			return watch.Cycle{}, err
+		}
+		if prepared.RunID == "" {
+			return watch.Cycle{}, fmt.Errorf("prepared automatic review run id is required")
+		}
+		if prepared.Run == nil {
+			return watch.Cycle{}, fmt.Errorf("prepared automatic review runner is required")
+		}
+		decision, err := review.Controller.AuthorizeReview(review.Key, prepared.Target, prepared.Policy, prepared.RunID)
+		if err != nil {
+			return watch.Cycle{}, err
+		}
+		if !decision.Allowed {
+			return watch.Cycle{}, fmt.Errorf("%w: %s", ErrAutomaticReviewStopped, decision.Reason)
+		}
+		runCtx := ctx
+		cancel := func() {}
+		if !decision.Deadline.IsZero() {
+			runCtx, cancel = context.WithDeadline(ctx, decision.Deadline)
+		}
+		cycle, economics, runErr := prepared.Run(runCtx)
+		cancel()
+		if economics != nil {
+			if economics.RunID != prepared.RunID {
+				return watch.Cycle{}, fmt.Errorf("automatic review economics run id %q does not match prepared run %q", economics.RunID, prepared.RunID)
+			}
+			if err := review.Controller.RecordEconomics(review.Key, now().UTC(), *economics); err != nil {
+				return watch.Cycle{}, errors.Join(runErr, err)
+			}
+		}
+		if runErr != nil {
+			return cycle, runErr
+		}
+		switch cycle.Result {
+		case watch.CycleError, watch.CycleNoChanges, watch.CycleFindings, watch.CycleStaleHead, watch.CycleClean:
+			return cycle, nil
+		default:
+			return watch.Cycle{}, fmt.Errorf("background review returned posting result %d", cycle.Result)
+		}
+	}}, nil
+}
+
+type ControlHistory interface {
+	ListEvents(store.PullRequestKeyV1) ([]store.ReviewEventV1, []store.CorruptRecord, error)
+}
+
+func StoredControl(history ControlHistory, key store.PullRequestKeyV1) func(context.Context, watch.PRState) (watch.ControlDecision, error) {
+	return func(ctx context.Context, _ watch.PRState) (watch.ControlDecision, error) {
+		if err := ctx.Err(); err != nil {
+			return watch.ControlDecision{}, err
+		}
+		if history == nil {
+			return watch.ControlDecision{}, fmt.Errorf("lifecycle control history is required")
+		}
+		events, corrupt, err := history.ListEvents(key)
+		if err != nil {
+			return watch.ControlDecision{}, err
+		}
+		if len(corrupt) > 0 {
+			return watch.ControlDecision{}, fmt.Errorf("lifecycle history contains %d corrupt record(s)", len(corrupt))
+		}
+		decision := watch.ControlDecision{State: watch.ControlActive}
+		var decidedAt time.Time
+		for _, event := range events {
+			var state watch.ControlState
+			switch event.Type {
+			case store.EventTypeUserSnoozed:
+				state = watch.ControlSnoozed
+			case store.EventTypeUserReleased:
+				state = watch.ControlReleased
+			case store.EventTypeUserOptedOut:
+				state = watch.ControlOptedOut
+			case store.EventTypeUserResumed:
+				state = watch.ControlActive
+			default:
+				continue
+			}
+			if decidedAt.IsZero() || !event.OccurredAt.Before(decidedAt) {
+				decision.State = state
+				decidedAt = event.OccurredAt
+			}
+		}
+		return decision, nil
+	}
+}
+
+func NewLifecycle(cfg watch.Config, polling watch.Polling, review BackgroundReview, control func(context.Context, watch.PRState) (watch.ControlDecision, error), presentation watch.Presentation) (*watch.Lifecycle, error) {
+	port, err := review.Port()
+	if err != nil {
+		return nil, err
+	}
+	cfg.Mode = watch.PostModeComment
+	return watch.NewLifecycle(
+		cfg,
+		polling,
+		port,
+		watch.ActionPolicies{Control: control},
+		presentation,
+	), nil
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -201,6 +201,9 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		}
 		decision, err := review.Controller.AuthorizeReview(review.Key, prepared.Work.target, prepared.Policy, prepared.Work.runID)
 		if err != nil {
+			if errors.Is(err, automatic.ErrRevisionAlreadyAuthorized) {
+				return watch.Cycle{Result: watch.CycleAlreadyReviewed, HeadSHA: prepared.Work.target.Revision.HeadObjectID}, nil
+			}
 			return watch.Cycle{}, err
 		}
 		if !decision.Allowed {
@@ -284,11 +287,11 @@ func cycleFromRun(run *domain.ReviewRun) (watch.Cycle, error) {
 	switch run.Status {
 	case domain.ReviewStatusFailed:
 		if run.Failure != nil {
-			return watch.Cycle{}, fmt.Errorf("background semantic review failed: %s", run.Failure.Message)
+			return watch.Cycle{}, fmt.Errorf("%w: background semantic review failed: %s", watch.ErrRetryableCycle, run.Failure.Message)
 		}
-		return watch.Cycle{}, fmt.Errorf("background semantic review failed")
+		return watch.Cycle{}, fmt.Errorf("%w: background semantic review failed", watch.ErrRetryableCycle)
 	case domain.ReviewStatusInterrupted:
-		return watch.Cycle{}, fmt.Errorf("background semantic review was interrupted")
+		return watch.Cycle{}, fmt.Errorf("%w: background semantic review was interrupted", watch.ErrRetryableCycle)
 	case domain.ReviewStatusCompleted:
 		switch run.Conclusion {
 		case domain.ReviewConclusionNoChanges:

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -112,35 +112,50 @@ type Controller interface {
 }
 
 type PreparedCycle struct {
-	RunID  string
-	Target store.ReviewTargetV1
 	Policy automatic.TrustedPolicy
 	Work   BackgroundWork
+}
+
+func NewPreparedCycle(work BackgroundWork, policy store.AdjudicationPolicyV1) (PreparedCycle, error) {
+	if work.runID == "" || work.run == nil {
+		return PreparedCycle{}, fmt.Errorf("prepared background review work is required")
+	}
+	trusted, err := automatic.NewTrustedPolicy(policy, work.target)
+	if err != nil {
+		return PreparedCycle{}, err
+	}
+	return PreparedCycle{Policy: trusted, Work: work}, nil
 }
 
 type PrepareCycle func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error)
 
 type BackgroundWork struct {
+	runID  string
 	target store.ReviewTargetV1
 	run    func(context.Context) (*domain.ReviewRun, error)
 }
 
-func NewBackgroundWork(service *reviewpkg.Service, request reviewpkg.Request) (BackgroundWork, error) {
+func NewBackgroundWork(ctx context.Context, service *reviewpkg.Service, request reviewpkg.Request) (BackgroundWork, error) {
 	if service == nil {
 		return BackgroundWork{}, fmt.Errorf("background semantic review service is required")
 	}
 	if request.Trigger != domain.ReviewTriggerDesk {
 		return BackgroundWork{}, fmt.Errorf("background review trigger must be %q", domain.ReviewTriggerDesk)
 	}
-	target := store.ToReviewTargetSchema(request.Target)
+	request.Events = nil
+	prepared, err := service.Prepare(ctx, request)
+	if err != nil {
+		return BackgroundWork{}, err
+	}
+	target := store.ToReviewTargetSchema(prepared.Target())
 	if target.PullRequest == nil {
 		return BackgroundWork{}, fmt.Errorf("background review target must identify a pull request")
 	}
-	request.Events = nil
 	return BackgroundWork{
+		runID:  prepared.ID(),
 		target: target,
 		run: func(ctx context.Context) (*domain.ReviewRun, error) {
-			return service.Run(ctx, request)
+			return prepared.Run(ctx)
 		},
 	}, nil
 }
@@ -148,6 +163,7 @@ func NewBackgroundWork(service *reviewpkg.Service, request reviewpkg.Request) (B
 type BackgroundReview struct {
 	Key        store.PullRequestKeyV1
 	Controller Controller
+	Runs       store.RunStore
 	Prepare    PrepareCycle
 	Now        func() time.Time
 }
@@ -158,6 +174,9 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 	}
 	if review.Controller == nil {
 		return watch.ReviewExecution{}, fmt.Errorf("automatic review controller is required")
+	}
+	if review.Runs == nil {
+		return watch.ReviewExecution{}, fmt.Errorf("automatic review run store is required")
 	}
 	if review.Prepare == nil {
 		return watch.ReviewExecution{}, fmt.Errorf("automatic review preparation is required")
@@ -171,21 +190,21 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		if err != nil {
 			return watch.Cycle{}, err
 		}
-		if prepared.RunID == "" {
+		if prepared.Work.runID == "" {
 			return watch.Cycle{}, fmt.Errorf("prepared automatic review run id is required")
 		}
 		if prepared.Work.run == nil {
 			return watch.Cycle{}, fmt.Errorf("prepared background review work is required")
 		}
-		if !reflect.DeepEqual(prepared.Work.target, prepared.Target) {
-			return watch.Cycle{}, fmt.Errorf("prepared background review work does not match its authorized target")
+		if prepared.Work.target.Revision.HeadObjectID == "" || prepared.Work.target.Revision.BaseObjectID == "" {
+			return watch.Cycle{}, fmt.Errorf("prepared background review target must have resolved object ids")
 		}
-		decision, err := review.Controller.AuthorizeReview(review.Key, prepared.Target, prepared.Policy, prepared.RunID)
+		decision, err := review.Controller.AuthorizeReview(review.Key, prepared.Work.target, prepared.Policy, prepared.Work.runID)
 		if err != nil {
 			return watch.Cycle{}, err
 		}
 		if !decision.Allowed {
-			return watch.Cycle{}, fmt.Errorf("%w: %s", ErrAutomaticReviewStopped, decision.Reason)
+			return watch.Cycle{}, automaticTermination{kind: decision.Kind, reason: decision.Reason}
 		}
 		runCtx := ctx
 		cancel := func() {}
@@ -200,8 +219,18 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		if run == nil {
 			return watch.Cycle{}, fmt.Errorf("background semantic review returned no run")
 		}
-		if run.ID != prepared.RunID {
-			return watch.Cycle{}, fmt.Errorf("background semantic review run id %q does not match prepared run %q", run.ID, prepared.RunID)
+		if run.ID != prepared.Work.runID {
+			return watch.Cycle{}, fmt.Errorf("background semantic review run id %q does not match prepared run %q", run.ID, prepared.Work.runID)
+		}
+		if !reflect.DeepEqual(store.ToReviewTargetSchema(run.Target), prepared.Work.target) {
+			return watch.Cycle{}, fmt.Errorf("background semantic review target does not match authorized target")
+		}
+		schema, err := store.ToReviewRunSchema(*run, store.RenderedOutcomeV1{})
+		if err != nil {
+			return watch.Cycle{}, fmt.Errorf("encode background semantic review run: %w", err)
+		}
+		if _, err := review.Runs.SaveRun(schema); err != nil {
+			return watch.Cycle{}, fmt.Errorf("persist background semantic review run: %w", err)
 		}
 		economics := economicsFromRun(run)
 		if err := review.Controller.RecordEconomics(review.Key, now().UTC(), economics); err != nil {
@@ -216,13 +245,7 @@ func economicsFromRun(run *domain.ReviewRun) store.ReviewEconomicsV1 {
 	for _, result := range run.ReviewerResults {
 		reviewerCalls += result.Attempts
 	}
-	modelCalls := reviewerCalls
-	if run.Stats.SummarizerDuration > 0 {
-		modelCalls++
-	}
-	if run.Stats.FPFilterDuration > 0 {
-		modelCalls++
-	}
+	modelCalls := run.Stats.ModelCallCount
 	duration := run.CompletedAt.Sub(run.StartedAt)
 	if duration < 0 {
 		duration = 0
@@ -234,6 +257,26 @@ func economicsFromRun(run *domain.ReviewRun) store.ReviewEconomicsV1 {
 		ModelCallCount:    modelCalls,
 		Duration:          duration,
 	}
+}
+
+type automaticTermination struct {
+	kind   store.LoopDecisionKindV1
+	reason string
+}
+
+func (e automaticTermination) Error() string {
+	return fmt.Sprintf("%s: %s", ErrAutomaticReviewStopped, e.reason)
+}
+
+func (e automaticTermination) Unwrap() error {
+	return ErrAutomaticReviewStopped
+}
+
+func (e automaticTermination) WatchExitReason() watch.ExitReason {
+	if e.kind == store.LoopDecisionEscalate {
+		return watch.ReasonEscalated
+	}
+	return watch.ReasonStopped
 }
 
 func cycleFromRun(run *domain.ReviewRun) (watch.Cycle, error) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,6 +2,8 @@ package scheduler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
@@ -107,7 +109,7 @@ func (s *Scheduler) release(key store.PullRequestKeyV1) {
 }
 
 type Controller interface {
-	AuthorizeReview(store.PullRequestKeyV1, store.ReviewTargetV1, automatic.TrustedPolicy, string) (automatic.Decision, error)
+	AuthorizeReview(store.PullRequestKeyV1, store.ReviewTargetV1, automatic.TrustedPolicy, string, ...string) (automatic.Decision, error)
 	RecordEconomics(store.PullRequestKeyV1, time.Time, store.ReviewEconomicsV1) error
 }
 
@@ -199,7 +201,11 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		if prepared.Work.target.Revision.HeadObjectID == "" || prepared.Work.target.Revision.BaseObjectID == "" {
 			return watch.Cycle{}, fmt.Errorf("prepared background review target must have resolved object ids")
 		}
-		decision, err := review.Controller.AuthorizeReview(review.Key, prepared.Work.target, prepared.Policy, prepared.Work.runID)
+		evidenceIdentity, err := cycleEvidenceIdentity(trigger, discussionRevision, prepared.Work.runID)
+		if err != nil {
+			return watch.Cycle{}, err
+		}
+		decision, err := review.Controller.AuthorizeReview(review.Key, prepared.Work.target, prepared.Policy, prepared.Work.runID, evidenceIdentity)
 		if err != nil {
 			if errors.Is(err, automatic.ErrRevisionAlreadyAuthorized) {
 				return watch.Cycle{Result: watch.CycleAlreadyReviewed, HeadSHA: prepared.Work.target.Revision.HeadObjectID}, nil
@@ -241,6 +247,21 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		}
 		return cycleFromRun(run)
 	}}, nil
+}
+
+func cycleEvidenceIdentity(trigger, discussionRevision, runID string) (string, error) {
+	switch trigger {
+	case "manual request", "re-review requested":
+		return "explicit:" + runID, nil
+	case "discussion requires reconsideration", "uncertain discussion requires reconsideration":
+		if discussionRevision == "" {
+			return "", fmt.Errorf("discussion review evidence is required")
+		}
+		digest := sha256.Sum256([]byte(discussionRevision))
+		return "discussion:" + hex.EncodeToString(digest[:]), nil
+	default:
+		return "automatic-revision", nil
+	}
 }
 
 func economicsFromRun(run *domain.ReviewRun) store.ReviewEconomicsV1 {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -239,11 +239,15 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 			return watch.Cycle{}, fmt.Errorf("encode background semantic review run: %w", err)
 		}
 		economics := economicsFromRun(run)
+		var persistenceErrors []error
 		if err := review.Controller.RecordEconomics(review.Key, now().UTC(), economics); err != nil {
-			return watch.Cycle{}, fmt.Errorf("persist background semantic review economics: %w", err)
+			persistenceErrors = append(persistenceErrors, fmt.Errorf("persist background semantic review economics: %w", err))
 		}
 		if _, err := review.Runs.SaveRun(schema); err != nil {
-			return watch.Cycle{}, fmt.Errorf("persist background semantic review run: %w", err)
+			persistenceErrors = append(persistenceErrors, fmt.Errorf("persist background semantic review run: %w", err))
+		}
+		if len(persistenceErrors) > 0 {
+			return watch.Cycle{}, errors.Join(persistenceErrors...)
 		}
 		return cycleFromRun(run)
 	}}, nil

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/automatic"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	reviewpkg "github.com/richhaase/agentic-code-reviewer/internal/review"
 	"github.com/richhaase/agentic-code-reviewer/internal/store"
 	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
@@ -112,10 +115,35 @@ type PreparedCycle struct {
 	RunID  string
 	Target store.ReviewTargetV1
 	Policy automatic.TrustedPolicy
-	Run    func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error)
+	Work   BackgroundWork
 }
 
 type PrepareCycle func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error)
+
+type BackgroundWork struct {
+	target store.ReviewTargetV1
+	run    func(context.Context) (*domain.ReviewRun, error)
+}
+
+func NewBackgroundWork(service *reviewpkg.Service, request reviewpkg.Request) (BackgroundWork, error) {
+	if service == nil {
+		return BackgroundWork{}, fmt.Errorf("background semantic review service is required")
+	}
+	if request.Trigger != domain.ReviewTriggerDesk {
+		return BackgroundWork{}, fmt.Errorf("background review trigger must be %q", domain.ReviewTriggerDesk)
+	}
+	target := store.ToReviewTargetSchema(request.Target)
+	if target.PullRequest == nil {
+		return BackgroundWork{}, fmt.Errorf("background review target must identify a pull request")
+	}
+	request.Events = nil
+	return BackgroundWork{
+		target: target,
+		run: func(ctx context.Context) (*domain.ReviewRun, error) {
+			return service.Run(ctx, request)
+		},
+	}, nil
+}
 
 type BackgroundReview struct {
 	Key        store.PullRequestKeyV1
@@ -146,8 +174,11 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		if prepared.RunID == "" {
 			return watch.Cycle{}, fmt.Errorf("prepared automatic review run id is required")
 		}
-		if prepared.Run == nil {
-			return watch.Cycle{}, fmt.Errorf("prepared automatic review runner is required")
+		if prepared.Work.run == nil {
+			return watch.Cycle{}, fmt.Errorf("prepared background review work is required")
+		}
+		if !reflect.DeepEqual(prepared.Work.target, prepared.Target) {
+			return watch.Cycle{}, fmt.Errorf("prepared background review work does not match its authorized target")
 		}
 		decision, err := review.Controller.AuthorizeReview(review.Key, prepared.Target, prepared.Policy, prepared.RunID)
 		if err != nil {
@@ -161,26 +192,75 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		if !decision.Deadline.IsZero() {
 			runCtx, cancel = context.WithDeadline(ctx, decision.Deadline)
 		}
-		cycle, economics, runErr := prepared.Run(runCtx)
+		run, runErr := prepared.Work.run(runCtx)
 		cancel()
-		if economics != nil {
-			if economics.RunID != prepared.RunID {
-				return watch.Cycle{}, fmt.Errorf("automatic review economics run id %q does not match prepared run %q", economics.RunID, prepared.RunID)
-			}
-			if err := review.Controller.RecordEconomics(review.Key, now().UTC(), *economics); err != nil {
-				return watch.Cycle{}, errors.Join(runErr, err)
-			}
-		}
 		if runErr != nil {
-			return cycle, runErr
+			return watch.Cycle{}, runErr
 		}
-		switch cycle.Result {
-		case watch.CycleError, watch.CycleNoChanges, watch.CycleFindings, watch.CycleStaleHead, watch.CycleClean:
-			return cycle, nil
-		default:
-			return watch.Cycle{}, fmt.Errorf("background review returned posting result %d", cycle.Result)
+		if run == nil {
+			return watch.Cycle{}, fmt.Errorf("background semantic review returned no run")
 		}
+		if run.ID != prepared.RunID {
+			return watch.Cycle{}, fmt.Errorf("background semantic review run id %q does not match prepared run %q", run.ID, prepared.RunID)
+		}
+		economics := economicsFromRun(run)
+		if err := review.Controller.RecordEconomics(review.Key, now().UTC(), economics); err != nil {
+			return watch.Cycle{}, errors.Join(runErr, err)
+		}
+		return cycleFromRun(run)
 	}}, nil
+}
+
+func economicsFromRun(run *domain.ReviewRun) store.ReviewEconomicsV1 {
+	reviewerCalls := 0
+	for _, result := range run.ReviewerResults {
+		reviewerCalls += result.Attempts
+	}
+	modelCalls := reviewerCalls
+	if run.Stats.SummarizerDuration > 0 {
+		modelCalls++
+	}
+	if run.Stats.FPFilterDuration > 0 {
+		modelCalls++
+	}
+	duration := run.CompletedAt.Sub(run.StartedAt)
+	if duration < 0 {
+		duration = 0
+	}
+	return store.ReviewEconomicsV1{
+		SchemaVersion:     store.CurrentSchemaVersion,
+		RunID:             run.ID,
+		ReviewerCallCount: reviewerCalls,
+		ModelCallCount:    modelCalls,
+		Duration:          duration,
+	}
+}
+
+func cycleFromRun(run *domain.ReviewRun) (watch.Cycle, error) {
+	cycle := watch.Cycle{HeadSHA: run.Target.Revision.HeadObjectID}
+	switch run.Status {
+	case domain.ReviewStatusFailed:
+		if run.Failure != nil {
+			return watch.Cycle{}, fmt.Errorf("background semantic review failed: %s", run.Failure.Message)
+		}
+		return watch.Cycle{}, fmt.Errorf("background semantic review failed")
+	case domain.ReviewStatusInterrupted:
+		return watch.Cycle{}, fmt.Errorf("background semantic review was interrupted")
+	case domain.ReviewStatusCompleted:
+		switch run.Conclusion {
+		case domain.ReviewConclusionNoChanges:
+			cycle.Result = watch.CycleNoChanges
+		case domain.ReviewConclusionFindings:
+			cycle.Result = watch.CycleFindings
+		case domain.ReviewConclusionClean:
+			cycle.Result = watch.CycleClean
+		default:
+			return watch.Cycle{}, fmt.Errorf("background semantic review completed without a supported conclusion")
+		}
+		return cycle, nil
+	default:
+		return watch.Cycle{}, fmt.Errorf("background semantic review returned unknown status %q", run.Status)
+	}
 }
 
 type ControlHistory interface {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -190,7 +190,7 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 	return watch.ReviewExecution{RunCycle: func(ctx context.Context, reviewNumber int, trigger string, discussion []watch.Discussion, discussionRevision string) (watch.Cycle, error) {
 		prepared, err := review.Prepare(ctx, reviewNumber, trigger, discussion, discussionRevision)
 		if err != nil {
-			return watch.Cycle{}, err
+			return watch.Cycle{}, fmt.Errorf("%w: prepare automatic review: %w", watch.ErrRetryableCycle, err)
 		}
 		if prepared.Work.runID == "" {
 			return watch.Cycle{}, fmt.Errorf("prepared automatic review run id is required")
@@ -238,12 +238,12 @@ func (review BackgroundReview) Port() (watch.ReviewExecution, error) {
 		if err != nil {
 			return watch.Cycle{}, fmt.Errorf("encode background semantic review run: %w", err)
 		}
-		if _, err := review.Runs.SaveRun(schema); err != nil {
-			return watch.Cycle{}, fmt.Errorf("persist background semantic review run: %w", err)
-		}
 		economics := economicsFromRun(run)
 		if err := review.Controller.RecordEconomics(review.Key, now().UTC(), economics); err != nil {
-			return watch.Cycle{}, errors.Join(runErr, err)
+			return watch.Cycle{}, fmt.Errorf("persist background semantic review economics: %w", err)
+		}
+		if _, err := review.Runs.SaveRun(schema); err != nil {
+			return watch.Cycle{}, fmt.Errorf("persist background semantic review run: %w", err)
 		}
 		return cycleFromRun(run)
 	}}, nil

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -409,10 +409,11 @@ func TestBackgroundReviewPersistsEconomicsBeforeTerminalRun(t *testing.T) {
 		runErr       error
 		wantOrder    string
 		wantRuns     int
-		wantErr      error
+		wantErrors   []error
 	}{
-		{name: "economics failure leaves no completed marker", economicsErr: economicsFailure, wantOrder: "economics", wantErr: economicsFailure},
-		{name: "run failure retains economics", runErr: runFailure, wantOrder: "economics,run", wantErr: runFailure},
+		{name: "economics failure still saves terminal run", economicsErr: economicsFailure, wantOrder: "economics,run", wantRuns: 1, wantErrors: []error{economicsFailure}},
+		{name: "run failure retains economics", runErr: runFailure, wantOrder: "economics,run", wantErrors: []error{runFailure}},
+		{name: "both failures preserve both causes", economicsErr: economicsFailure, runErr: runFailure, wantOrder: "economics,run", wantErrors: []error{economicsFailure, runFailure}},
 		{name: "success records economics then run", wantOrder: "economics,run", wantRuns: 1},
 	}
 	for _, test := range tests {
@@ -440,11 +441,13 @@ func TestBackgroundReviewPersistsEconomicsBeforeTerminalRun(t *testing.T) {
 				t.Fatal(err)
 			}
 			_, cycleErr := port.RunCycle(context.Background(), 1, "initial review", nil, "")
-			if test.wantErr == nil && cycleErr != nil {
+			if len(test.wantErrors) == 0 && cycleErr != nil {
 				t.Fatalf("RunCycle: %v", cycleErr)
 			}
-			if test.wantErr != nil && !errors.Is(cycleErr, test.wantErr) {
-				t.Fatalf("RunCycle error = %v, want %v", cycleErr, test.wantErr)
+			for _, wantErr := range test.wantErrors {
+				if !errors.Is(cycleErr, wantErr) {
+					t.Fatalf("RunCycle error = %v, want cause %v", cycleErr, wantErr)
+				}
 			}
 			persisted, corrupt, listErr := runs.ListRuns(key)
 			if listErr != nil || len(corrupt) != 0 || len(persisted) != test.wantRuns {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -297,8 +297,8 @@ func TestBackgroundReviewPersistsFailedAndInterruptedRuns(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if _, err := port.RunCycle(context.Background(), 1, "initial review", nil, ""); err == nil {
-				t.Fatalf("expected %s cycle error", status)
+			if _, err := port.RunCycle(context.Background(), 1, "initial review", nil, ""); !errors.Is(err, watch.ErrRetryableCycle) {
+				t.Fatalf("%s cycle error = %v, want retryable", status, err)
 			}
 			runs, corrupt, err := runStore.ListRuns(key)
 			if err != nil || len(corrupt) != 0 || len(runs) != 1 || runs[0].Status != string(status) {
@@ -430,8 +430,9 @@ func TestBackgroundReviewDurablyDeduplicatesRevisionAcrossRecreation(t *testing.
 	if err != nil {
 		t.Fatalf("duplicate Port: %v", err)
 	}
-	if _, err := duplicate.RunCycle(context.Background(), 1, "initial review", nil, ""); !errors.Is(err, automatic.ErrRevisionAlreadyAuthorized) {
-		t.Fatalf("duplicate RunCycle error = %v, want durable revision rejection", err)
+	duplicateCycle, err := duplicate.RunCycle(context.Background(), 1, "initial review", nil, "")
+	if err != nil || duplicateCycle.Result != watch.CycleAlreadyReviewed {
+		t.Fatalf("duplicate cycle = %+v, err = %v, want already reviewed", duplicateCycle, err)
 	}
 	if runs.Load() != 1 {
 		t.Fatalf("runs after duplicate = %d, want 1", runs.Load())
@@ -447,6 +448,184 @@ func TestBackgroundReviewDurablyDeduplicatesRevisionAcrossRecreation(t *testing.
 	}
 	if runs.Load() != 2 {
 		t.Fatalf("runs after replacement = %d, want 2", runs.Load())
+	}
+}
+
+func TestLifecycleSkipsCompletedRevisionAfterRestartAndReviewsReplacement(t *testing.T) {
+	dataDir := t.TempDir()
+	key := schedulerKey(1)
+	targetA := schedulerTarget(key, "head-a")
+	policyRecord := store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 3},
+	}
+	newPolicy := func(target store.ReviewTargetV1) automatic.TrustedPolicy {
+		policy, err := automatic.NewTrustedPolicy(policyRecord, target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return policy
+	}
+	newController := func() *automatic.Controller {
+		controller, err := automatic.NewController(
+			store.NewFilesystemLoopDecisionStore(dataDir),
+			store.NewFilesystemEconomicsStore(dataDir),
+			store.NewFilesystemRunStore(dataDir),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return controller
+	}
+	authorization, err := automatic.WorkspaceAuthorization("restart-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller := newController()
+	if _, err := controller.Commission(key, targetA, newPolicy(targetA), authorization); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.AuthorizeReview(key, targetA, newPolicy(targetA), "completed-head-a"); err != nil {
+		t.Fatal(err)
+	}
+	completed := schedulerRun(t, "completed-head-a", targetA, domain.ReviewConclusionClean)
+	schema, err := store.ToReviewRunSchema(*completed, store.RenderedOutcomeV1{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.NewFilesystemRunStore(dataDir).SaveRun(schema); err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &advancingClock{now: time.Now()}
+	states := []watch.PRState{{HeadSHA: "head-a"}, {HeadSHA: "head-b"}, {HeadSHA: "head-b"}}
+	var stateIndex int
+	var mu sync.Mutex
+	var preparedHeads []string
+	var executedHeads []string
+	lifecycle, err := NewLifecycle(watch.Config{
+		PollInterval:    time.Minute,
+		SettleTime:      time.Minute,
+		MaxReviews:      1,
+		MaxDuration:     time.Hour,
+		UncertainPolicy: watch.UncertainWait,
+	}, watch.Polling{
+		Clock: clock,
+		State: func(context.Context) (watch.PRState, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if stateIndex < len(states)-1 {
+				stateIndex++
+				return states[stateIndex-1], nil
+			}
+			return states[len(states)-1], nil
+		},
+	}, BackgroundReview{
+		Key:        key,
+		Controller: newController(),
+		Runs:       store.NewFilesystemRunStore(dataDir),
+		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			mu.Lock()
+			head := states[stateIndex-1].HeadSHA
+			preparedHeads = append(preparedHeads, head)
+			mu.Unlock()
+			target := schedulerTarget(key, head)
+			runID := "restart-" + head
+			return PreparedCycle{
+				Policy: newPolicy(target),
+				Work: schedulerWork(runID, target, func(context.Context) (*domain.ReviewRun, error) {
+					executedHeads = append(executedHeads, head)
+					return schedulerRun(t, runID, target, domain.ReviewConclusionClean), nil
+				}),
+			}, nil
+		},
+	}, nil, watch.Presentation{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason := lifecycle.Run(context.Background()); reason != watch.ReasonMaxReviews {
+		t.Fatalf("reason = %v, want max reviews", reason)
+	}
+	if fmt.Sprint(preparedHeads) != "[head-a head-b]" || fmt.Sprint(executedHeads) != "[head-b]" {
+		t.Fatalf("prepared = %v, executed = %v", preparedHeads, executedHeads)
+	}
+}
+
+func TestLifecycleRetriesTerminalFailuresWithinControllerIterationBudget(t *testing.T) {
+	dataDir := t.TempDir()
+	key := schedulerKey(1)
+	target := schedulerTarget(key, "head-1")
+	policyRecord := store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 2},
+	}
+	policy, err := automatic.NewTrustedPolicy(policyRecord, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err := automatic.NewController(
+		store.NewFilesystemLoopDecisionStore(dataDir),
+		store.NewFilesystemEconomicsStore(dataDir),
+		store.NewFilesystemRunStore(dataDir),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization, err := automatic.WorkspaceAuthorization("retry-budget-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, target, policy, authorization); err != nil {
+		t.Fatal(err)
+	}
+	clock := &advancingClock{now: time.Now()}
+	var prepared int
+	var executed int
+	lifecycle, err := NewLifecycle(watch.Config{
+		PollInterval:    time.Minute,
+		SettleTime:      time.Minute,
+		MaxReviews:      10,
+		MaxDuration:     time.Hour,
+		UncertainPolicy: watch.UncertainWait,
+	}, watch.Polling{
+		Clock: clock,
+		State: func(context.Context) (watch.PRState, error) {
+			return watch.PRState{HeadSHA: "head-1"}, nil
+		},
+	}, BackgroundReview{
+		Key:        key,
+		Controller: controller,
+		Runs:       store.NewFilesystemRunStore(dataDir),
+		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			prepared++
+			runID := fmt.Sprintf("failed-%d", prepared)
+			return PreparedCycle{
+				Policy: policy,
+				Work: schedulerWork(runID, target, func(context.Context) (*domain.ReviewRun, error) {
+					executed++
+					run := schedulerRun(t, runID, target, domain.ReviewConclusionClean)
+					run.Status = domain.ReviewStatusFailed
+					run.Conclusion = domain.ReviewConclusionNone
+					run.Failure = &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: "failed"}
+					return run, nil
+				}),
+			}, nil
+		},
+	}, nil, watch.Presentation{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason := lifecycle.Run(context.Background()); reason != watch.ReasonStopped {
+		t.Fatalf("reason = %v, want controller stop", reason)
+	}
+	if prepared != 3 || executed != 2 {
+		t.Fatalf("prepared = %d, executed = %d, want 3 and 2", prepared, executed)
+	}
+	runs, corrupt, err := store.NewFilesystemRunStore(dataDir).ListRuns(key)
+	if err != nil || len(corrupt) != 0 || len(runs) != 2 {
+		t.Fatalf("runs = %+v, corrupt = %+v, err = %v", runs, corrupt, err)
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -169,7 +169,7 @@ type controllerStub struct {
 	recorded   []store.ReviewEconomicsV1
 }
 
-func (c *controllerStub) AuthorizeReview(_ store.PullRequestKeyV1, _ store.ReviewTargetV1, _ automatic.TrustedPolicy, runID string) (automatic.Decision, error) {
+func (c *controllerStub) AuthorizeReview(_ store.PullRequestKeyV1, _ store.ReviewTargetV1, _ automatic.TrustedPolicy, runID string, _ ...string) (automatic.Decision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.authorized = append(c.authorized, runID)
@@ -549,6 +549,113 @@ func TestLifecycleSkipsCompletedRevisionAfterRestartAndReviewsReplacement(t *tes
 	}
 	if fmt.Sprint(preparedHeads) != "[head-a head-b]" || fmt.Sprint(executedHeads) != "[head-b]" {
 		t.Fatalf("prepared = %v, executed = %v", preparedHeads, executedHeads)
+	}
+}
+
+func TestBackgroundReviewDeduplicatesTargetByWatcherEvidence(t *testing.T) {
+	dataDir := t.TempDir()
+	key := schedulerKey(1)
+	target := schedulerTarget(key, "head-1")
+	policyRecord := store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 10},
+	}
+	policy, err := automatic.NewTrustedPolicy(policyRecord, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newController := func() *automatic.Controller {
+		controller, err := automatic.NewController(
+			store.NewFilesystemLoopDecisionStore(dataDir),
+			store.NewFilesystemEconomicsStore(dataDir),
+			store.NewFilesystemRunStore(dataDir),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return controller
+	}
+	controller := newController()
+	authorization, err := automatic.WorkspaceAuthorization("evidence-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Commission(key, target, policy, authorization); err != nil {
+		t.Fatal(err)
+	}
+	var prepared int
+	var executed int
+	newPort := func(controller *automatic.Controller) watch.ReviewExecution {
+		port, err := (BackgroundReview{
+			Key:        key,
+			Controller: controller,
+			Runs:       store.NewFilesystemRunStore(dataDir),
+			Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+				prepared++
+				runID := fmt.Sprintf("evidence-run-%d", prepared)
+				return PreparedCycle{
+					Policy: policy,
+					Work: schedulerWork(runID, target, func(context.Context) (*domain.ReviewRun, error) {
+						executed++
+						return schedulerRun(t, runID, target, domain.ReviewConclusionClean), nil
+					}),
+				}, nil
+			},
+		}).Port()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return port
+	}
+	run := func(port watch.ReviewExecution, trigger, discussionRevision string) watch.Cycle {
+		cycle, err := port.RunCycle(context.Background(), 1, trigger, nil, discussionRevision)
+		if err != nil {
+			t.Fatalf("RunCycle(%q): %v", trigger, err)
+		}
+		return cycle
+	}
+	port := newPort(controller)
+	if cycle := run(port, "initial review", ""); cycle.Result != watch.CycleClean {
+		t.Fatalf("initial cycle = %+v", cycle)
+	}
+	if cycle := run(port, "manual request", ""); cycle.Result != watch.CycleClean {
+		t.Fatalf("manual cycle = %+v", cycle)
+	}
+	if cycle := run(port, "re-review requested", ""); cycle.Result != watch.CycleClean {
+		t.Fatalf("re-review cycle = %+v", cycle)
+	}
+	discussionA := "issue_comment:10:revision-a\n"
+	if cycle := run(port, "discussion requires reconsideration", discussionA); cycle.Result != watch.CycleClean {
+		t.Fatalf("discussion cycle = %+v", cycle)
+	}
+
+	port = newPort(newController())
+	if cycle := run(port, "discussion requires reconsideration", discussionA); cycle.Result != watch.CycleAlreadyReviewed {
+		t.Fatalf("repeated discussion cycle = %+v", cycle)
+	}
+	discussionB := discussionA + "review_comment:11:revision-b\n"
+	if cycle := run(port, "discussion requires reconsideration", discussionB); cycle.Result != watch.CycleClean {
+		t.Fatalf("new discussion cycle = %+v", cycle)
+	}
+	if cycle := run(port, "commits settled", ""); cycle.Result != watch.CycleAlreadyReviewed {
+		t.Fatalf("ordinary duplicate cycle = %+v", cycle)
+	}
+	if executed != 5 {
+		t.Fatalf("executed = %d, want five distinct evidence reviews", executed)
+	}
+	decisions, corrupt, err := store.NewFilesystemLoopDecisionStore(dataDir).ListLoopDecisions(key)
+	if err != nil || len(corrupt) != 0 {
+		t.Fatalf("decisions = %+v, corrupt = %+v, err = %v", decisions, corrupt, err)
+	}
+	var identities []string
+	for _, decision := range decisions {
+		if decision.Decision == store.LoopDecisionContinue {
+			identities = append(identities, decision.EvidenceIdentity)
+		}
+	}
+	if len(identities) != 5 || identities[0] != "automatic-revision" || identities[1] != "explicit:evidence-run-2" || identities[2] != "explicit:evidence-run-3" || identities[3] == identities[4] {
+		t.Fatalf("evidence identities = %v", identities)
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -163,10 +164,12 @@ func TestSchedulerRejectsDuplicateActivePullRequestAcrossCallers(t *testing.T) {
 }
 
 type controllerStub struct {
-	mu         sync.Mutex
-	decision   automatic.Decision
-	authorized []string
-	recorded   []store.ReviewEconomicsV1
+	mu           sync.Mutex
+	decision     automatic.Decision
+	authorized   []string
+	recorded     []store.ReviewEconomicsV1
+	economicsErr error
+	order        *[]string
 }
 
 func (c *controllerStub) AuthorizeReview(_ store.PullRequestKeyV1, _ store.ReviewTargetV1, _ automatic.TrustedPolicy, runID string, _ ...string) (automatic.Decision, error) {
@@ -179,8 +182,48 @@ func (c *controllerStub) AuthorizeReview(_ store.PullRequestKeyV1, _ store.Revie
 func (c *controllerStub) RecordEconomics(_ store.PullRequestKeyV1, _ time.Time, economics store.ReviewEconomicsV1) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.order != nil {
+		*c.order = append(*c.order, "economics")
+	}
 	c.recorded = append(c.recorded, economics)
-	return nil
+	return c.economicsErr
+}
+
+type runStoreStub struct {
+	mu      sync.Mutex
+	runs    []store.ReviewRunV1
+	saveErr error
+	order   *[]string
+}
+
+func (s *runStoreStub) SaveRun(run store.ReviewRunV1) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.order != nil {
+		*s.order = append(*s.order, "run")
+	}
+	if s.saveErr != nil {
+		return "", s.saveErr
+	}
+	s.runs = append(s.runs, run)
+	return run.ID, nil
+}
+
+func (s *runStoreStub) ListRuns(store.PullRequestKeyV1) ([]store.ReviewRunV1, []store.CorruptRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]store.ReviewRunV1(nil), s.runs...), nil, nil
+}
+
+func (s *runStoreStub) LoadRun(_ store.PullRequestKeyV1, runID string) (store.ReviewRunV1, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, run := range s.runs {
+		if run.ID == runID {
+			return run, nil
+		}
+	}
+	return store.ReviewRunV1{}, fmt.Errorf("run %s not found", runID)
 }
 
 func schedulerTarget(key store.PullRequestKeyV1, head string) store.ReviewTargetV1 {
@@ -268,6 +311,152 @@ func TestBackgroundReviewAuthorizesBoundsAndRecordsRun(t *testing.T) {
 	}
 	if len(controller.recorded) != 1 || controller.recorded[0].RunID != "run-1" {
 		t.Fatalf("recorded = %v", controller.recorded)
+	}
+}
+
+func TestBackgroundReviewRetriesPreparationFailures(t *testing.T) {
+	transient := errors.New("revision lookup unavailable")
+	key := schedulerKey(1)
+	target := schedulerTarget(key, "head-1")
+	newReview := func(prepare func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error)) BackgroundReview {
+		return BackgroundReview{
+			Key:        key,
+			Controller: &controllerStub{decision: automatic.Decision{Allowed: true}},
+			Runs:       store.NewFilesystemRunStore(t.TempDir()),
+			Prepare:    prepare,
+		}
+	}
+	t.Run("preserves original error", func(t *testing.T) {
+		port, err := newReview(func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			return PreparedCycle{}, transient
+		}).Port()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = port.RunCycle(context.Background(), 1, "initial review", nil, "")
+		if !errors.Is(err, watch.ErrRetryableCycle) || !errors.Is(err, transient) {
+			t.Fatalf("RunCycle error = %v, want retryable wrapper preserving original", err)
+		}
+	})
+	t.Run("succeeds after retry", func(t *testing.T) {
+		attempts := 0
+		lifecycle, err := NewLifecycle(watch.Config{
+			PollInterval: time.Minute,
+			SettleTime:   time.Minute,
+			MaxReviews:   2,
+			MaxDuration:  time.Hour,
+		}, watch.Polling{
+			Clock: &advancingClock{now: time.Now()},
+			State: func(context.Context) (watch.PRState, error) {
+				if attempts >= 2 {
+					return watch.PRState{HeadSHA: "head-1", Closed: true}, nil
+				}
+				return watch.PRState{HeadSHA: "head-1"}, nil
+			},
+		}, newReview(func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			attempts++
+			if attempts == 1 {
+				return PreparedCycle{}, transient
+			}
+			return PreparedCycle{Work: schedulerWork("prepare-retry", target, func(context.Context) (*domain.ReviewRun, error) {
+				return schedulerRun(t, "prepare-retry", target, domain.ReviewConclusionClean), nil
+			})}, nil
+		}), nil, watch.Presentation{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reason := lifecycle.Run(context.Background()); reason != watch.ReasonClosed {
+			t.Fatalf("reason = %v, want closed after successful retry", reason)
+		}
+		if attempts != 2 {
+			t.Fatalf("attempts = %d, want 2", attempts)
+		}
+	})
+	t.Run("stops after bounded failures", func(t *testing.T) {
+		attempts := 0
+		lifecycle, err := NewLifecycle(watch.Config{
+			PollInterval: time.Minute,
+			SettleTime:   time.Minute,
+			MaxReviews:   10,
+			MaxDuration:  time.Hour,
+		}, watch.Polling{
+			Clock: &advancingClock{now: time.Now()},
+			State: func(context.Context) (watch.PRState, error) {
+				return watch.PRState{HeadSHA: "head-1"}, nil
+			},
+		}, newReview(func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			attempts++
+			return PreparedCycle{}, transient
+		}), nil, watch.Presentation{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reason := lifecycle.Run(context.Background()); reason != watch.ReasonError {
+			t.Fatalf("reason = %v, want error", reason)
+		}
+		if attempts != 5 {
+			t.Fatalf("attempts = %d, want bounded retry count 5", attempts)
+		}
+	})
+}
+
+func TestBackgroundReviewPersistsEconomicsBeforeTerminalRun(t *testing.T) {
+	economicsFailure := errors.New("economics unavailable")
+	runFailure := errors.New("run store unavailable")
+	tests := []struct {
+		name         string
+		economicsErr error
+		runErr       error
+		wantOrder    string
+		wantRuns     int
+		wantErr      error
+	}{
+		{name: "economics failure leaves no completed marker", economicsErr: economicsFailure, wantOrder: "economics", wantErr: economicsFailure},
+		{name: "run failure retains economics", runErr: runFailure, wantOrder: "economics,run", wantErr: runFailure},
+		{name: "success records economics then run", wantOrder: "economics,run", wantRuns: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			key := schedulerKey(1)
+			target := schedulerTarget(key, "head-1")
+			var order []string
+			controller := &controllerStub{
+				decision:     automatic.Decision{Allowed: true},
+				economicsErr: test.economicsErr,
+				order:        &order,
+			}
+			runs := &runStoreStub{saveErr: test.runErr, order: &order}
+			port, err := (BackgroundReview{
+				Key:        key,
+				Controller: controller,
+				Runs:       runs,
+				Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+					return PreparedCycle{Work: schedulerWork("ordered-run", target, func(context.Context) (*domain.ReviewRun, error) {
+						return schedulerRun(t, "ordered-run", target, domain.ReviewConclusionClean), nil
+					})}, nil
+				},
+			}).Port()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, cycleErr := port.RunCycle(context.Background(), 1, "initial review", nil, "")
+			if test.wantErr == nil && cycleErr != nil {
+				t.Fatalf("RunCycle: %v", cycleErr)
+			}
+			if test.wantErr != nil && !errors.Is(cycleErr, test.wantErr) {
+				t.Fatalf("RunCycle error = %v, want %v", cycleErr, test.wantErr)
+			}
+			persisted, corrupt, listErr := runs.ListRuns(key)
+			if listErr != nil || len(corrupt) != 0 || len(persisted) != test.wantRuns {
+				t.Fatalf("runs = %+v, corrupt = %+v, err = %v", persisted, corrupt, listErr)
+			}
+			if strings.Join(order, ",") != test.wantOrder {
+				t.Fatalf("persistence order = %v, want %q", order, test.wantOrder)
+			}
+			if len(controller.recorded) != 1 || controller.recorded[0].RunID != "ordered-run" {
+				t.Fatalf("recorded economics = %+v", controller.recorded)
+			}
+		})
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -197,18 +197,37 @@ func schedulerTarget(key store.PullRequestKeyV1, head string) store.ReviewTarget
 	}
 }
 
-func schedulerWork(target store.ReviewTargetV1, run func(context.Context) (*domain.ReviewRun, error)) BackgroundWork {
-	return BackgroundWork{target: target, run: run}
+func schedulerWork(runID string, target store.ReviewTargetV1, run func(context.Context) (*domain.ReviewRun, error)) BackgroundWork {
+	return BackgroundWork{runID: runID, target: target, run: run}
 }
 
-func schedulerRun(id string, target store.ReviewTargetV1, conclusion domain.ReviewConclusion) *domain.ReviewRun {
+func schedulerRun(t *testing.T, id string, target store.ReviewTargetV1, conclusion domain.ReviewConclusion) *domain.ReviewRun {
+	t.Helper()
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"inert"},
+		SummarizerAgent:   "inert",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatalf("NewReviewConfiguration: %v", err)
+	}
 	return &domain.ReviewRun{
-		ID:          id,
-		Target:      target.ToDomain(),
-		StartedAt:   time.Unix(10, 0),
-		CompletedAt: time.Unix(20, 0),
-		Status:      domain.ReviewStatusCompleted,
-		Conclusion:  conclusion,
+		ID:                       id,
+		Target:                   target.ToDomain(),
+		Trigger:                  domain.ReviewTriggerDesk,
+		Engine:                   domain.ReviewEngine{Name: "acr", Version: "test"},
+		StartedAt:                time.Unix(10, 0),
+		CompletedAt:              time.Unix(20, 0),
+		Configuration:            configuration,
+		ConfigurationSource:      domain.ConfigurationSourceIdentity{Kind: "test"},
+		ConfigurationFingerprint: configuration.Fingerprint(),
+		Status:                   domain.ReviewStatusCompleted,
+		Conclusion:               conclusion,
 	}
 }
 
@@ -220,17 +239,16 @@ func TestBackgroundReviewAuthorizesBoundsAndRecordsRun(t *testing.T) {
 	port, err := (BackgroundReview{
 		Key:        key,
 		Controller: controller,
+		Runs:       store.NewFilesystemRunStore(t.TempDir()),
 		Now:        func() time.Time { return time.Unix(100, 0) },
 		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
 			return PreparedCycle{
-				RunID:  "run-1",
-				Target: target,
-				Work: schedulerWork(target, func(ctx context.Context) (*domain.ReviewRun, error) {
+				Work: schedulerWork("run-1", target, func(ctx context.Context) (*domain.ReviewRun, error) {
 					gotDeadline, ok := ctx.Deadline()
 					if !ok || !gotDeadline.Equal(deadline) {
 						t.Fatalf("deadline = %v, %t, want %v", gotDeadline, ok, deadline)
 					}
-					return schedulerRun("run-1", target, domain.ReviewConclusionFindings), nil
+					return schedulerRun(t, "run-1", target, domain.ReviewConclusionFindings), nil
 				}),
 			}, nil
 		},
@@ -253,6 +271,67 @@ func TestBackgroundReviewAuthorizesBoundsAndRecordsRun(t *testing.T) {
 	}
 }
 
+func TestBackgroundReviewPersistsFailedAndInterruptedRuns(t *testing.T) {
+	tests := []domain.ReviewStatus{domain.ReviewStatusFailed, domain.ReviewStatusInterrupted}
+	for _, status := range tests {
+		t.Run(string(status), func(t *testing.T) {
+			key := schedulerKey(1)
+			target := schedulerTarget(key, "head-1")
+			runID := "run-" + string(status)
+			runStore := store.NewFilesystemRunStore(t.TempDir())
+			controller := &controllerStub{decision: automatic.Decision{Allowed: true}}
+			port, err := (BackgroundReview{
+				Key:        key,
+				Controller: controller,
+				Runs:       runStore,
+				Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+					return PreparedCycle{Work: schedulerWork(runID, target, func(context.Context) (*domain.ReviewRun, error) {
+						run := schedulerRun(t, runID, target, domain.ReviewConclusionClean)
+						run.Status = status
+						run.Conclusion = domain.ReviewConclusionNone
+						run.Failure = &domain.ReviewFailure{Phase: domain.ReviewPhaseReviewers, Message: string(status)}
+						return run, nil
+					})}, nil
+				},
+			}).Port()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := port.RunCycle(context.Background(), 1, "initial review", nil, ""); err == nil {
+				t.Fatalf("expected %s cycle error", status)
+			}
+			runs, corrupt, err := runStore.ListRuns(key)
+			if err != nil || len(corrupt) != 0 || len(runs) != 1 || runs[0].Status != string(status) {
+				t.Fatalf("persisted runs = %+v, corrupt = %+v, err = %v", runs, corrupt, err)
+			}
+			if len(controller.recorded) != 1 || controller.recorded[0].RunID != runID {
+				t.Fatalf("recorded economics = %+v", controller.recorded)
+			}
+		})
+	}
+}
+
+func TestEconomicsUsesMeasuredModelCalls(t *testing.T) {
+	run := &domain.ReviewRun{
+		ID:          "run-measured",
+		StartedAt:   time.Unix(10, 0),
+		CompletedAt: time.Unix(20, 0),
+		ReviewerResults: []domain.ReviewerResult{
+			{Attempts: 2},
+			{Attempts: 1},
+		},
+		Stats: domain.ReviewStats{
+			SummarizerDuration: time.Second,
+			FPFilterDuration:   time.Second,
+			ModelCallCount:     6,
+		},
+	}
+	economics := economicsFromRun(run)
+	if economics.ReviewerCallCount != 3 || economics.ModelCallCount != 6 {
+		t.Fatalf("economics = %+v, want reviewer=3 model=6", economics)
+	}
+}
+
 func TestBackgroundReviewHonorsStopAndResumeDecision(t *testing.T) {
 	controller := &controllerStub{decision: automatic.Decision{Reason: "review budget exhausted"}}
 	key := schedulerKey(1)
@@ -261,14 +340,13 @@ func TestBackgroundReviewHonorsStopAndResumeDecision(t *testing.T) {
 	review := BackgroundReview{
 		Key:        key,
 		Controller: controller,
+		Runs:       store.NewFilesystemRunStore(t.TempDir()),
 		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
 			runID := fmt.Sprintf("run-%d", len(controller.authorized)+1)
 			return PreparedCycle{
-				RunID:  runID,
-				Target: target,
-				Work: schedulerWork(target, func(context.Context) (*domain.ReviewRun, error) {
+				Work: schedulerWork(runID, target, func(context.Context) (*domain.ReviewRun, error) {
 					runs.Add(1)
-					return schedulerRun(runID, target, domain.ReviewConclusionFindings), nil
+					return schedulerRun(t, runID, target, domain.ReviewConclusionFindings), nil
 				}),
 			}, nil
 		},
@@ -311,6 +389,7 @@ func TestBackgroundReviewDurablyDeduplicatesRevisionAcrossRecreation(t *testing.
 		controller, err := automatic.NewController(
 			store.NewFilesystemLoopDecisionStore(dataDir),
 			store.NewFilesystemEconomicsStore(dataDir),
+			store.NewFilesystemRunStore(dataDir),
 		)
 		if err != nil {
 			t.Fatalf("NewController: %v", err)
@@ -330,17 +409,15 @@ func TestBackgroundReviewDurablyDeduplicatesRevisionAcrossRecreation(t *testing.
 	prepare := func(runID string, target store.ReviewTargetV1, policy automatic.TrustedPolicy) PrepareCycle {
 		return func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
 			return PreparedCycle{
-				RunID:  runID,
-				Target: target,
 				Policy: policy,
-				Work: schedulerWork(target, func(context.Context) (*domain.ReviewRun, error) {
+				Work: schedulerWork(runID, target, func(context.Context) (*domain.ReviewRun, error) {
 					runs.Add(1)
-					return schedulerRun(runID, target, domain.ReviewConclusionFindings), nil
+					return schedulerRun(t, runID, target, domain.ReviewConclusionFindings), nil
 				}),
 			}, nil
 		}
 	}
-	first, err := (BackgroundReview{Key: key, Controller: controller, Prepare: prepare("run-a-1", targetA, newPolicy(targetA))}).Port()
+	first, err := (BackgroundReview{Key: key, Controller: controller, Runs: store.NewFilesystemRunStore(dataDir), Prepare: prepare("run-a-1", targetA, newPolicy(targetA))}).Port()
 	if err != nil {
 		t.Fatalf("first Port: %v", err)
 	}
@@ -349,7 +426,7 @@ func TestBackgroundReviewDurablyDeduplicatesRevisionAcrossRecreation(t *testing.
 	}
 
 	restarted := newController()
-	duplicate, err := (BackgroundReview{Key: key, Controller: restarted, Prepare: prepare("run-a-2", targetA, newPolicy(targetA))}).Port()
+	duplicate, err := (BackgroundReview{Key: key, Controller: restarted, Runs: store.NewFilesystemRunStore(dataDir), Prepare: prepare("run-a-2", targetA, newPolicy(targetA))}).Port()
 	if err != nil {
 		t.Fatalf("duplicate Port: %v", err)
 	}
@@ -361,7 +438,7 @@ func TestBackgroundReviewDurablyDeduplicatesRevisionAcrossRecreation(t *testing.
 	}
 
 	targetB := schedulerTarget(key, "head-b")
-	replacement, err := (BackgroundReview{Key: key, Controller: restarted, Prepare: prepare("run-b-1", targetB, newPolicy(targetB))}).Port()
+	replacement, err := (BackgroundReview{Key: key, Controller: restarted, Runs: store.NewFilesystemRunStore(dataDir), Prepare: prepare("run-b-1", targetB, newPolicy(targetB))}).Port()
 	if err != nil {
 		t.Fatalf("replacement Port: %v", err)
 	}
@@ -423,8 +500,11 @@ func TestBackgroundWorkExposesNoSubmissionCapability(t *testing.T) {
 		t.Fatalf("NewService: %v", err)
 	}
 	var submissionCalls atomic.Int32
-	work, err := NewBackgroundWork(service, reviewpkg.Request{
-		Target:        target.ToDomain(),
+	requestTarget := target
+	requestTarget.Revision.HeadObjectID = ""
+	requestTarget.Revision.BaseObjectID = ""
+	work, err := NewBackgroundWork(context.Background(), service, reviewpkg.Request{
+		Target:        requestTarget.ToDomain(),
 		Trigger:       domain.ReviewTriggerDesk,
 		Engine:        domain.ReviewEngine{Name: "acr", Version: "test"},
 		Configuration: configuration,
@@ -438,16 +518,21 @@ func TestBackgroundWorkExposesNoSubmissionCapability(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBackgroundWork: %v", err)
 	}
+	if work.runID != "run-clean" || work.target.Revision.HeadObjectID != "head-1" || work.target.Revision.BaseObjectID != "base-1" {
+		t.Fatalf("background work identity = %q %+v, want resolved prepared identity", work.runID, work.target.Revision)
+	}
 	controller := &controllerStub{decision: automatic.Decision{Allowed: true}}
+	runStore := store.NewFilesystemRunStore(t.TempDir())
 	port, err := (BackgroundReview{
 		Key:        key,
 		Controller: controller,
+		Runs:       runStore,
 		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
-			return PreparedCycle{
-				RunID:  "run-clean",
-				Target: target,
-				Work:   work,
-			}, nil
+			return NewPreparedCycle(work, store.AdjudicationPolicyV1{
+				SchemaVersion: store.CurrentSchemaVersion,
+				Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+				Budget:        store.BudgetPolicyV1{MaxIterations: 1},
+			})
 		},
 	}).Port()
 	if err != nil {
@@ -462,6 +547,13 @@ func TestBackgroundWorkExposesNoSubmissionCapability(t *testing.T) {
 	}
 	if submissionCalls.Load() != 0 {
 		t.Fatalf("background work invoked supplied submission callback %d time(s)", submissionCalls.Load())
+	}
+	runs, corrupt, err := runStore.ListRuns(key)
+	if err != nil || len(corrupt) != 0 || len(runs) != 1 || runs[0].ID != "run-clean" {
+		t.Fatalf("persisted runs = %+v, corrupt = %+v, err = %v", runs, corrupt, err)
+	}
+	if len(controller.recorded) != 1 || controller.recorded[0].ModelCallCount != 0 {
+		t.Fatalf("recorded economics = %+v, want exact zero model calls", controller.recorded)
 	}
 }
 
@@ -547,6 +639,7 @@ func TestLifecycleReviewsSettledReplacementHeadOnce(t *testing.T) {
 	review := BackgroundReview{
 		Key:        key,
 		Controller: controller,
+		Runs:       store.NewFilesystemRunStore(t.TempDir()),
 		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
 			mu.Lock()
 			head := states[stateIndex-1].HeadSHA
@@ -555,14 +648,12 @@ func TestLifecycleReviewsSettledReplacementHeadOnce(t *testing.T) {
 			target := schedulerTarget(key, head)
 			runID := "run-" + head
 			return PreparedCycle{
-				RunID:  runID,
-				Target: target,
-				Work: schedulerWork(target, func(context.Context) (*domain.ReviewRun, error) {
+				Work: schedulerWork(runID, target, func(context.Context) (*domain.ReviewRun, error) {
 					conclusion := domain.ReviewConclusionFindings
 					if head == "head-b" {
 						conclusion = domain.ReviewConclusionClean
 					}
-					return schedulerRun(runID, target, conclusion), nil
+					return schedulerRun(t, runID, target, conclusion), nil
 				}),
 			}, nil
 		},
@@ -582,5 +673,50 @@ func TestLifecycleReviewsSettledReplacementHeadOnce(t *testing.T) {
 	}
 	if fmt.Sprint(heads) != "[head-a head-b]" {
 		t.Fatalf("reviewed heads = %v, want [head-a head-b]", heads)
+	}
+}
+
+func TestLifecycleMapsControllerStopAndEscalation(t *testing.T) {
+	tests := []struct {
+		kind store.LoopDecisionKindV1
+		want watch.ExitReason
+	}{
+		{kind: store.LoopDecisionStop, want: watch.ReasonStopped},
+		{kind: store.LoopDecisionEscalate, want: watch.ReasonEscalated},
+	}
+	for _, test := range tests {
+		t.Run(string(test.kind), func(t *testing.T) {
+			key := schedulerKey(1)
+			target := schedulerTarget(key, "head-1")
+			clock := &advancingClock{now: time.Now()}
+			lifecycle, err := NewLifecycle(watch.Config{
+				PollInterval:    time.Minute,
+				SettleTime:      time.Minute,
+				MaxReviews:      2,
+				MaxDuration:     time.Hour,
+				UncertainPolicy: watch.UncertainWait,
+			}, watch.Polling{
+				Clock: clock,
+				State: func(context.Context) (watch.PRState, error) {
+					return watch.PRState{HeadSHA: "head-1"}, nil
+				},
+			}, BackgroundReview{
+				Key:        key,
+				Controller: &controllerStub{decision: automatic.Decision{Kind: test.kind, Reason: "controlled"}},
+				Runs:       store.NewFilesystemRunStore(t.TempDir()),
+				Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+					return PreparedCycle{Work: schedulerWork("run-controlled", target, func(context.Context) (*domain.ReviewRun, error) {
+						t.Fatal("controlled termination executed review work")
+						return nil, nil
+					})}, nil
+				},
+			}, nil, watch.Presentation{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if reason := lifecycle.Run(context.Background()); reason != test.want {
+				t.Fatalf("reason = %v, want %v", reason, test.want)
+			}
+		})
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,380 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/automatic"
+	"github.com/richhaase/agentic-code-reviewer/internal/store"
+	"github.com/richhaase/agentic-code-reviewer/internal/watch"
+)
+
+type lifecycleFunc func(context.Context) watch.ExitReason
+
+func (f lifecycleFunc) Run(ctx context.Context) watch.ExitReason {
+	return f(ctx)
+}
+
+func schedulerKey(number int) store.PullRequestKeyV1 {
+	return store.PullRequestKeyV1{Host: "github.com", Owner: "acme", Repository: "widgets", Number: number}
+}
+
+func TestSchedulerBoundsConcurrentLifecycles(t *testing.T) {
+	scheduler, err := New(2)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	release := make(chan struct{})
+	started := make(chan struct{}, 6)
+	var active atomic.Int32
+	var maximum atomic.Int32
+	jobs := make([]Job, 6)
+	for i := range jobs {
+		jobs[i] = Job{Key: schedulerKey(i + 1), Lifecycle: lifecycleFunc(func(ctx context.Context) watch.ExitReason {
+			current := active.Add(1)
+			for {
+				observed := maximum.Load()
+				if current <= observed || maximum.CompareAndSwap(observed, current) {
+					break
+				}
+			}
+			started <- struct{}{}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			active.Add(-1)
+			return watch.ReasonClosed
+		})}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		results, runErr := scheduler.Run(context.Background(), jobs)
+		if runErr == nil && len(results) != len(jobs) {
+			runErr = fmt.Errorf("results = %d, want %d", len(results), len(jobs))
+		}
+		done <- runErr
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("scheduler did not fill configured capacity")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatal("scheduler exceeded configured capacity")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := maximum.Load(); got != 2 {
+		t.Fatalf("maximum concurrency = %d, want 2", got)
+	}
+}
+
+func TestSchedulerRejectsDuplicatePullRequestLifecycle(t *testing.T) {
+	scheduler, err := New(2)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var calls atomic.Int32
+	lifecycle := lifecycleFunc(func(context.Context) watch.ExitReason {
+		calls.Add(1)
+		return watch.ReasonClosed
+	})
+	key := schedulerKey(1)
+	_, err = scheduler.Run(context.Background(), []Job{{Key: key, Lifecycle: lifecycle}, {Key: key, Lifecycle: lifecycle}})
+	if err == nil {
+		t.Fatal("expected duplicate lifecycle rejection")
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("lifecycle calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestSchedulerRejectsDuplicateActivePullRequestAcrossCallers(t *testing.T) {
+	scheduler, err := New(2)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	key := schedulerKey(1)
+	firstDone := make(chan error, 1)
+	go func() {
+		_, runErr := scheduler.Run(context.Background(), []Job{{Key: key, Lifecycle: lifecycleFunc(func(context.Context) watch.ExitReason {
+			close(started)
+			<-release
+			return watch.ReasonClosed
+		})}})
+		firstDone <- runErr
+	}()
+	<-started
+	var duplicateCalls atomic.Int32
+	_, err = scheduler.Run(context.Background(), []Job{{Key: key, Lifecycle: lifecycleFunc(func(context.Context) watch.ExitReason {
+		duplicateCalls.Add(1)
+		return watch.ReasonClosed
+	})}})
+	if err == nil {
+		t.Fatal("expected active duplicate rejection")
+	}
+	if duplicateCalls.Load() != 0 {
+		t.Fatalf("duplicate calls = %d, want 0", duplicateCalls.Load())
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+}
+
+type controllerStub struct {
+	mu         sync.Mutex
+	decision   automatic.Decision
+	authorized []string
+	recorded   []store.ReviewEconomicsV1
+}
+
+func (c *controllerStub) AuthorizeReview(_ store.PullRequestKeyV1, _ store.ReviewTargetV1, _ automatic.TrustedPolicy, runID string) (automatic.Decision, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.authorized = append(c.authorized, runID)
+	return c.decision, nil
+}
+
+func (c *controllerStub) RecordEconomics(_ store.PullRequestKeyV1, _ time.Time, economics store.ReviewEconomicsV1) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.recorded = append(c.recorded, economics)
+	return nil
+}
+
+func TestBackgroundReviewAuthorizesBoundsAndRecordsRun(t *testing.T) {
+	deadline := time.Now().Add(time.Minute).Round(0)
+	controller := &controllerStub{decision: automatic.Decision{Allowed: true, Deadline: deadline}}
+	key := schedulerKey(1)
+	port, err := (BackgroundReview{
+		Key:        key,
+		Controller: controller,
+		Now:        func() time.Time { return time.Unix(100, 0) },
+		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			return PreparedCycle{
+				RunID:  "run-1",
+				Target: store.ReviewTargetV1{PullRequest: &key},
+				Run: func(ctx context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
+					gotDeadline, ok := ctx.Deadline()
+					if !ok || !gotDeadline.Equal(deadline) {
+						t.Fatalf("deadline = %v, %t, want %v", gotDeadline, ok, deadline)
+					}
+					economics := &store.ReviewEconomicsV1{SchemaVersion: store.CurrentSchemaVersion, RunID: "run-1"}
+					return watch.Cycle{Result: watch.CycleFindings, HeadSHA: "head-1"}, economics, nil
+				},
+			}, nil
+		},
+	}).Port()
+	if err != nil {
+		t.Fatalf("Port: %v", err)
+	}
+	cycle, err := port.RunCycle(context.Background(), 1, "initial review", nil, "")
+	if err != nil {
+		t.Fatalf("RunCycle: %v", err)
+	}
+	if cycle.Result != watch.CycleFindings {
+		t.Fatalf("cycle result = %d, want findings", cycle.Result)
+	}
+	if len(controller.authorized) != 1 || controller.authorized[0] != "run-1" {
+		t.Fatalf("authorized = %v", controller.authorized)
+	}
+	if len(controller.recorded) != 1 || controller.recorded[0].RunID != "run-1" {
+		t.Fatalf("recorded = %v", controller.recorded)
+	}
+}
+
+func TestBackgroundReviewHonorsStopAndResumeDecision(t *testing.T) {
+	controller := &controllerStub{decision: automatic.Decision{Reason: "review budget exhausted"}}
+	key := schedulerKey(1)
+	var runs atomic.Int32
+	review := BackgroundReview{
+		Key:        key,
+		Controller: controller,
+		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			return PreparedCycle{
+				RunID:  fmt.Sprintf("run-%d", len(controller.authorized)+1),
+				Target: store.ReviewTargetV1{PullRequest: &key},
+				Run: func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
+					runs.Add(1)
+					return watch.Cycle{Result: watch.CycleFindings}, nil, nil
+				},
+			}, nil
+		},
+	}
+	port, err := review.Port()
+	if err != nil {
+		t.Fatalf("Port: %v", err)
+	}
+	if _, err := port.RunCycle(context.Background(), 1, "initial review", nil, ""); !errors.Is(err, ErrAutomaticReviewStopped) {
+		t.Fatalf("RunCycle error = %v, want stopped", err)
+	}
+	if runs.Load() != 0 {
+		t.Fatalf("runs = %d, want 0", runs.Load())
+	}
+	controller.decision = automatic.Decision{Allowed: true}
+	if _, err := port.RunCycle(context.Background(), 1, "initial review", nil, ""); err != nil {
+		t.Fatalf("resumed RunCycle: %v", err)
+	}
+	if runs.Load() != 1 {
+		t.Fatalf("runs = %d, want 1", runs.Load())
+	}
+}
+
+func TestBackgroundReviewRejectsPostingResults(t *testing.T) {
+	controller := &controllerStub{decision: automatic.Decision{Allowed: true}}
+	key := schedulerKey(1)
+	port, err := (BackgroundReview{
+		Key:        key,
+		Controller: controller,
+		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			return PreparedCycle{
+				RunID:  "run-post",
+				Target: store.ReviewTargetV1{PullRequest: &key},
+				Run: func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
+					return watch.Cycle{Result: watch.CycleLGTMComment}, nil, nil
+				},
+			}, nil
+		},
+	}).Port()
+	if err != nil {
+		t.Fatalf("Port: %v", err)
+	}
+	if _, err := port.RunCycle(context.Background(), 1, "initial review", nil, ""); err == nil {
+		t.Fatal("expected posting result rejection")
+	}
+}
+
+type eventHistory struct {
+	events []store.ReviewEventV1
+}
+
+func (h eventHistory) ListEvents(store.PullRequestKeyV1) ([]store.ReviewEventV1, []store.CorruptRecord, error) {
+	return h.events, nil, nil
+}
+
+func TestStoredControlUsesLatestRecordedDecision(t *testing.T) {
+	base := time.Unix(100, 0)
+	tests := []struct {
+		name   string
+		types  []store.ReviewEventTypeV1
+		wanted watch.ControlState
+	}{
+		{name: "active by default", wanted: watch.ControlActive},
+		{name: "snoozed", types: []store.ReviewEventTypeV1{store.EventTypeUserSnoozed}, wanted: watch.ControlSnoozed},
+		{name: "released", types: []store.ReviewEventTypeV1{store.EventTypeUserReleased}, wanted: watch.ControlReleased},
+		{name: "opted out", types: []store.ReviewEventTypeV1{store.EventTypeUserOptedOut}, wanted: watch.ControlOptedOut},
+		{name: "resumed", types: []store.ReviewEventTypeV1{store.EventTypeUserSnoozed, store.EventTypeUserResumed}, wanted: watch.ControlActive},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			events := make([]store.ReviewEventV1, len(test.types))
+			for i, eventType := range test.types {
+				events[i] = store.ReviewEventV1{Type: eventType, OccurredAt: base.Add(time.Duration(i) * time.Second)}
+			}
+			decision, err := StoredControl(eventHistory{events: events}, schedulerKey(1))(context.Background(), watch.PRState{})
+			if err != nil {
+				t.Fatalf("control: %v", err)
+			}
+			if decision.State != test.wanted {
+				t.Fatalf("state = %q, want %q", decision.State, test.wanted)
+			}
+		})
+	}
+}
+
+type advancingClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *advancingClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *advancingClock) Sleep(ctx context.Context, duration time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.now = c.now.Add(duration)
+	c.mu.Unlock()
+	return nil
+}
+
+func TestLifecycleReviewsSettledReplacementHeadOnce(t *testing.T) {
+	key := schedulerKey(1)
+	controller := &controllerStub{decision: automatic.Decision{Allowed: true}}
+	clock := &advancingClock{now: time.Now()}
+	states := []watch.PRState{{HeadSHA: "head-a"}, {HeadSHA: "head-b"}, {HeadSHA: "head-b"}}
+	var stateIndex int
+	var mu sync.Mutex
+	polling := watch.Polling{
+		Clock: clock,
+		State: func(context.Context) (watch.PRState, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if stateIndex < len(states)-1 {
+				stateIndex++
+				return states[stateIndex-1], nil
+			}
+			return states[len(states)-1], nil
+		},
+	}
+	var heads []string
+	review := BackgroundReview{
+		Key:        key,
+		Controller: controller,
+		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			mu.Lock()
+			head := states[stateIndex-1].HeadSHA
+			heads = append(heads, head)
+			mu.Unlock()
+			return PreparedCycle{
+				RunID:  "run-" + head,
+				Target: store.ReviewTargetV1{PullRequest: &key},
+				Run: func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
+					result := watch.CycleFindings
+					if head == "head-b" {
+						result = watch.CycleClean
+					}
+					return watch.Cycle{Result: result, HeadSHA: head}, nil, nil
+				},
+			}, nil
+		},
+	}
+	lifecycle, err := NewLifecycle(watch.Config{
+		PollInterval:    time.Minute,
+		SettleTime:      time.Minute,
+		MaxReviews:      2,
+		MaxDuration:     time.Hour,
+		UncertainPolicy: watch.UncertainWait,
+	}, polling, review, nil, watch.Presentation{})
+	if err != nil {
+		t.Fatalf("NewLifecycle: %v", err)
+	}
+	if reason := lifecycle.Run(context.Background()); reason != watch.ReasonMaxReviews {
+		t.Fatalf("reason = %v, want max reviews", reason)
+	}
+	if fmt.Sprint(heads) != "[head-a head-b]" {
+		t.Fatalf("reviewed heads = %v, want [head-a head-b]", heads)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -4,17 +4,41 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
 	"github.com/richhaase/agentic-code-reviewer/internal/automatic"
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+	reviewpkg "github.com/richhaase/agentic-code-reviewer/internal/review"
 	"github.com/richhaase/agentic-code-reviewer/internal/store"
 	"github.com/richhaase/agentic-code-reviewer/internal/watch"
 )
 
 type lifecycleFunc func(context.Context) watch.ExitReason
+
+type inertAgent struct{}
+
+func (inertAgent) Name() string {
+	return "inert"
+}
+
+func (inertAgent) IsAvailable() error {
+	return nil
+}
+
+func (inertAgent) ExecuteReview(context.Context, *agent.ReviewConfig) (*agent.ExecutionResult, error) {
+	return nil, fmt.Errorf("review execution was not expected")
+}
+
+func (inertAgent) ExecuteSummary(context.Context, *agent.SummaryConfig) (*agent.ExecutionResult, error) {
+	return nil, fmt.Errorf("summary execution was not expected")
+}
 
 func (f lifecycleFunc) Run(ctx context.Context) watch.ExitReason {
 	return f(ctx)
@@ -159,10 +183,40 @@ func (c *controllerStub) RecordEconomics(_ store.PullRequestKeyV1, _ time.Time, 
 	return nil
 }
 
+func schedulerTarget(key store.PullRequestKeyV1, head string) store.ReviewTargetV1 {
+	return store.ReviewTargetV1{
+		RepositoryRoot: "/repo",
+		WorktreeRoot:   "/repo/worktree",
+		Revision: store.RevisionEvidenceV1{
+			RequestedBaseRef: "main",
+			ResolvedBaseRef:  "origin/main",
+			HeadObjectID:     head,
+			BaseObjectID:     "base-1",
+		},
+		PullRequest: &key,
+	}
+}
+
+func schedulerWork(target store.ReviewTargetV1, run func(context.Context) (*domain.ReviewRun, error)) BackgroundWork {
+	return BackgroundWork{target: target, run: run}
+}
+
+func schedulerRun(id string, target store.ReviewTargetV1, conclusion domain.ReviewConclusion) *domain.ReviewRun {
+	return &domain.ReviewRun{
+		ID:          id,
+		Target:      target.ToDomain(),
+		StartedAt:   time.Unix(10, 0),
+		CompletedAt: time.Unix(20, 0),
+		Status:      domain.ReviewStatusCompleted,
+		Conclusion:  conclusion,
+	}
+}
+
 func TestBackgroundReviewAuthorizesBoundsAndRecordsRun(t *testing.T) {
 	deadline := time.Now().Add(time.Minute).Round(0)
 	controller := &controllerStub{decision: automatic.Decision{Allowed: true, Deadline: deadline}}
 	key := schedulerKey(1)
+	target := schedulerTarget(key, "head-1")
 	port, err := (BackgroundReview{
 		Key:        key,
 		Controller: controller,
@@ -170,15 +224,14 @@ func TestBackgroundReviewAuthorizesBoundsAndRecordsRun(t *testing.T) {
 		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
 			return PreparedCycle{
 				RunID:  "run-1",
-				Target: store.ReviewTargetV1{PullRequest: &key},
-				Run: func(ctx context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
+				Target: target,
+				Work: schedulerWork(target, func(ctx context.Context) (*domain.ReviewRun, error) {
 					gotDeadline, ok := ctx.Deadline()
 					if !ok || !gotDeadline.Equal(deadline) {
 						t.Fatalf("deadline = %v, %t, want %v", gotDeadline, ok, deadline)
 					}
-					economics := &store.ReviewEconomicsV1{SchemaVersion: store.CurrentSchemaVersion, RunID: "run-1"}
-					return watch.Cycle{Result: watch.CycleFindings, HeadSHA: "head-1"}, economics, nil
-				},
+					return schedulerRun("run-1", target, domain.ReviewConclusionFindings), nil
+				}),
 			}, nil
 		},
 	}).Port()
@@ -203,18 +256,20 @@ func TestBackgroundReviewAuthorizesBoundsAndRecordsRun(t *testing.T) {
 func TestBackgroundReviewHonorsStopAndResumeDecision(t *testing.T) {
 	controller := &controllerStub{decision: automatic.Decision{Reason: "review budget exhausted"}}
 	key := schedulerKey(1)
+	target := schedulerTarget(key, "head-1")
 	var runs atomic.Int32
 	review := BackgroundReview{
 		Key:        key,
 		Controller: controller,
 		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			runID := fmt.Sprintf("run-%d", len(controller.authorized)+1)
 			return PreparedCycle{
-				RunID:  fmt.Sprintf("run-%d", len(controller.authorized)+1),
-				Target: store.ReviewTargetV1{PullRequest: &key},
-				Run: func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
+				RunID:  runID,
+				Target: target,
+				Work: schedulerWork(target, func(context.Context) (*domain.ReviewRun, error) {
 					runs.Add(1)
-					return watch.Cycle{Result: watch.CycleFindings}, nil, nil
-				},
+					return schedulerRun(runID, target, domain.ReviewConclusionFindings), nil
+				}),
 			}, nil
 		},
 	}
@@ -237,27 +292,176 @@ func TestBackgroundReviewHonorsStopAndResumeDecision(t *testing.T) {
 	}
 }
 
-func TestBackgroundReviewRejectsPostingResults(t *testing.T) {
-	controller := &controllerStub{decision: automatic.Decision{Allowed: true}}
+func TestBackgroundReviewDurablyDeduplicatesRevisionAcrossRecreation(t *testing.T) {
+	dataDir := t.TempDir()
 	key := schedulerKey(1)
+	policyRecord := store.AdjudicationPolicyV1{
+		SchemaVersion: store.CurrentSchemaVersion,
+		Source:        store.PolicySourceV1{Kind: config.SourceKindDefaults},
+		Budget:        store.BudgetPolicyV1{MaxIterations: 3},
+	}
+	newPolicy := func(target store.ReviewTargetV1) automatic.TrustedPolicy {
+		policy, err := automatic.NewTrustedPolicy(policyRecord, target)
+		if err != nil {
+			t.Fatalf("NewTrustedPolicy: %v", err)
+		}
+		return policy
+	}
+	newController := func() *automatic.Controller {
+		controller, err := automatic.NewController(
+			store.NewFilesystemLoopDecisionStore(dataDir),
+			store.NewFilesystemEconomicsStore(dataDir),
+		)
+		if err != nil {
+			t.Fatalf("NewController: %v", err)
+		}
+		return controller
+	}
+	authorization, err := automatic.WorkspaceAuthorization("scheduler-test")
+	if err != nil {
+		t.Fatalf("WorkspaceAuthorization: %v", err)
+	}
+	targetA := schedulerTarget(key, "head-a")
+	controller := newController()
+	if _, err := controller.Commission(key, targetA, newPolicy(targetA), authorization); err != nil {
+		t.Fatalf("Commission: %v", err)
+	}
+	var runs atomic.Int32
+	prepare := func(runID string, target store.ReviewTargetV1, policy automatic.TrustedPolicy) PrepareCycle {
+		return func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
+			return PreparedCycle{
+				RunID:  runID,
+				Target: target,
+				Policy: policy,
+				Work: schedulerWork(target, func(context.Context) (*domain.ReviewRun, error) {
+					runs.Add(1)
+					return schedulerRun(runID, target, domain.ReviewConclusionFindings), nil
+				}),
+			}, nil
+		}
+	}
+	first, err := (BackgroundReview{Key: key, Controller: controller, Prepare: prepare("run-a-1", targetA, newPolicy(targetA))}).Port()
+	if err != nil {
+		t.Fatalf("first Port: %v", err)
+	}
+	if _, err := first.RunCycle(context.Background(), 1, "initial review", nil, ""); err != nil {
+		t.Fatalf("first RunCycle: %v", err)
+	}
+
+	restarted := newController()
+	duplicate, err := (BackgroundReview{Key: key, Controller: restarted, Prepare: prepare("run-a-2", targetA, newPolicy(targetA))}).Port()
+	if err != nil {
+		t.Fatalf("duplicate Port: %v", err)
+	}
+	if _, err := duplicate.RunCycle(context.Background(), 1, "initial review", nil, ""); !errors.Is(err, automatic.ErrRevisionAlreadyAuthorized) {
+		t.Fatalf("duplicate RunCycle error = %v, want durable revision rejection", err)
+	}
+	if runs.Load() != 1 {
+		t.Fatalf("runs after duplicate = %d, want 1", runs.Load())
+	}
+
+	targetB := schedulerTarget(key, "head-b")
+	replacement, err := (BackgroundReview{Key: key, Controller: restarted, Prepare: prepare("run-b-1", targetB, newPolicy(targetB))}).Port()
+	if err != nil {
+		t.Fatalf("replacement Port: %v", err)
+	}
+	if _, err := replacement.RunCycle(context.Background(), 1, "commits settled", nil, ""); err != nil {
+		t.Fatalf("replacement RunCycle: %v", err)
+	}
+	if runs.Load() != 2 {
+		t.Fatalf("runs after replacement = %d, want 2", runs.Load())
+	}
+}
+
+func TestBackgroundWorkExposesNoSubmissionCapability(t *testing.T) {
+	workType := reflect.TypeOf(BackgroundWork{})
+	for i := 0; i < workType.NumField(); i++ {
+		if workType.Field(i).IsExported() {
+			t.Fatalf("background work exposes configurable field %q", workType.Field(i).Name)
+		}
+	}
+	if workType.NumMethod() != 0 {
+		t.Fatalf("background work exposes %d public method(s)", workType.NumMethod())
+	}
+	preparedType := reflect.TypeOf(PreparedCycle{})
+	for i := 0; i < preparedType.NumField(); i++ {
+		if preparedType.Field(i).Type.Kind() == reflect.Func {
+			t.Fatalf("prepared background cycle accepts executable function %q", preparedType.Field(i).Name)
+		}
+	}
+
+	repositoryRoot := t.TempDir()
+	if output, err := exec.Command("git", "init", repositoryRoot).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, output)
+	}
+	key := schedulerKey(1)
+	target := schedulerTarget(key, "head-1")
+	target.RepositoryRoot = repositoryRoot
+	target.WorktreeRoot = repositoryRoot
+	configuration, err := domain.NewReviewConfiguration(domain.ReviewConfigurationValues{
+		Reviewers:         1,
+		Concurrency:       1,
+		Timeout:           time.Minute,
+		ReviewerAgents:    []string{"inert"},
+		SummarizerAgent:   "inert",
+		SummarizerTimeout: time.Minute,
+		FPFilterTimeout:   time.Minute,
+		FPThreshold:       75,
+	})
+	if err != nil {
+		t.Fatalf("NewReviewConfiguration: %v", err)
+	}
+	service, err := reviewpkg.NewService(
+		reviewpkg.WithRunIDGenerator(func(time.Time) (string, error) { return "run-clean", nil }),
+		reviewpkg.WithAgentFactory(func(string, string) (agent.Agent, error) { return inertAgent{}, nil }),
+		reviewpkg.WithRevisionProvider(func(context.Context, domain.ReviewTarget) (domain.RevisionEvidence, error) {
+			return target.Revision.ToDomain(), nil
+		}),
+		reviewpkg.WithDiffProvider(func(context.Context, domain.ReviewTarget) (string, error) { return "", nil }),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	var submissionCalls atomic.Int32
+	work, err := NewBackgroundWork(service, reviewpkg.Request{
+		Target:        target.ToDomain(),
+		Trigger:       domain.ReviewTriggerDesk,
+		Engine:        domain.ReviewEngine{Name: "acr", Version: "test"},
+		Configuration: configuration,
+		ConfigurationSource: domain.ConfigurationSourceIdentity{
+			Kind: "test",
+		},
+		Events: reviewpkg.EventSinkFunc(func(reviewpkg.Event) {
+			submissionCalls.Add(1)
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewBackgroundWork: %v", err)
+	}
+	controller := &controllerStub{decision: automatic.Decision{Allowed: true}}
 	port, err := (BackgroundReview{
 		Key:        key,
 		Controller: controller,
 		Prepare: func(context.Context, int, string, []watch.Discussion, string) (PreparedCycle, error) {
 			return PreparedCycle{
-				RunID:  "run-post",
-				Target: store.ReviewTargetV1{PullRequest: &key},
-				Run: func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
-					return watch.Cycle{Result: watch.CycleLGTMComment}, nil, nil
-				},
+				RunID:  "run-clean",
+				Target: target,
+				Work:   work,
 			}, nil
 		},
 	}).Port()
 	if err != nil {
 		t.Fatalf("Port: %v", err)
 	}
-	if _, err := port.RunCycle(context.Background(), 1, "initial review", nil, ""); err == nil {
-		t.Fatal("expected posting result rejection")
+	cycle, err := port.RunCycle(context.Background(), 1, "initial review", nil, "")
+	if err != nil {
+		t.Fatalf("RunCycle: %v", err)
+	}
+	if cycle.Result != watch.CycleNoChanges {
+		t.Fatalf("cycle result = %d, want no changes", cycle.Result)
+	}
+	if submissionCalls.Load() != 0 {
+		t.Fatalf("background work invoked supplied submission callback %d time(s)", submissionCalls.Load())
 	}
 }
 
@@ -348,16 +552,18 @@ func TestLifecycleReviewsSettledReplacementHeadOnce(t *testing.T) {
 			head := states[stateIndex-1].HeadSHA
 			heads = append(heads, head)
 			mu.Unlock()
+			target := schedulerTarget(key, head)
+			runID := "run-" + head
 			return PreparedCycle{
-				RunID:  "run-" + head,
-				Target: store.ReviewTargetV1{PullRequest: &key},
-				Run: func(context.Context) (watch.Cycle, *store.ReviewEconomicsV1, error) {
-					result := watch.CycleFindings
+				RunID:  runID,
+				Target: target,
+				Work: schedulerWork(target, func(context.Context) (*domain.ReviewRun, error) {
+					conclusion := domain.ReviewConclusionFindings
 					if head == "head-b" {
-						result = watch.CycleClean
+						conclusion = domain.ReviewConclusionClean
 					}
-					return watch.Cycle{Result: result, HeadSHA: head}, nil, nil
-				},
+					return schedulerRun(runID, target, conclusion), nil
+				}),
 			}, nil
 		},
 	}

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -107,6 +107,7 @@ type LoopDecisionV1 struct {
 	AuthorizedBy               string                          `json:"authorized_by,omitempty"`
 	PolicySource               *PolicySourceV1                 `json:"policy_source,omitempty"`
 	ReviewTarget               *ReviewTargetV1                 `json:"review_target,omitempty"`
+	EvidenceIdentity           string                          `json:"evidence_identity,omitempty"`
 	AcknowledgedCorruptRecords []CorruptRecordAcknowledgmentV1 `json:"acknowledged_corrupt_records,omitempty"`
 	Scope                      LoopDecisionScopeV1             `json:"scope,omitempty"`
 	Decision                   LoopDecisionKindV1              `json:"decision"`

--- a/internal/store/loopdecision.go
+++ b/internal/store/loopdecision.go
@@ -192,6 +192,19 @@ func (d LoopDecisionV1) Validate() error {
 		}
 	} else if len(d.AcknowledgedCorruptRecords) != 0 {
 		return fmt.Errorf("acknowledged corrupt decision files require an admission decision")
+	} else if d.ReviewTarget != nil {
+		if d.Scope != LoopDecisionScopeAutomaticExecution || d.Decision != LoopDecisionContinue {
+			return fmt.Errorf("loop decision review target requires an automatic execution continue decision")
+		}
+		if d.ReviewTarget.PullRequest == nil {
+			return fmt.Errorf("automatic execution continue decision requires a pull-request review target")
+		}
+		if err := d.ReviewTarget.Validate(); err != nil {
+			return fmt.Errorf("automatic execution continue review target: %w", err)
+		}
+		if *d.ReviewTarget.PullRequest != d.PullRequest {
+			return fmt.Errorf("automatic execution continue review target does not match pull request")
+		}
 	}
 	if err := d.Decision.Validate(); err != nil {
 		return err

--- a/internal/store/reviewer.go
+++ b/internal/store/reviewer.go
@@ -227,6 +227,7 @@ type ReviewStatsV1 struct {
 	SummarizerDuration  time.Duration         `json:"summarizer_duration"`
 	FPFilterDuration    time.Duration         `json:"fp_filter_duration"`
 	FPFilteredCount     int                   `json:"fp_filtered_count"`
+	ModelCallCount      int                   `json:"model_call_count"`
 }
 
 func cloneIntDurationMap(m map[int]time.Duration) map[int]time.Duration {
@@ -265,6 +266,7 @@ func ToReviewStatsSchema(s domain.ReviewStats) ReviewStatsV1 {
 		SummarizerDuration:  s.SummarizerDuration,
 		FPFilterDuration:    s.FPFilterDuration,
 		FPFilteredCount:     s.FPFilteredCount,
+		ModelCallCount:      s.ModelCallCount,
 	}
 }
 
@@ -282,5 +284,6 @@ func (s ReviewStatsV1) ToDomain() domain.ReviewStats {
 		SummarizerDuration:  s.SummarizerDuration,
 		FPFilterDuration:    s.FPFilterDuration,
 		FPFilteredCount:     s.FPFilteredCount,
+		ModelCallCount:      s.ModelCallCount,
 	}
 }

--- a/internal/store/reviewer_test.go
+++ b/internal/store/reviewer_test.go
@@ -96,6 +96,7 @@ func TestReviewStatsV1_RoundTrip(t *testing.T) {
 		SummarizerDuration:  time.Second,
 		FPFilterDuration:    time.Second,
 		FPFilteredCount:     1,
+		ModelCallCount:      5,
 	}
 
 	schema := ToReviewStatsSchema(stats)
@@ -108,7 +109,7 @@ func TestReviewStatsV1_RoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	got := decoded.ToDomain()
-	if got.TotalReviewers != stats.TotalReviewers || got.ReviewerAgentNames[1] != "codex" || got.ReviewerDurations[0] != time.Second {
+	if got.TotalReviewers != stats.TotalReviewers || got.ReviewerAgentNames[1] != "codex" || got.ReviewerDurations[0] != time.Second || got.ModelCallCount != 5 {
 		t.Fatalf("round trip mismatch: got %+v, want %+v", got, stats)
 	}
 }

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -60,12 +60,13 @@ Rules:
 - If the input is empty, return: {"findings": [], "info": []}`
 
 type Result struct {
-	Grouped  domain.GroupedFindings
-	ExitCode int
-	Stderr   string
-	RawOut   string
-	Duration time.Duration
-	Warnings []string
+	Grouped        domain.GroupedFindings
+	ExitCode       int
+	Stderr         string
+	RawOut         string
+	Duration       time.Duration
+	Warnings       []string
+	ModelCallCount int
 }
 
 type inputItem struct {
@@ -132,12 +133,13 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 
 		if ctx.Err() != nil {
 			return &Result{
-				ExitCode: -1,
-				Stderr:   "context canceled",
-				Duration: time.Since(start),
+				ExitCode:       -1,
+				Stderr:         "context canceled",
+				Duration:       time.Since(start),
+				ModelCallCount: 1,
 			}, nil
 		}
-		return nil, err
+		return &Result{Duration: time.Since(start), ModelCallCount: 1}, err
 	}
 
 	closed := false
@@ -162,10 +164,11 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 
 		if ctx.Err() != nil {
 			return &Result{
-				ExitCode: -1,
-				Stderr:   "context canceled",
-				Duration: time.Since(start),
-				Warnings: append([]string(nil), warnings...),
+				ExitCode:       -1,
+				Stderr:         "context canceled",
+				Duration:       time.Since(start),
+				Warnings:       append([]string(nil), warnings...),
+				ModelCallCount: 1,
 			}, nil
 		}
 		readErr := fmt.Errorf("read summarizer output: %w", err)
@@ -179,11 +182,12 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 		}
 		stderr += readErr.Error()
 		return &Result{
-			ExitCode: exitCode,
-			Stderr:   stderr,
-			RawOut:   string(output),
-			Duration: time.Since(start),
-			Warnings: append([]string(nil), warnings...),
+			ExitCode:       exitCode,
+			Stderr:         stderr,
+			RawOut:         string(output),
+			Duration:       time.Since(start),
+			Warnings:       append([]string(nil), warnings...),
+			ModelCallCount: 1,
 		}, readErr
 	}
 
@@ -195,28 +199,30 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 
 	if exitCode != 0 && agent.IsAuthFailure(agentName, exitCode, stderr, rawOut) {
 		return &Result{
-			Grouped:  domain.GroupedFindings{},
-			ExitCode: exitCode,
-			Stderr:   fmt.Sprintf("%s authentication failed: %s", agentName, agent.AuthHint(agentName)),
-			RawOut:   rawOut,
-			Duration: duration,
-			Warnings: append([]string(nil), warnings...),
+			Grouped:        domain.GroupedFindings{},
+			ExitCode:       exitCode,
+			Stderr:         fmt.Sprintf("%s authentication failed: %s", agentName, agent.AuthHint(agentName)),
+			RawOut:         rawOut,
+			Duration:       duration,
+			Warnings:       append([]string(nil), warnings...),
+			ModelCallCount: 1,
 		}, nil
 	}
 
 	if len(output) == 0 {
 		return &Result{
-			Grouped:  domain.GroupedFindings{},
-			ExitCode: exitCode,
-			Stderr:   stderr,
-			Duration: duration,
-			Warnings: append([]string(nil), warnings...),
+			Grouped:        domain.GroupedFindings{},
+			ExitCode:       exitCode,
+			Stderr:         stderr,
+			Duration:       duration,
+			Warnings:       append([]string(nil), warnings...),
+			ModelCallCount: 1,
 		}, nil
 	}
 
 	parser, err := agent.NewSummaryParser(agentName)
 	if err != nil {
-		return nil, err
+		return &Result{Duration: duration, ModelCallCount: 1}, err
 	}
 
 	grouped, err := parser.Parse(output)
@@ -226,21 +232,23 @@ func summarize(ctx context.Context, ag agent.Agent, aggregated []domain.Aggregat
 			parseErr = stderr + "\n" + parseErr
 		}
 		return &Result{
-			Grouped:  domain.GroupedFindings{},
-			ExitCode: 1,
-			Stderr:   parseErr,
-			RawOut:   rawOut,
-			Duration: duration,
-			Warnings: append([]string(nil), warnings...),
+			Grouped:        domain.GroupedFindings{},
+			ExitCode:       1,
+			Stderr:         parseErr,
+			RawOut:         rawOut,
+			Duration:       duration,
+			Warnings:       append([]string(nil), warnings...),
+			ModelCallCount: 1,
 		}, nil
 	}
 
 	return &Result{
-		Grouped:  *grouped,
-		ExitCode: exitCode,
-		Stderr:   stderr,
-		RawOut:   rawOut,
-		Duration: duration,
-		Warnings: append([]string(nil), warnings...),
+		Grouped:        *grouped,
+		ExitCode:       exitCode,
+		Stderr:         stderr,
+		RawOut:         rawOut,
+		Duration:       duration,
+		Warnings:       append([]string(nil), warnings...),
+		ModelCallCount: 1,
 	}, nil
 }

--- a/internal/summarizer/summarizer_test.go
+++ b/internal/summarizer/summarizer_test.go
@@ -27,6 +27,9 @@ func TestSummarize_EmptyInput(t *testing.T) {
 	if len(result.Grouped.Info) != 0 {
 		t.Errorf("expected no info, got %d", len(result.Grouped.Info))
 	}
+	if result.ModelCallCount != 0 {
+		t.Errorf("model calls = %d, want 0", result.ModelCallCount)
+	}
 }
 
 func TestSummarize_EmptySlice(t *testing.T) {

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -372,6 +372,11 @@ func mergeRetryDiscussion(saved, current []Discussion) []Discussion {
 	return merged
 }
 
+func triggerCoversDiscussionEvidence(trigger string) bool {
+	return trigger == "discussion requires reconsideration" ||
+		trigger == "uncertain discussion requires reconsideration"
+}
+
 func (l *loop) initializeDiscussion(items []Discussion) {
 	l.discussionCursor = make(map[DiscussionID]string, len(items))
 	l.ownDiscussion = make(map[DiscussionID]struct{})
@@ -1000,10 +1005,12 @@ func (l *loop) cycle(
 		}
 		l.pendingHead = ""
 		l.pendingApproval = ""
-		l.consumeDiscussion(discussion)
-		l.pendingDiscussion = nil
-		l.waitingDiscussion = ""
-		l.logf("Revision %s was already reviewed; continuing to monitor for a replacement head.", shortSHA(l.lastHead))
+		if len(discussion) == 0 || triggerCoversDiscussionEvidence(trigger) {
+			l.consumeDiscussion(discussion)
+			l.pendingDiscussion = nil
+			l.waitingDiscussion = ""
+		}
+		l.logf("Revision %s was already reviewed; continuing lifecycle monitoring.", shortSHA(l.lastHead))
 		return 0, false
 	}
 	l.cycleErrors = 0

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -83,6 +83,7 @@ const (
 	CycleLGTMDeclined
 	CycleLGTMSkipped
 	CycleStaleHead
+	CycleClean
 )
 
 type Cycle struct {
@@ -980,6 +981,9 @@ func (l *loop) cycle(
 		return 0, false
 	case CycleFindings:
 		l.logf("Review #%d complete (findings); resuming watch.", l.reviews)
+		return 0, false
+	case CycleClean:
+		l.logf("Review #%d complete (clean); resuming watch.", l.reviews)
 		return 0, false
 	default:
 		return ReasonError, true

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -349,6 +349,29 @@ func DiscussionRevision(items []Discussion) string {
 	return signature
 }
 
+func mergeRetryDiscussion(saved, current []Discussion) []Discussion {
+	currentByID := make(map[DiscussionID]Discussion, len(current))
+	for _, item := range current {
+		currentByID[item.ID] = item
+	}
+	merged := make([]Discussion, 0, len(saved)+len(current))
+	seen := make(map[DiscussionID]struct{}, len(saved)+len(current))
+	for _, item := range saved {
+		if replacement, exists := currentByID[item.ID]; exists {
+			item = replacement
+		}
+		merged = append(merged, item)
+		seen[item.ID] = struct{}{}
+	}
+	for _, item := range current {
+		if _, exists := seen[item.ID]; exists {
+			continue
+		}
+		merged = append(merged, item)
+	}
+	return merged
+}
+
 func (l *loop) initializeDiscussion(items []Discussion) {
 	l.discussionCursor = make(map[DiscussionID]string, len(items))
 	l.ownDiscussion = make(map[DiscussionID]struct{})
@@ -542,7 +565,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 
 	l.requestArmed = !st.ReviewRequested
 
-	if reason, done := l.cycle(ctx, st.HeadSHA, "initial review", nil, DiscussionRevision(st.Discussion)); done {
+	if reason, done := l.cycle(ctx, st.HeadSHA, "initial review", nil, DiscussionRevision(st.Discussion), false); done {
 		return reason
 	}
 	if reason, done := l.checkMaxReviews(); done {
@@ -665,6 +688,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		trigger := ""
 		var cycleDiscussion []Discussion
 		cycleRevision := DiscussionRevision(st.Discussion)
+		replayingRetry := false
 		unprocessed := l.unprocessedDiscussion(st.Discussion)
 		l.updatePendingDiscussion(unprocessed)
 		if manualTrigger {
@@ -681,8 +705,11 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 
 		if trigger == "" && l.retryPending {
 			trigger = l.retryTrigger
-			cycleDiscussion = append([]Discussion(nil), l.retryDiscussion...)
-			cycleRevision = l.retryRevision
+			cycleDiscussion = mergeRetryDiscussion(l.retryDiscussion, unprocessed)
+			if cycleRevision == "" {
+				cycleRevision = l.retryRevision
+			}
+			replayingRetry = true
 		}
 
 		if trigger == "" && l.pendingApproval != "" {
@@ -805,7 +832,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			}
 			continue
 		}
-		if reason, done := l.cycle(ctx, st.HeadSHA, trigger, cycleDiscussion, cycleRevision); done {
+		if reason, done := l.cycle(ctx, st.HeadSHA, trigger, cycleDiscussion, cycleRevision, replayingRetry); done {
 			return reason
 		}
 		if reason, done := l.checkMaxReviews(); done {
@@ -910,8 +937,8 @@ func (l *loop) cycle(
 	trigger string,
 	discussion []Discussion,
 	discussionRevision string,
+	replayingRetry bool,
 ) (ExitReason, bool) {
-	replayingRetry := l.retryPending && trigger == l.retryTrigger
 	l.retryPending = false
 	l.retryHead = ""
 	l.retryTrigger = ""

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -172,6 +172,8 @@ const (
 	ReasonInterrupted
 	ReasonReleased
 	ReasonOptedOut
+	ReasonStopped
+	ReasonEscalated
 	ReasonError
 )
 
@@ -195,6 +197,10 @@ func (r ExitReason) String() string {
 		return "released"
 	case ReasonOptedOut:
 		return "opted out"
+	case ReasonStopped:
+		return "automatic review stopped"
+	case ReasonEscalated:
+		return "automatic review requires trusted intervention"
 	default:
 		return "error"
 	}
@@ -929,6 +935,14 @@ func (l *loop) cycle(
 			l.retryPending = true
 			l.retryHead = head
 			return 0, false
+		}
+		var controlled interface {
+			error
+			WatchExitReason() ExitReason
+		}
+		if errors.As(err, &controlled) {
+			l.logf("Review lifecycle ended: %v", err)
+			return controlled.WatchExitReason(), true
 		}
 		l.logf("Review #%d failed: %v", l.reviews, err)
 		return ReasonError, true

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -911,7 +911,7 @@ func (l *loop) cycle(
 	discussion []Discussion,
 	discussionRevision string,
 ) (ExitReason, bool) {
-	retrying := l.retryPending
+	replayingRetry := l.retryPending && trigger == l.retryTrigger
 	l.retryPending = false
 	l.retryHead = ""
 	l.retryTrigger = ""
@@ -919,7 +919,7 @@ func (l *loop) cycle(
 	l.retryRevision = ""
 	l.pendingApproval = ""
 	l.reviews++
-	if trigger == "manual request" && !retrying {
+	if trigger == "manual request" && !replayingRetry {
 		l.emit(Event{Type: EventManualReviewStarted, RequestCount: l.manualRequests, ReviewNumber: l.reviews})
 		l.manualRequests = 0
 	}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -224,6 +224,9 @@ type loop struct {
 	cycleErrors        int
 	retryPending       bool
 	retryHead          string
+	retryTrigger       string
+	retryDiscussion    []Discussion
+	retryRevision      string
 	manualRequests     int
 	discussionCursor   map[DiscussionID]string
 	ownDiscussion      map[DiscussionID]struct{}
@@ -653,11 +656,15 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		if l.retryPending && st.HeadSHA != l.retryHead {
 			l.retryPending = false
 			l.retryHead = ""
+			l.retryTrigger = ""
+			l.retryDiscussion = nil
+			l.retryRevision = ""
 			l.cycleErrors = 0
 		}
 
 		trigger := ""
 		var cycleDiscussion []Discussion
+		cycleRevision := DiscussionRevision(st.Discussion)
 		unprocessed := l.unprocessedDiscussion(st.Discussion)
 		l.updatePendingDiscussion(unprocessed)
 		if manualTrigger {
@@ -673,8 +680,9 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		}
 
 		if trigger == "" && l.retryPending {
-			trigger = "retry after transient preparation failure"
-			cycleDiscussion = unprocessed
+			trigger = l.retryTrigger
+			cycleDiscussion = append([]Discussion(nil), l.retryDiscussion...)
+			cycleRevision = l.retryRevision
 		}
 
 		if trigger == "" && l.pendingApproval != "" {
@@ -797,7 +805,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 			}
 			continue
 		}
-		if reason, done := l.cycle(ctx, st.HeadSHA, trigger, cycleDiscussion, DiscussionRevision(st.Discussion)); done {
+		if reason, done := l.cycle(ctx, st.HeadSHA, trigger, cycleDiscussion, cycleRevision); done {
 			return reason
 		}
 		if reason, done := l.checkMaxReviews(); done {
@@ -903,11 +911,15 @@ func (l *loop) cycle(
 	discussion []Discussion,
 	discussionRevision string,
 ) (ExitReason, bool) {
+	retrying := l.retryPending
 	l.retryPending = false
 	l.retryHead = ""
+	l.retryTrigger = ""
+	l.retryDiscussion = nil
+	l.retryRevision = ""
 	l.pendingApproval = ""
 	l.reviews++
-	if trigger == "manual request" {
+	if trigger == "manual request" && !retrying {
 		l.emit(Event{Type: EventManualReviewStarted, RequestCount: l.manualRequests, ReviewNumber: l.reviews})
 		l.manualRequests = 0
 	}
@@ -935,6 +947,9 @@ func (l *loop) cycle(
 			l.logf("Review cycle failed (%d/%d); will retry: %v", l.cycleErrors, maxConsecutivePollErrors, err)
 			l.retryPending = true
 			l.retryHead = head
+			l.retryTrigger = trigger
+			l.retryDiscussion = append([]Discussion(nil), discussion...)
+			l.retryRevision = discussionRevision
 			return 0, false
 		}
 		var controlled interface {

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -84,6 +84,7 @@ const (
 	CycleLGTMSkipped
 	CycleStaleHead
 	CycleClean
+	CycleAlreadyReviewed
 )
 
 type Cycle struct {
@@ -928,10 +929,10 @@ func (l *loop) cycle(
 			l.reviews--
 			l.cycleErrors++
 			if l.cycleErrors >= maxConsecutivePollErrors {
-				l.logf("Review preparation failed (%d/%d); stopping: %v", l.cycleErrors, maxConsecutivePollErrors, err)
+				l.logf("Review cycle failed (%d/%d); stopping: %v", l.cycleErrors, maxConsecutivePollErrors, err)
 				return ReasonError, true
 			}
-			l.logf("Review preparation failed (%d/%d); will retry: %v", l.cycleErrors, maxConsecutivePollErrors, err)
+			l.logf("Review cycle failed (%d/%d); will retry: %v", l.cycleErrors, maxConsecutivePollErrors, err)
 			l.retryPending = true
 			l.retryHead = head
 			return 0, false
@@ -946,6 +947,21 @@ func (l *loop) cycle(
 		}
 		l.logf("Review #%d failed: %v", l.reviews, err)
 		return ReasonError, true
+	}
+	if c.Result == CycleAlreadyReviewed {
+		l.reviews--
+		l.cycleErrors = 0
+		l.lastHead = head
+		if c.HeadSHA != "" {
+			l.lastHead = c.HeadSHA
+		}
+		l.pendingHead = ""
+		l.pendingApproval = ""
+		l.consumeDiscussion(discussion)
+		l.pendingDiscussion = nil
+		l.waitingDiscussion = ""
+		l.logf("Revision %s was already reviewed; continuing to monitor for a replacement head.", shortSHA(l.lastHead))
+		return 0, false
 	}
 	l.cycleErrors = 0
 	for _, id := range c.OwnDiscussionIDs {

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -706,6 +706,7 @@ func run(ctx context.Context, cfg Config, deps Deps) ExitReason {
 		if trigger == "" && l.retryPending {
 			trigger = l.retryTrigger
 			cycleDiscussion = mergeRetryDiscussion(l.retryDiscussion, unprocessed)
+			cycleRevision = DiscussionRevision(cycleDiscussion)
 			if cycleRevision == "" {
 				cycleRevision = l.retryRevision
 			}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1190,6 +1190,49 @@ func TestRetryablePreparationFailureSettlesChangedHead(t *testing.T) {
 	}
 }
 
+func TestManualRequestSupersedesSettledCommitRetry(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa"), open("bbb")}
+	deps := h.deps()
+	attempts := 0
+	manualSent := false
+	deps.RunCycle = func(_ context.Context, _ int, trigger string, _ []Discussion, _ string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		switch attempts {
+		case 1:
+			return Cycle{Result: CycleFindings}, nil
+		case 2:
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		default:
+			return Cycle{Result: CycleLGTMApproved}, nil
+		}
+	}
+	deps.Wait = func(ctx context.Context, duration time.Duration) (WaitResult, error) {
+		if attempts == 2 && !manualSent {
+			manualSent = true
+			return WaitResult{ManualRequests: 1}, nil
+		}
+		return WaitResult{}, h.clock.Sleep(ctx, duration)
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if fmt.Sprint(h.triggers) != "[initial review commits settled manual request]" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	var started []Event
+	for _, event := range h.events {
+		if event.Type == EventManualReviewStarted {
+			started = append(started, event)
+		}
+	}
+	if len(started) != 1 || started[0].RequestCount != 1 || started[0].ReviewNumber != 2 {
+		t.Fatalf("manual review events = %#v", started)
+	}
+}
+
 func TestRetryablePreparationFailuresResetWhenHeadChanges(t *testing.T) {
 	h := newHarness(t)
 	h.states = []PRState{open("aaa"), open("bbb")}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1076,21 +1076,21 @@ func TestRetryableCycleFailuresBecomeFatalAfterLimit(t *testing.T) {
 	if attempts != maxConsecutivePollErrors {
 		t.Fatalf("attempts = %d, want %d", attempts, maxConsecutivePollErrors)
 	}
-	var preparationLogs []string
+	var cycleLogs []string
 	for _, entry := range h.logs {
-		if strings.Contains(entry, "Review preparation failed") {
-			preparationLogs = append(preparationLogs, entry)
+		if strings.Contains(entry, "Review cycle failed") {
+			cycleLogs = append(cycleLogs, entry)
 		}
 	}
-	if len(preparationLogs) != maxConsecutivePollErrors {
-		t.Fatalf("preparation logs = %v", preparationLogs)
+	if len(cycleLogs) != maxConsecutivePollErrors {
+		t.Fatalf("cycle logs = %v", cycleLogs)
 	}
-	for _, entry := range preparationLogs[:len(preparationLogs)-1] {
+	for _, entry := range cycleLogs[:len(cycleLogs)-1] {
 		if !strings.Contains(entry, "will retry") {
 			t.Fatalf("retrying log = %q", entry)
 		}
 	}
-	finalLog := preparationLogs[len(preparationLogs)-1]
+	finalLog := cycleLogs[len(cycleLogs)-1]
 	if !strings.Contains(finalLog, "stopping") || strings.Contains(finalLog, "will retry") {
 		t.Fatalf("terminal log = %q", finalLog)
 	}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -309,6 +309,56 @@ func TestTerminalDiscussionRetryIncludesNewDiscussionEvidence(t *testing.T) {
 	}
 }
 
+func TestDiscussionRetryEvidenceIncludesSavedAndCurrentItems(t *testing.T) {
+	saved := discussion("issue_comment", 1, "v1", "reviewer", "The nil case changes the conclusion.")
+	current := discussion("review_comment", 2, "v1", "reviewer", "The error path also needs reconsideration.")
+	h := newHarness(t)
+	h.routes = []RoutingDecision{RoutingReviewRequired}
+	deps := h.deps()
+	attempts := 0
+	stateCalls := 0
+	deps.State = func(context.Context) (PRState, error) {
+		stateCalls++
+		if stateCalls == 1 {
+			return open("aaa"), nil
+		}
+		if attempts >= 2 {
+			return discussed("aaa", current), nil
+		}
+		return discussed("aaa", saved), nil
+	}
+	var cycleDiscussion [][]Discussion
+	var revisions []string
+	deps.RunCycle = func(_ context.Context, _ int, trigger string, discussion []Discussion, revision string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		cycleDiscussion = append(cycleDiscussion, append([]Discussion(nil), discussion...))
+		revisions = append(revisions, revision)
+		switch attempts {
+		case 1:
+			return Cycle{Result: CycleFindings}, nil
+		case 2:
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		default:
+			return Cycle{Result: CycleLGTMApproved}, nil
+		}
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if len(cycleDiscussion[2]) != 2 || cycleDiscussion[2][0].ID != saved.ID || cycleDiscussion[2][1].ID != current.ID {
+		t.Fatalf("retry discussion = %#v", cycleDiscussion[2])
+	}
+	wantRevision := DiscussionRevision([]Discussion{saved, current})
+	if revisions[2] != wantRevision {
+		t.Fatalf("retry revision = %q, want merged evidence %q", revisions[2], wantRevision)
+	}
+	if revisions[2] == DiscussionRevision([]Discussion{current}) {
+		t.Fatalf("retry revision retained current-only evidence: %q", revisions[2])
+	}
+}
+
 func TestNoReviewDiscussionConsumesWithoutReviewSlot(t *testing.T) {
 	item := discussion("issue_comment", 1, "v1", "reviewer", "Thanks.")
 	h := newHarness(t)

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -258,6 +258,57 @@ func TestRetryableDiscussionReviewPreservesEvidence(t *testing.T) {
 	}
 }
 
+func TestTerminalDiscussionRetryIncludesNewDiscussionEvidence(t *testing.T) {
+	first := discussion("issue_comment", 1, "v1", "reviewer", "The nil case changes the conclusion.")
+	updated := discussion("issue_comment", 1, "v2", "reviewer", "The nil and empty cases change the conclusion.")
+	newItem := discussion("review_comment", 2, "v1", "reviewer", "The error path also needs reconsideration.")
+	h := newHarness(t)
+	h.routes = []RoutingDecision{RoutingReviewRequired}
+	deps := h.deps()
+	attempts := 0
+	stateCalls := 0
+	deps.State = func(context.Context) (PRState, error) {
+		stateCalls++
+		if stateCalls == 1 {
+			return open("aaa"), nil
+		}
+		if attempts >= 2 {
+			return discussed("aaa", updated, newItem), nil
+		}
+		return discussed("aaa", first), nil
+	}
+	var cycleDiscussion [][]Discussion
+	var revisions []string
+	deps.RunCycle = func(_ context.Context, _ int, trigger string, discussion []Discussion, revision string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		cycleDiscussion = append(cycleDiscussion, append([]Discussion(nil), discussion...))
+		revisions = append(revisions, revision)
+		switch attempts {
+		case 1:
+			return Cycle{Result: CycleFindings}, nil
+		case 2:
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		default:
+			return Cycle{Result: CycleLGTMApproved}, nil
+		}
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if fmt.Sprint(h.triggers) != "[initial review discussion requires reconsideration discussion requires reconsideration]" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	if len(cycleDiscussion[2]) != 2 || cycleDiscussion[2][0].Revision != updated.Revision || cycleDiscussion[2][1].ID != newItem.ID {
+		t.Fatalf("retry discussion = %#v", cycleDiscussion[2])
+	}
+	wantRevision := DiscussionRevision([]Discussion{updated, newItem})
+	if revisions[2] != wantRevision {
+		t.Fatalf("retry revision = %q, want %q", revisions[2], wantRevision)
+	}
+}
+
 func TestNoReviewDiscussionConsumesWithoutReviewSlot(t *testing.T) {
 	item := discussion("issue_comment", 1, "v1", "reviewer", "Thanks.")
 	h := newHarness(t)
@@ -1229,6 +1280,53 @@ func TestManualRequestSupersedesSettledCommitRetry(t *testing.T) {
 		}
 	}
 	if len(started) != 1 || started[0].RequestCount != 1 || started[0].ReviewNumber != 2 {
+		t.Fatalf("manual review events = %#v", started)
+	}
+}
+
+func TestNewManualRequestSupersedesManualRetry(t *testing.T) {
+	h := newHarness(t)
+	h.states = []PRState{open("aaa")}
+	deps := h.deps()
+	attempts := 0
+	manualRequests := 0
+	deps.RunCycle = func(_ context.Context, _ int, trigger string, _ []Discussion, _ string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		switch attempts {
+		case 1:
+			return Cycle{Result: CycleFindings}, nil
+		case 2:
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		default:
+			return Cycle{Result: CycleLGTMApproved}, nil
+		}
+	}
+	deps.Wait = func(ctx context.Context, duration time.Duration) (WaitResult, error) {
+		if attempts == 1 && manualRequests == 0 {
+			manualRequests++
+			return WaitResult{ManualRequests: 1}, nil
+		}
+		if attempts == 2 && manualRequests == 1 {
+			manualRequests++
+			return WaitResult{ManualRequests: 1}, nil
+		}
+		return WaitResult{}, h.clock.Sleep(ctx, duration)
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if fmt.Sprint(h.triggers) != "[initial review manual request manual request]" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	var started []Event
+	for _, event := range h.events {
+		if event.Type == EventManualReviewStarted {
+			started = append(started, event)
+		}
+	}
+	if len(started) != 2 || started[0].RequestCount != 1 || started[1].RequestCount != 1 {
 		t.Fatalf("manual review events = %#v", started)
 	}
 }

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -220,6 +220,44 @@ func TestSettledDiscussionRoutesIntoFullReview(t *testing.T) {
 	}
 }
 
+func TestRetryableDiscussionReviewPreservesEvidence(t *testing.T) {
+	item := discussion("issue_comment", 1, "v1", "reviewer", "The nil case changes the conclusion.")
+	h := newHarness(t)
+	h.states = []PRState{open("aaa"), discussed("aaa", item)}
+	h.routes = []RoutingDecision{RoutingReviewRequired}
+	deps := h.deps()
+	var triggers []string
+	var revisions []string
+	var cycleDiscussion [][]Discussion
+	deps.RunCycle = func(_ context.Context, _ int, trigger string, discussion []Discussion, revision string) (Cycle, error) {
+		triggers = append(triggers, trigger)
+		revisions = append(revisions, revision)
+		cycleDiscussion = append(cycleDiscussion, append([]Discussion(nil), discussion...))
+		switch len(triggers) {
+		case 1:
+			return Cycle{Result: CycleFindings}, nil
+		case 2:
+			return Cycle{Result: CycleError}, fmt.Errorf("%w: network unavailable", ErrRetryableCycle)
+		default:
+			return Cycle{Result: CycleLGTMApproved}, nil
+		}
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	wantRevision := DiscussionRevision([]Discussion{item})
+	if len(triggers) != 3 || triggers[1] != "discussion requires reconsideration" || triggers[2] != triggers[1] {
+		t.Fatalf("triggers = %v", triggers)
+	}
+	if revisions[1] != wantRevision || revisions[2] != wantRevision {
+		t.Fatalf("revisions = %v, want routed retries to preserve %q", revisions, wantRevision)
+	}
+	if len(cycleDiscussion[1]) != 1 || len(cycleDiscussion[2]) != 1 || cycleDiscussion[2][0].ID != item.ID {
+		t.Fatalf("cycle discussion = %#v", cycleDiscussion)
+	}
+}
+
 func TestNoReviewDiscussionConsumesWithoutReviewSlot(t *testing.T) {
 	item := discussion("issue_comment", 1, "v1", "reviewer", "Thanks.")
 	h := newHarness(t)
@@ -1055,7 +1093,7 @@ func TestRetryableCycleFailureDoesNotConsumeReviewBudget(t *testing.T) {
 	if len(reviewNumbers) != 2 || reviewNumbers[0] != 1 || reviewNumbers[1] != 1 {
 		t.Fatalf("review numbers = %v, want [1 1]", reviewNumbers)
 	}
-	if len(h.triggers) != 2 || h.triggers[1] != "retry after transient preparation failure" {
+	if len(h.triggers) != 2 || h.triggers[1] != "initial review" {
 		t.Fatalf("triggers = %v", h.triggers)
 	}
 }
@@ -1121,7 +1159,7 @@ func TestRetryableRequestedReviewCannotPostPriorPendingApproval(t *testing.T) {
 	if len(h.approvedWith) != 0 {
 		t.Fatalf("obsolete approval posted: %v", h.approvedWith)
 	}
-	if len(h.triggers) != 3 || h.triggers[1] != "re-review requested" || h.triggers[2] != "retry after transient preparation failure" {
+	if len(h.triggers) != 3 || h.triggers[1] != "re-review requested" || h.triggers[2] != "re-review requested" {
 		t.Fatalf("triggers = %v", h.triggers)
 	}
 }

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -439,6 +439,68 @@ func TestHeadAndDiscussionChangesCoalesceIntoOneReview(t *testing.T) {
 	}
 }
 
+func TestAlreadyReviewedReturningHeadPreservesNewDiscussionForRouting(t *testing.T) {
+	item := discussion("issue_comment", 1, "v1", "reviewer", "The returning head needs another look in this context.")
+	h := newHarness(t)
+	h.routes = []RoutingDecision{RoutingReviewRequired}
+	deps := h.deps()
+	attempts := 0
+	deps.State = func(context.Context) (PRState, error) {
+		switch attempts {
+		case 0:
+			return open("aaa"), nil
+		case 1:
+			return open("bbb"), nil
+		default:
+			return discussed("aaa", item), nil
+		}
+	}
+	var cycleDiscussion [][]Discussion
+	deps.RunCycle = func(_ context.Context, _ int, trigger string, discussion []Discussion, _ string) (Cycle, error) {
+		attempts++
+		h.triggers = append(h.triggers, trigger)
+		cycleDiscussion = append(cycleDiscussion, append([]Discussion(nil), discussion...))
+		switch attempts {
+		case 1, 2:
+			return Cycle{Result: CycleFindings}, nil
+		case 3:
+			return Cycle{Result: CycleAlreadyReviewed, HeadSHA: "aaa"}, nil
+		default:
+			return Cycle{Result: CycleLGTMApproved}, nil
+		}
+	}
+
+	if reason := Run(context.Background(), defaultConfig(PostModeApprove), deps); reason != ReasonLGTM {
+		t.Fatalf("reason = %v, want ReasonLGTM", reason)
+	}
+	if fmt.Sprint(h.triggers) != "[initial review commits settled commits settled discussion requires reconsideration]" {
+		t.Fatalf("triggers = %v", h.triggers)
+	}
+	if len(h.routed) != 1 || len(h.routed[0]) != 1 || h.routed[0][0].ID != item.ID {
+		t.Fatalf("routed discussion = %#v", h.routed)
+	}
+	if len(cycleDiscussion[3]) != 1 || cycleDiscussion[3][0].ID != item.ID {
+		t.Fatalf("discussion review payload = %#v", cycleDiscussion[3])
+	}
+}
+
+func TestAlreadyReviewedDiscussionEvidenceConsumesDiscussion(t *testing.T) {
+	item := discussion("issue_comment", 1, "v1", "reviewer", "Please reconsider this path.")
+	h := newHarness(t)
+	h.states = []PRState{open("aaa"), discussed("aaa", item)}
+	h.cycles = []Cycle{{Result: CycleFindings}, {Result: CycleAlreadyReviewed, HeadSHA: "aaa"}}
+	h.routes = []RoutingDecision{RoutingReviewRequired}
+	cfg := defaultConfig(PostModeComment)
+	cfg.MaxDuration = 15 * time.Minute
+
+	if reason := Run(context.Background(), cfg, h.deps()); reason != ReasonMaxDuration {
+		t.Fatalf("reason = %v, want ReasonMaxDuration", reason)
+	}
+	if len(h.routed) != 1 || len(h.triggers) != 2 || h.triggers[1] != "discussion requires reconsideration" {
+		t.Fatalf("routes = %#v triggers = %v", h.routed, h.triggers)
+	}
+}
+
 func TestHeadWaitsForLaterDiscussionSettleDeadline(t *testing.T) {
 	item := discussion("issue_comment", 1, "v1", "reviewer", "Please reconsider.")
 	h := newHarness(t)


### PR DESCRIPTION
## What changed

- add a reusable scheduler that bounds concurrent per-PR watcher lifecycles and reserves active PR keys across concurrent callers
- persist the effective head/base target on every automatic run admission and reject the same revision across lifecycle or controller recreation
- gate prepared background cycles through the durable automatic controller, including lifecycle deadlines and derived run economics
- map persisted release, snooze, opt-out, and resume events into the shared watcher lifecycle
- make background work an opaque desk-triggered semantic-review capability with no posting callback or post-bearing result surface
- add a clean, non-posting watcher outcome that remains eligible for later settled heads

## Impact

Eligible pull requests can stay current within a workspace-wide concurrency bound without duplicate automatic reviews or automatic GitHub posting. Existing `acr` and `acr watch` entry points remain unchanged.

## Validation

- `GOCACHE=/private/tmp/acr-issue-211-gocache make check`
- `GOCACHE=/private/tmp/acr-issue-211-gocache go test -race -count=20 ./internal/automatic ./internal/scheduler`
- focused race tests cover global capacity, active-key overlap, durable same-revision rejection after controller recreation, replacement-head admission, recorded controls, and absence of a background submission capability
- Steward `workspace-scheduler@1`: pass for AC1-AC5 at `e95b47911bdb34f3599a4aee125c84fca8f2fa08`, assessment hash `93a1bbb5176f8ae600e8cb66e7b33dacf8c1e89c3842b23116e63422545c72e7`

Closes #211